### PR TITLE
docs(contributing): add CLA reference section to root guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,19 @@ Contributions are welcome across infrastructure code, deployment automation, doc
 
 If you are new to the project, start with issues labeled `good first issue` or documentation updates before making larger changes.
 
+## Contributor License Agreement (CLA)
+
+Most contributions require you to agree to a Contributor License Agreement (CLA)
+declaring that you have the right to grant us the rights to use your
+contribution.
+
+When you submit a pull request, a CLA bot automatically determines whether you
+need to provide a CLA and decorates the PR (for example, status check, comment).
+Follow the bot instructions. You only need to complete this process once across
+all repositories using this CLA.
+
+For details, visit <https://cla.opensource.microsoft.com>.
+
 ## Getting Started
 
 1. Read the [Contributing Guide](docs/contributing/README.md) for prerequisites, workflow, and conventions


### PR DESCRIPTION
## Summary
- add a Contributor License Agreement (CLA) section near the top of `CONTRIBUTING.md`
- include the official CLA portal link and CLA bot behavior (automatic check and one-time completion)
- place the section before Getting Started as requested

## Testing
- npm run lint:md
- npm run spell-check

Resolves #237