### PR TITLE
chore(workflows): update Dependabot, CodeQL, CODEOWNERS, and cspell for dataviewer coverage

### DIFF
--- a/.cspell/general-technical.txt
+++ b/.cspell/general-technical.txt
@@ -1958,18 +1958,24 @@ desync
 dvwh
 dvwm
 emanufacturing
+fastapi
 faststart
 fourcc
 midtone
 movflags
 nameidentifier
 persistable
+pydantic
+radix
 rawvideo
 rvfc
+shadcn
 srcs
+tanstack
 tobytes
 ultrafast
 
 kolmogorov
 mqtt
 smirnov
+zustand

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -16,6 +16,9 @@
 # Source code
 /src/                       @microsoft/edge-ai-core-dev
 
+# Dataviewer application
+/src/dataviewer/            @microsoft/edge-ai-core-dev
+
 # Infrastructure as code
 /deploy/                    @microsoft/edge-ai-core-dev
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -143,6 +143,44 @@ updates:
       prefix: "chore"
       include: "scope"
 
+  # Python dependencies for dataviewer backend
+  - package-ecosystem: "pip"
+    directory: "/src/dataviewer/backend"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    groups:
+      dataviewer-backend-dependencies:
+        patterns:
+          - "*"
+    labels:
+      - "dependencies"
+      - "python"
+      - "dataviewer"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+
+  # npm dependencies for dataviewer frontend
+  - package-ecosystem: "npm"
+    directory: "/src/dataviewer/frontend"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    groups:
+      dataviewer-frontend-dependencies:
+        patterns:
+          - "*"
+    labels:
+      - "dependencies"
+      - "npm"
+      - "dataviewer"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+
   # Python dependencies for LeRobot inference
   - package-ecosystem: "pip"
     directory: "/workflows/azureml"

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        language: ['python']
+        language: ['javascript-typescript', 'python']
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## Description

Extended CI/CD configuration to cover the **dataviewer application** (`src/dataviewer/`). This adds automated dependency monitoring, security scanning, code ownership routing, and spell-check dictionary support for the dataviewer's Python/FastAPI backend and TypeScript/React frontend.

Closes #117

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change fixing an issue)
- [ ] ✨ New feature (non-breaking change adding functionality)
- [ ] 💥 Breaking change (fix or feature causing existing functionality to change)
- [ ] 📚 Documentation update
- [ ] 🏗️ Infrastructure change (Terraform/IaC)
- [x] ♻️ Refactoring (no functional changes)

## Component(s) Affected

- [ ] `deploy/000-prerequisites` - Azure subscription setup
- [ ] `deploy/001-iac` - Terraform infrastructure
- [ ] `deploy/002-setup` - OSMO control plane / Helm
- [ ] `deploy/004-workflow` - Training workflows
- [ ] `src/training` - Python training scripts
- [ ] `docs/` - Documentation

## Changes

### Dependabot Dependency Monitoring

Added two new Dependabot entries in *.github/dependabot.yml* to enable automated dependency update PRs for the dataviewer.

- **pip ecosystem** entry for `/src/dataviewer/backend` with grouped `dataviewer-backend-dependencies` and labels `dependencies`/`python`/`dataviewer`
- **npm ecosystem** entry for `/src/dataviewer/frontend` with grouped `dataviewer-frontend-dependencies` and labels `dependencies`/`npm`/`dataviewer`
  - Both follow the established repository pattern: weekly monday schedule, open-pull-requests-limit 5, `chore` commit-message prefix with scope

### CodeQL Security Analysis

Expanded the language matrix in *.github/workflows/codeql-analysis.yml* from `['python']` to `['javascript-typescript', 'python']`, enabling static security analysis for the frontend TypeScript/JavaScript codebase.

### CODEOWNERS Routing

Added a `/src/dataviewer/` entry in *.github/CODEOWNERS* assigned to `@microsoft/edge-ai-core-dev`. Positioned after the broader `/src/` entry to leverage CODEOWNERS last-match-wins semantics for specific ownership routing on dataviewer PRs.

### Spell-Check Dictionary

Added 6 dataviewer-related terms to *.cspell/general-technical.txt*: *fastapi*, *pydantic*, *radix*, *shadcn*, *tanstack*, *zustand*. These correspond to backend frameworks (FastAPI, Pydantic) and frontend UI libraries (Radix, shadcn/ui, TanStack, Zustand), alphabetically interleaved into the existing dictionary section.

## Testing Performed

- [x] Terraform `plan` reviewed (no unexpected changes)
- [ ] Terraform `apply` tested in dev environment
- [ ] Training scripts tested locally with Isaac Sim
- [ ] OSMO workflow submitted successfully
- [ ] Smoke tests passed (`smoke_test_azure.py`)

> No Terraform or runtime changes in this PR. Validation consisted of YAML lint (29 workflow files, 0 issues), cspell (419 files, 0 issues), and VS Code diagnostics (0 errors across all modified files).

## Documentation Impact

- [x] No documentation changes needed
- [ ] Documentation updated in this PR
- [ ] Documentation issue filed

## Bug Fix Checklist

*Complete this section for bug fix PRs. Skip for other contribution types.*

- [ ] Linked to issue being fixed
- [ ] Regression test included, OR
- [ ] Justification for no regression test:

## Checklist

- [x] My code follows the [project conventions](copilot-instructions.md)
- [x] Commit messages follow [conventional commit format](instructions/commit-message.instructions.md)
- [x] I have performed a self-review
- [x] Documentation impact assessed above
- [x] No new linting warnings introduced