### PR TITLE
chore(ci): remove unused jacoco parser from codecov config

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -42,10 +42,6 @@ flags:
       - src/
     carryforward: true
 
-parsers:
-  jacoco:
-    partials_as_hits: true
-
 comment:
   layout: "header, diff, flags, files"
   behavior: default


### PR DESCRIPTION
## Summary
Removes the unused JaCoCo parser block from `codecov.yml`. This repository has no Java coverage uploads, and Cobertura-based coverage remains unchanged.

### Changes
- Removed:
  - `parsers.jacoco.partials_as_hits`

### Validation
- Parsed `codecov.yml` with `python3` + `yaml.safe_load`

Note: `npm run lint:yaml` requires `pwsh`, which is unavailable in this runner environment.

Resolves #140