### PR TITLE
docs(infrastructure): add TFLint local setup and validation guidance

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -174,7 +174,7 @@ Run `npm install` (or `npm ci`) before any `npm run` lint commands. `shellcheck`
 | File Type | Validation Commands |
 | --- | --- |
 | `*.md` | `npm run lint:md`, `npm run spell-check`, `npm run format:tables` |
-| `*.tf`, `*.tfvars` | `terraform fmt -check`, `terraform validate`, `terraform plan` |
+| `*.tf`, `*.tfvars` | `terraform fmt -check`, `terraform validate`, `tflint --recursive deploy/001-iac/`, `terraform plan` |
 | `*.sh` | `shellcheck <file>` |
 | `*.ps1` | `npm run lint:ps` |
 | `*.yml` (GitHub Actions) | `npm run lint:yaml` |

--- a/docs/contributing/prerequisites.md
+++ b/docs/contributing/prerequisites.md
@@ -37,6 +37,57 @@ Install these tools before contributing:
 | OSMO CLI    | latest          | <https://developer.nvidia.com/osmo>                                   |
 | hve-core    | latest          | <https://github.com/microsoft/hve-core>                               |
 
+## TFLint Setup
+
+Install TFLint locally to match CI linting for Terraform changes.
+
+### Install Commands
+
+**macOS (Homebrew):**
+
+```bash
+brew install tflint
+```
+
+**Windows (Chocolatey):**
+
+```powershell
+choco install tflint
+```
+
+**Windows (Scoop):**
+
+```powershell
+scoop install tflint
+```
+
+**Linux (official install script):**
+
+```bash
+curl -s https://raw.githubusercontent.com/terraform-linters/tflint/master/install_linux.sh | bash
+```
+
+### First-Time Initialization
+
+Run plugin initialization before your first lint run:
+
+```bash
+# From repository root
+tflint --init --chdir=deploy/001-iac/
+
+# Or from the Terraform directory directly
+cd deploy/001-iac/
+tflint --init
+```
+
+### Optional VS Code Extension
+
+For inline Terraform lint diagnostics, install the `TFLint` VS Code extension:
+
+```bash
+code --install-extension terraform-linters.tflint
+```
+
 ## Azure Access Requirements
 
 Deploying this architecture requires Azure subscription access with specific permissions and quotas:


### PR DESCRIPTION
## Summary
This PR adds explicit TFLint developer setup guidance and updates the validation quick-reference to include TFLint for Terraform changes.

### What changed
- Updated `docs/contributing/prerequisites.md`:
  - Added a dedicated **TFLint Setup** section
  - Added install commands for macOS, Windows (Chocolatey/Scoop), and Linux
  - Documented first-time plugin initialization with `tflint --init`
  - Added optional VS Code extension install command
- Updated `.github/copilot-instructions.md`:
  - Added `tflint --recursive deploy/001-iac/` to Terraform validation commands table

### Validation
- `npm run lint:md`
- `npm run spell-check`

Resolves #206