### PR TITLE
fix(scripts): replace lambda with def in lerobot_handler to satisfy R…

### DIFF
--- a/src/dataviewer/backend/src/api/services/dataset_service/lerobot_handler.py
+++ b/src/dataviewer/backend/src/api/services/dataset_service/lerobot_handler.py
@@ -9,29 +9,22 @@ import io
 import logging
 from pathlib import Path
 
-from ...models.datasources import (
-    DatasetInfo,
-    EpisodeData,
-    EpisodeMeta,
-    FeatureSchema,
-    TrajectoryPoint,
-)
+from ...models.datasources import DatasetInfo, EpisodeData, EpisodeMeta, FeatureSchema, TrajectoryPoint
 from .base import build_trajectory
 
 logger = logging.getLogger(__name__)
 
 # LeRobot parquet support is optional
 try:
-    from ..lerobot_loader import (
-        LeRobotLoader,
-        is_lerobot_dataset,
-    )
+    from ..lerobot_loader import LeRobotLoader, is_lerobot_dataset
 
     LEROBOT_AVAILABLE = True
 except ImportError:
     LEROBOT_AVAILABLE = False
     LeRobotLoader = None
-    is_lerobot_dataset = lambda x: False  # noqa: E731
+
+    def is_lerobot_dataset(x):
+        return False
 
 
 class LeRobotFormatHandler:


### PR DESCRIPTION
Closes #139

## Summary

Replaced a lambda assignment with a named function to comply with Ruff rule **E731**.

In `lerobot_handler.py`, the fallback implementation used:

```python
is_lerobot_dataset = lambda x: False
```

This was replaced with a named function:

```
def is_lerobot_dataset(x):
    return False
```

This change removes the `noqa: E731` workaround and follows Python style conventions.

## Validation

* Ruff lint check passes: `ruff check src/dataviewer/`
* No functional behavior changes introduced
* Existing tests executed locally

## Documentation Impact

* [x] No documentation changes needed
