### PR TITLE
docs: refresh stale ms.date in empty-description fixture

### DIFF
--- a/scripts/tests/Fixtures/Frontmatter/empty-description.md
+++ b/scripts/tests/Fixtures/Frontmatter/empty-description.md
@@ -1,7 +1,7 @@
 ---
 title: Empty Description Test
 description: ""
-ms.date: 2025-01-15
+ms.date: 2026-03-14
 ---
 
 # Empty Description


### PR DESCRIPTION
## Summary
- refresh stale ms.date in scripts/tests/Fixtures/Frontmatter/empty-description.md to 2026-03-14
- keep fixture content unchanged except the stale date update

## Testing
- Not run (fixture-only stale-docs update)

Resolves #153