### PR TITLE
chore: add tracked artifacts directory for dependency pinning outputs

### DIFF
--- a/dependency-pinning-artifacts/README.md
+++ b/dependency-pinning-artifacts/README.md
@@ -1,0 +1,15 @@
+---
+title: Dependency Pinning Artifacts
+description: Temporary artifacts generated during dependency pinning validation
+---
+
+This directory is reserved for artifacts produced by dependency-pinning checks
+and related security validation scripts.
+
+Examples include:
+
+- Generated scan outputs during local test runs
+- Temporary comparison artifacts used by dependency pinning tests
+
+Do not commit generated artifact files unless explicitly required for a test or
+baseline update.


### PR DESCRIPTION
## Summary
Adds `dependency-pinning-artifacts/README.md` so the directory is tracked and its purpose is documented.

### Details
- Created `dependency-pinning-artifacts/README.md`
- Documented that the directory stores temporary/generated outputs for dependency-pinning checks

### Validation
- `npm run lint:md`

Resolves #143