### PR TITLE
docs(contributing): document terraform-docs conventions in infra style

### DIFF
--- a/docs/contributing/infrastructure-style.md
+++ b/docs/contributing/infrastructure-style.md
@@ -44,6 +44,45 @@ modules/
     README.md        # Module documentation
 ```
 
+### Terraform-docs Workflow
+
+Terraform module documentation is generated with `terraform-docs` using the
+repository-level `.terraform-docs.yml` configuration.
+
+#### Inject Mode and Markers
+
+This repository uses `mode: inject`, which preserves hand-written README
+content and updates only the generated section between these markers:
+
+```md
+<!-- BEGIN_TF_DOCS -->
+<!-- END_TF_DOCS -->
+```
+
+Place markers after introductory content and before footer blocks. Keep
+hand-written usage notes outside the marker block.
+
+#### CI Validation Model
+
+CI validates generated documentation by running terraform-docs and checking for
+diffs. Pull requests should include regenerated README changes when Terraform
+inputs/outputs/resources are modified.
+
+#### Variable Documentation Best Practices
+
+* Add concise, factual `description` values for all variables
+* Keep variable types explicit and accurate
+* Declare defaults where optional behavior is intended
+* Use repository naming conventions (for example `should_*` for booleans)
+
+#### Local Regeneration Command
+
+Regenerate module documentation locally before submitting a PR:
+
+```bash
+./scripts/update-terraform-docs.sh
+```
+
 ### Resource Tagging
 
 All Azure resources must include standard tags:


### PR DESCRIPTION
## Summary
- extend `docs/contributing/infrastructure-style.md` with terraform-docs conventions
- document `mode: inject` behavior and marker placement (`BEGIN_TF_DOCS` / `END_TF_DOCS`)
- add CI validation guidance for generated docs drift
- add variable documentation best practices and local regeneration command

## Testing
- npm run lint:md
- npm run spell-check

Resolves #195