### PR TITLE
fix(deploy): add strict error handling flags to prerequisite scripts

### DIFF
--- a/deploy/000-prerequisites/az-sub-init.sh
+++ b/deploy/000-prerequisites/az-sub-init.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
 tenant=""
 help="Usage: az-sub-init.sh [--tenant your-tenant.onmicrosoft.com] [--help]

--- a/deploy/000-prerequisites/register-azure-providers.sh
+++ b/deploy/000-prerequisites/register-azure-providers.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROVIDERS_FILE="${SCRIPT_DIR}/robotics-azure-resource-providers.txt"


### PR DESCRIPTION
## Summary
Adds strict shell error handling flags to prerequisite scripts to align with shell conventions.

### Changes
- `deploy/000-prerequisites/az-sub-init.sh`: added `set -euo pipefail`
- `deploy/000-prerequisites/register-azure-providers.sh`: added `set -euo pipefail`

### Validation
- `bash -n deploy/000-prerequisites/az-sub-init.sh`
- `bash -n deploy/000-prerequisites/register-azure-providers.sh`

Note: `shellcheck` is not available in this runner environment.

Resolves #149