### PR TITLE
docs: refresh stale ms.date in warning-author-empty fixture

### DIFF
--- a/scripts/tests/Fixtures/Frontmatter/warning-author-empty.md
+++ b/scripts/tests/Fixtures/Frontmatter/warning-author-empty.md
@@ -2,7 +2,7 @@
 title: Warning Test Fixture
 description: File with empty author field to trigger a validation warning
 author: ""
-ms.date: 2025-01-15
+ms.date: 2026-03-14
 ms.topic: conceptual
 ---
 


### PR DESCRIPTION
## Summary
- refresh stale ms.date in scripts/tests/Fixtures/Frontmatter/warning-author-empty.md to 2026-03-14
- keep fixture content unchanged except the stale date update

## Testing
- Not run (fixture-only stale-docs update)

Resolves #160