### PR TITLE
fix(terraform): add missing location variable to sil module

### DIFF
--- a/deploy/001-iac/modules/sil/variables.core.tf
+++ b/deploy/001-iac/modules/sil/variables.core.tf
@@ -20,6 +20,11 @@ variable "instance" {
   default     = "001"
 }
 
+variable "location" {
+  type        = string
+  description = "Location for all resources in this module"
+}
+
 variable "resource_group" {
   type = object({
     id       = string


### PR DESCRIPTION
## Summary
- add the missing `location` core variable in `deploy/001-iac/modules/sil/variables.core.tf`
- align the variable definition format with the platform module convention

## Testing
- Not run: `terraform` CLI is not available in this environment (`terraform: command not found`)

Resolves #151