### PR TITLE
fix(docs): remove trailingSlash: false for GitHub Pages compatibility

### DIFF
--- a/docs/docusaurus/docusaurus.config.js
+++ b/docs/docusaurus/docusaurus.config.js
@@ -12,7 +12,6 @@ const config = {
 
   organizationName: 'microsoft',
   projectName: 'physical-ai-toolchain',
-  trailingSlash: false,
 
   onBrokenLinks: 'warn',
 


### PR DESCRIPTION
Removed the explicit `trailingSlash: false` setting from the Docusaurus configuration. This property caused category index pages to render as blank on GitHub Pages because the framework generated sibling `.html` files instead of `dir/index.html`, while GitHub Pages redirected directory URLs to trailing-slash paths with no matching file. Removing the property reverts to the Docusaurus default and aligns with the microsoft/hve-core Docusaurus configuration.

## Description

All nine documentation category pages (`getting-started`, `deploy`, `training`, `inference`, `edge`, `operations`, `security`, `reference`, `contributing`) returned blank content on GitHub Pages. The root cause was `trailingSlash: false` in *docs/docusaurus/docusaurus.config.js*, which instructed Docusaurus to emit `operations.html` as a sibling file rather than `operations/index.html`. GitHub Pages saw the `operations/` directory, issued a redirect to the trailing-slash URL, and found no `index.html` inside.

- Removed **`trailingSlash: false`** from the Docusaurus site configuration, reverting to the framework default (`undefined`)
  - The default behavior generates `dir/index.html` for category pages, which GitHub Pages serves correctly
  - Matches microsoft/hve-core's Docusaurus configuration, which omits the property entirely

## Type of Change

- [x] 🐛 Bug fix (non-breaking change fixing an issue)
- [ ] ✨ New feature (non-breaking change adding functionality)
- [ ] 💥 Breaking change (fix or feature causing existing functionality to change)
- [x] 📚 Documentation update
- [ ] 🏗️ Infrastructure change (Terraform/IaC)
- [ ] ♻️ Refactoring (no functional changes)

## Component(s) Affected

- [ ] `deploy/000-prerequisites` - Azure subscription setup
- [ ] `deploy/001-iac` - Terraform infrastructure
- [ ] `deploy/002-setup` - OSMO control plane / Helm
- [ ] `deploy/004-workflow` - Training workflows
- [ ] `src/training` - Python training scripts
- [x] `docs/` - Documentation

## Testing Performed

- [ ] Terraform `plan` reviewed (no unexpected changes)
- [ ] Terraform `apply` tested in dev environment
- [ ] Training scripts tested locally with Isaac Sim
- [ ] OSMO workflow submitted successfully
- [ ] Smoke tests passed (`smoke_test_azure.py`)

> Docusaurus build verified locally — all nine category directories generate `index.html` with the default `trailingSlash` setting.

## Documentation Impact

- [x] No documentation changes needed
- [ ] Documentation updated in this PR
- [ ] Documentation issue filed

## Checklist

- [x] My code follows the [project conventions](copilot-instructions.md)
- [x] Commit messages follow [conventional commit format](instructions/commit-message.instructions.md)
- [x] I have performed a self-review
- [x] Documentation impact assessed above
- [x] No new linting warnings introduced

## Related Issues

None