### PR TITLE
chore(dx): add terraform-docs install to setup scripts and docs

### DIFF
--- a/docs/contributing/prerequisites.md
+++ b/docs/contributing/prerequisites.md
@@ -25,6 +25,7 @@ Install these tools before contributing:
 | Tool        | Minimum Version | Installation                                                          |
 |-------------|-----------------|-----------------------------------------------------------------------|
 | Terraform   | 1.9.8           | <https://developer.hashicorp.com/terraform/install>                   |
+| terraform-docs | 0.21.0       | <https://github.com/terraform-docs/terraform-docs/releases/tag/v0.21.0> |
 | TFLint      | 0.61.0          | <https://github.com/terraform-linters/tflint>                         |
 | Azure CLI   | 2.65.0          | <https://learn.microsoft.com/cli/azure/install-azure-cli>             |
 | kubectl     | 1.31            | <https://kubernetes.io/docs/tasks/tools/>                             |
@@ -106,6 +107,9 @@ Verify tool versions before validating:
 # Terraform
 terraform version  # >= 1.9.8
 
+# terraform-docs
+terraform-docs --version  # = v0.21.0
+
 # TFLint (Terraform linter)
 tflint --version  # >= 0.61.0
 
@@ -170,6 +174,9 @@ shellcheck deploy/**/*.sh scripts/**/*.sh
 **Documentation:**
 
 ```bash
+# Regenerate Terraform module documentation (required for IaC README updates)
+./scripts/update-terraform-docs.sh
+
 # Install dependencies (first time only)
 npm install
 

--- a/setup-dev.ps1
+++ b/setup-dev.ps1
@@ -94,6 +94,71 @@ Write-Section 'Tool Verification'
 Assert-Tools az, terraform, kubectl, helm, jq
 Write-Info 'All required tools found'
 
+Write-Section 'Terraform-docs Setup'
+
+$TerraformDocsVersion = 'v0.21.0'
+$TerraformDocsArchive = "terraform-docs-$TerraformDocsVersion-linux-amd64.tar.gz"
+$TerraformDocsUrl = "https://github.com/terraform-docs/terraform-docs/releases/download/$TerraformDocsVersion/$TerraformDocsArchive"
+$TerraformDocsChecksumUrl = "https://github.com/terraform-docs/terraform-docs/releases/download/$TerraformDocsVersion/terraform-docs-$TerraformDocsVersion.sha256sum"
+$TerraformDocsInstallDir = Join-Path $HOME '.local/bin'
+
+$currentTerraformDocsVersion = $null
+if (Get-Command terraform-docs -ErrorAction SilentlyContinue) {
+    $versionOutput = terraform-docs --version 2>$null
+    $versionMatch = [regex]::Match($versionOutput, 'v\d+\.\d+\.\d+')
+    if ($versionMatch.Success) {
+        $currentTerraformDocsVersion = $versionMatch.Value
+    }
+}
+
+if ($currentTerraformDocsVersion -eq $TerraformDocsVersion) {
+    Write-Info "terraform-docs $TerraformDocsVersion already installed"
+}
+else {
+    Write-Info "Installing terraform-docs $TerraformDocsVersion with checksum verification..."
+    $tempDir = Join-Path ([System.IO.Path]::GetTempPath()) ("terraform-docs-" + [Guid]::NewGuid().ToString('N'))
+    New-Item -ItemType Directory -Path $tempDir -Force | Out-Null
+
+    try {
+        $archivePath = Join-Path $tempDir $TerraformDocsArchive
+        $checksumPath = Join-Path $tempDir "terraform-docs-$TerraformDocsVersion.sha256sum"
+
+        Invoke-WebRequest -Uri $TerraformDocsUrl -OutFile $archivePath -UseBasicParsing
+        Invoke-WebRequest -Uri $TerraformDocsChecksumUrl -OutFile $checksumPath -UseBasicParsing
+
+        $checksumLine = Get-Content $checksumPath | Where-Object { $_ -match [regex]::Escape($TerraformDocsArchive) } | Select-Object -First 1
+        if (-not $checksumLine) {
+            Write-Error "Unable to locate checksum for $TerraformDocsArchive"
+        }
+
+        $expectedHash = ($checksumLine -split '\s+')[0].ToLowerInvariant()
+        $actualHash = (Get-FileHash -Path $archivePath -Algorithm SHA256).Hash.ToLowerInvariant()
+        if ($expectedHash -ne $actualHash) {
+            Write-Error 'Checksum verification failed for terraform-docs archive'
+        }
+
+        New-Item -ItemType Directory -Path $TerraformDocsInstallDir -Force | Out-Null
+        tar -xzf $archivePath -C $tempDir terraform-docs
+        if ($LASTEXITCODE -ne 0) {
+            Write-Error "tar extraction failed (exit code $LASTEXITCODE)"
+        }
+
+        Copy-Item -Path (Join-Path $tempDir 'terraform-docs') -Destination (Join-Path $TerraformDocsInstallDir 'terraform-docs') -Force
+        if (-not $IsWindows) {
+            chmod +x (Join-Path $TerraformDocsInstallDir 'terraform-docs')
+        }
+
+        if ($env:PATH -notlike "*$TerraformDocsInstallDir*") {
+            $env:PATH = "$TerraformDocsInstallDir:$env:PATH"
+        }
+
+        Write-Info "Installed terraform-docs: $((& terraform-docs --version | Select-Object -First 1))"
+    }
+    finally {
+        Remove-Item $tempDir -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
+
 Write-Section 'UV Package Manager Setup'
 
 $UvVersion = '0.7.12'

--- a/setup-dev.sh
+++ b/setup-dev.sh
@@ -42,6 +42,46 @@ section "Tool Verification"
 require_tools az terraform kubectl helm jq
 info "All required tools found"
 
+section "Terraform-docs Setup"
+
+TERRAFORM_DOCS_VERSION="v0.21.0"
+TERRAFORM_DOCS_ARCHIVE="terraform-docs-${TERRAFORM_DOCS_VERSION}-linux-amd64.tar.gz"
+TERRAFORM_DOCS_URL="https://github.com/terraform-docs/terraform-docs/releases/download/${TERRAFORM_DOCS_VERSION}/${TERRAFORM_DOCS_ARCHIVE}"
+TERRAFORM_DOCS_SHA_URL="https://github.com/terraform-docs/terraform-docs/releases/download/${TERRAFORM_DOCS_VERSION}/terraform-docs-${TERRAFORM_DOCS_VERSION}.sha256sum"
+TERRAFORM_DOCS_INSTALL_DIR="${HOME}/.local/bin"
+
+current_terraform_docs_version=""
+if command -v terraform-docs &>/dev/null; then
+  current_terraform_docs_version="$(terraform-docs --version 2>/dev/null | sed -n 's/.*version \\(v[0-9.]*\\).*/\\1/p' | head -n 1)"
+fi
+
+if [[ "${current_terraform_docs_version}" == "${TERRAFORM_DOCS_VERSION}" ]]; then
+  info "terraform-docs ${TERRAFORM_DOCS_VERSION} already installed"
+else
+  info "Installing terraform-docs ${TERRAFORM_DOCS_VERSION} with checksum verification..."
+  tmp_dir="$(mktemp -d)"
+  trap 'rm -rf "${tmp_dir}"' EXIT
+
+  archive_path="${tmp_dir}/${TERRAFORM_DOCS_ARCHIVE}"
+  sha_path="${tmp_dir}/terraform-docs-${TERRAFORM_DOCS_VERSION}.sha256sum"
+
+  curl -fsSL "${TERRAFORM_DOCS_URL}" -o "${archive_path}"
+  curl -fsSL "${TERRAFORM_DOCS_SHA_URL}" -o "${sha_path}"
+
+  expected_sha="$(awk -v target="${TERRAFORM_DOCS_ARCHIVE}" '$2 == target {print $1}' "${sha_path}" | head -n 1)"
+  [[ -n "${expected_sha}" ]] || fatal "Unable to locate checksum for ${TERRAFORM_DOCS_ARCHIVE}"
+
+  actual_sha="$(sha256sum "${archive_path}" | awk '{print $1}')"
+  [[ "${actual_sha}" == "${expected_sha}" ]] || fatal "Checksum verification failed for terraform-docs archive"
+
+  mkdir -p "${TERRAFORM_DOCS_INSTALL_DIR}"
+  tar -xzf "${archive_path}" -C "${tmp_dir}" terraform-docs
+  install -m 0755 "${tmp_dir}/terraform-docs" "${TERRAFORM_DOCS_INSTALL_DIR}/terraform-docs"
+
+  export PATH="${TERRAFORM_DOCS_INSTALL_DIR}:$PATH"
+  info "Installed terraform-docs: $(terraform-docs --version | head -n 1)"
+fi
+
 section "UV Package Manager Setup"
 
 if ! command -v uv &>/dev/null; then


### PR DESCRIPTION
## Summary
- add terraform-docs v0.21.0 installation to `setup-dev.sh` with SHA256 verification against release checksums
- add the same pinned installation and checksum verification flow to `setup-dev.ps1`
- skip installation when the correct terraform-docs version is already present
- document terraform-docs v0.21.0 in `docs/contributing/prerequisites.md` and add local regeneration command guidance

## Testing
- bash -n setup-dev.sh
- npm run lint:md
- npm run spell-check
- Not run: PSScriptAnalyzer (`pwsh` is not available in this environment)

Resolves #199