### PR TITLE
chore(terraform): add root .terraform-docs.yml configuration

### DIFF
--- a/.terraform-docs.yml
+++ b/.terraform-docs.yml
@@ -1,0 +1,26 @@
+formatter: markdown table
+
+output:
+  file: README.md
+  mode: inject
+  template: |-
+    <!-- BEGIN_TF_DOCS -->
+    {{ .Content }}
+    <!-- END_TF_DOCS -->
+
+sort:
+  enabled: true
+  by: required
+
+sections:
+  show:
+    - resources
+    - inputs
+    - outputs
+  hide:
+    - providers
+    - requirements
+
+settings:
+  anchor: false
+  html: false


### PR DESCRIPTION
## Summary
- add root `.terraform-docs.yml` for repository-wide terraform-docs behavior
- configure `mode: inject` output into `README.md` between `BEGIN_TF_DOCS`/`END_TF_DOCS` markers
- enable required-first sorting and show only `resources`, `inputs`, and `outputs`
- disable anchors/html and hide `providers`/`requirements`

## Testing
- python3 YAML parse/shape check for `.terraform-docs.yml`

Resolves #188