### PR TITLE
docs(terraform): add module README files with tf-docs markers

### DIFF
--- a/deploy/001-iac/modules/aks/README.md
+++ b/deploy/001-iac/modules/aks/README.md
@@ -1,0 +1,8 @@
+# AKS Module
+
+This module provisions the Azure Kubernetes Service (AKS) cluster foundation
+for the platform deployment, including core cluster settings and supporting
+resources.
+
+<!-- BEGIN_TF_DOCS -->
+<!-- END_TF_DOCS -->

--- a/deploy/001-iac/modules/automation/README.md
+++ b/deploy/001-iac/modules/automation/README.md
@@ -1,0 +1,7 @@
+# Automation Module
+
+This module provisions the automation resources that schedule and run
+infrastructure lifecycle operations for the deployed environment.
+
+<!-- BEGIN_TF_DOCS -->
+<!-- END_TF_DOCS -->

--- a/deploy/001-iac/modules/dataviewer/README.md
+++ b/deploy/001-iac/modules/dataviewer/README.md
@@ -1,0 +1,7 @@
+# Dataviewer Module
+
+This module provisions infrastructure dependencies for the dataviewer service,
+including platform resources required to host and operate the application.
+
+<!-- BEGIN_TF_DOCS -->
+<!-- END_TF_DOCS -->

--- a/deploy/001-iac/modules/platform/README.md
+++ b/deploy/001-iac/modules/platform/README.md
@@ -1,0 +1,7 @@
+# Platform Module
+
+This module provisions core platform infrastructure shared by workloads,
+including cluster-adjacent services and foundational Azure resources.
+
+<!-- BEGIN_TF_DOCS -->
+<!-- END_TF_DOCS -->

--- a/deploy/001-iac/modules/sil/README.md
+++ b/deploy/001-iac/modules/sil/README.md
@@ -1,0 +1,7 @@
+# SIL Module
+
+This module provisions Simulation Infrastructure Layer (SIL) resources used for
+simulation workloads and GPU-enabled training/inference support.
+
+<!-- BEGIN_TF_DOCS -->
+<!-- END_TF_DOCS -->

--- a/deploy/001-iac/modules/vpn/README.md
+++ b/deploy/001-iac/modules/vpn/README.md
@@ -1,0 +1,7 @@
+# VPN Module
+
+This module provisions reusable VPN-related infrastructure components used by
+the private networking and access model for the deployment.
+
+<!-- BEGIN_TF_DOCS -->
+<!-- END_TF_DOCS -->


### PR DESCRIPTION
## Summary
- add missing `README.md` files with hand-written module summaries and `BEGIN_TF_DOCS`/`END_TF_DOCS` markers
- cover the current child module layout under `deploy/001-iac/modules/`:
  - `aks`
  - `automation`
  - `dataviewer`
  - `platform`
  - `sil`
  - `vpn`
- keep the marker placement consistent for terraform-docs `mode: inject`

## Testing
- npm run lint:md

Resolves #186