### PR TITLE
fix(scripts): resolve SC2318 in tf_require local assignment

### DIFF
--- a/deploy/002-setup/lib/common.sh
+++ b/deploy/002-setup/lib/common.sh
@@ -83,7 +83,10 @@ tf_get() {
 
 # Require a terraform output value (fatal if missing)
 tf_require() {
-  local json="${1:?json required}" key="${2:?key required}" description="${3:-$key}"
+  local json key description
+  json="${1:?json required}"
+  key="${2:?key required}"
+  description="${3:-$key}"
   local val
   val=$(tf_get "$json" "$key")
   [[ -n "$val" ]] || fatal "$description not found in terraform outputs"


### PR DESCRIPTION
## Summary
Fixes the ShellCheck SC2318 pattern in `tf_require` by splitting local declaration from assignment.

### Change
- Updated `deploy/002-setup/lib/common.sh` `tf_require`:
  - Declare `json`, `key`, `description` first
  - Assign values in separate statements

### Validation
- `bash -n deploy/002-setup/lib/common.sh`

Note: `shellcheck` is not available in this runner environment, so I validated syntax with `bash -n`.

Resolves #136