### PR TITLE
docs: refresh stale ms.date in valid-root-community fixture

### DIFF
--- a/scripts/tests/Fixtures/Frontmatter/valid-root-community.md
+++ b/scripts/tests/Fixtures/Frontmatter/valid-root-community.md
@@ -2,7 +2,7 @@
 title: Contributing Guide
 description: Guidelines for contributing to the Physical AI Toolchain
 author: Robotics-AI Team
-ms.date: 2025-01-15
+ms.date: 2026-03-14
 ---
 
 Thank you for your interest in contributing to this project.


### PR DESCRIPTION
## Summary
- refresh stale ms.date in scripts/tests/Fixtures/Frontmatter/valid-root-community.md to 2026-03-14
- keep fixture content unchanged except the stale date update

## Testing
- Not run (fixture-only stale-docs update)

Resolves #159