### PR TITLE
docs: refresh stale ms.date in valid-docs-with-footer fixture

### DIFF
--- a/scripts/tests/Fixtures/Frontmatter/valid-docs-with-footer.md
+++ b/scripts/tests/Fixtures/Frontmatter/valid-docs-with-footer.md
@@ -2,7 +2,7 @@
 title: Azure ML Validation Job Debugging
 description: Troubleshooting guide for Azure Machine Learning validation job failures
 author: Robotics-AI Team
-ms.date: 2025-01-15
+ms.date: 2026-03-14
 ms.topic: troubleshooting
 ---
 


### PR DESCRIPTION
## Summary
- refresh stale ms.date in scripts/tests/Fixtures/Frontmatter/valid-docs-with-footer.md to 2026-03-14
- keep fixture content unchanged except the stale date update

## Testing
- Not run (fixture-only stale-docs update)

Resolves #156