### PR TITLE
docs: replace stale coming-soon labels for training and inference

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -22,7 +22,7 @@ Documentation spans the full lifecycle — from provisioning Azure infrastructur
 | Role                   | Start here                                                                            |
 |------------------------|---------------------------------------------------------------------------------------|
 | First-time deployer    | Getting Started (coming soon), then [Deploy](https://github.com/microsoft/physical-ai-toolchain/tree/main/deploy)                              |
-| ML / Robotics engineer | Training (coming soon) and Inference (coming soon)                                    |
+| ML / Robotics engineer | [Training](training/README.md) and [Inference](inference/README.md)                  |
 | Platform operator      | [Operations](operations/README.md) and [Security Guide](operations/security-guide.md) |
 | Contributor            | [Contributing](contributing/README.md)                                                |
 
@@ -32,8 +32,8 @@ Documentation spans the full lifecycle — from provisioning Azure infrastructur
 |----------------------------------------|-------------------------------------------------------------------------------------|-------------|
 | Getting Started                        | Environment setup, prerequisites, and first deployment walkthrough                  | Coming soon |
 | [Deploy](https://github.com/microsoft/physical-ai-toolchain/tree/main/deploy)                   | Infrastructure provisioning with Terraform, AKS cluster setup, and networking       | Available   |
-| Training                               | Model training pipelines with Isaac Lab, AzureML jobs, and OSMO orchestration       | Coming soon |
-| Inference                              | Serving trained policies for real-time control on edge and cloud                    | Coming soon |
+| [Training](training/README.md)         | Model training pipelines with Isaac Lab, AzureML jobs, and OSMO orchestration       | Available   |
+| [Inference](inference/README.md)       | Serving trained policies for real-time control on edge and cloud                    | Available   |
 | Workflows                              | AzureML and OSMO job templates, pipeline configuration, and submission scripts      | Coming soon |
 | [Operations](operations/README.md)     | Monitoring, scaling, troubleshooting, and cost management for running clusters      | Available   |
 | Security                               | Identity, networking, compliance, and hardening for production deployments          | Coming soon |
@@ -47,6 +47,7 @@ Standalone guides available now. These cover common tasks and will move into the
 | Guide                                                                   | Description                                                                                                         |
 |-------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------|
 | [AzureML Validation Job Debugging](operations/azureml-validation-job-debugging.md) | Diagnosing and resolving AzureML validation job failures on AKS, including pod scheduling and resource quota issues |
+| [LeRobot Training](training/lerobot-training.md)                        | Training LeRobot ACT and Diffusion policies for robotics tasks on AzureML and OSMO                                 |
 | [LeRobot Inference](inference/lerobot-inference.md)                     | Running LeRobot inference workloads with pre-trained policies on Azure infrastructure                               |
 | [MLflow Integration](training/mlflow-integration.md)                    | Configuring MLflow experiment tracking for SKRL training agents with automatic metric logging to Azure ML           |
 | [Security Guide](operations/security-guide.md)                          | Security configuration inventory, deployment responsibilities, and hardening checklist for robotics workloads       |


### PR DESCRIPTION
## Summary
This updates `docs/README.md` to remove stale `Coming soon` labels for sections that already have published docs.

### Changes
- Updated the audience guide for ML/Robotics engineers to point to:
  - `docs/training/README.md`
  - `docs/inference/README.md`
- Updated the documentation index entries for Training and Inference:
  - Added section links
  - Changed status from `Coming soon` to `Available`
- Added `LeRobot Training` to the current guides table.

### Validation
- `npm run lint:md`

Resolves #135