### PR TITLE
fix(scripts): align setup-dev.sh shebang and uv pin with PowerShell setup

### DIFF
--- a/setup-dev.sh
+++ b/setup-dev.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -46,7 +46,7 @@ section "UV Package Manager Setup"
 
 if ! command -v uv &>/dev/null; then
   info "Installing uv package manager..."
-  curl -LsSf https://astral.sh/uv/0.10.9/install.sh | sh
+  curl -LsSf https://astral.sh/uv/0.7.12/install.sh | sh
   export PATH="$HOME/.local/bin:$HOME/.cargo/bin:$PATH"
 fi
 


### PR DESCRIPTION
## Summary
Aligns `setup-dev.sh` with shell conventions and the pinned uv version used in `setup-dev.ps1`.

### Changes
- Shebang updated: `#!/bin/bash` -> `#!/usr/bin/env bash`
- uv installer pin updated: `0.10.9` -> `0.7.12` (matches `setup-dev.ps1`)

### Validation
- `bash -n setup-dev.sh`

Note: `shellcheck` is not available in this runner environment.

Resolves #144