### PR TITLE
chore(lint): add cspell terms for terraform-docs output

### DIFF
--- a/.cspell/general-technical.txt
+++ b/.cspell/general-technical.txt
@@ -39,6 +39,8 @@ anydb
 anymal
 aobo
 apis
+aks
+aksconfig
 app
 apple
 appletalk
@@ -124,6 +126,7 @@ bombay
 bootdiagnostics
 bootstorm
 borderless
+bool
 bots
 bpel
 bpms
@@ -1184,6 +1187,7 @@ sios
 sitelogs
 sklearn
 skrl
+sku
 skus
 slas
 sles
@@ -1246,7 +1250,9 @@ subcomponents
 subfolders
 submillisecond
 submittext
+subnet
 subnetting
+subnets
 subnetworks
 subresource
 subresources


### PR DESCRIPTION
## Summary
- add Terraform docs terminology to `.cspell/general-technical.txt`
- include focused entries used by generated documentation and module variables (`aks`, `aksconfig`, `bool`, `sku`, `subnet`, `subnets`)
- keep dictionary additions specific and minimal (no wildcard terms)

## Testing
- npm run spell-check

Resolves #197