### PR TITLE
fix(infrastructure): resolve TFLint violations in root and automation modules

### DIFF
--- a/docs/infrastructure/infrastructure.md
+++ b/docs/infrastructure/infrastructure.md
@@ -70,7 +70,7 @@ terraform init && terraform apply -var-file=terraform.tfvars
 | `system_node_pool_vm_size`             | VM size for AKS system node pool         | `Standard_D8ds_v5` |
 | `system_node_pool_node_count`          | Number of nodes for AKS system node pool | `1`                |
 | `system_node_pool_zones`               | Availability zones for system node pool  | `null`             |
-| `system_node_pool_enable_auto_scaling` | Enable auto-scaling for system node pool | `false`            |
+| `should_enable_system_node_pool_auto_scaling` | Enable auto-scaling for system node pool | `false`            |
 | `system_node_pool_min_count`           | Minimum nodes when auto-scaling enabled  | `null`             |
 | `system_node_pool_max_count`           | Maximum nodes when auto-scaling enabled  | `null`             |
 

--- a/infrastructure/examples/terraform.tfvars.prod
+++ b/infrastructure/examples/terraform.tfvars.prod
@@ -66,7 +66,7 @@ postgresql_high_availability = {
 }
 
 // Redis HA
-redis_high_availability_enabled = true
+should_enable_redis_high_availability = true
 
 // Network Security — Full Private
 should_enable_private_endpoint    = true

--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -109,7 +109,7 @@ module "platform" {
   redis_config = {
     sku_name                  = var.redis_sku_name
     clustering_policy         = var.redis_clustering_policy
-    high_availability_enabled = var.redis_high_availability_enabled
+    high_availability_enabled = var.should_enable_redis_high_availability
   }
 
   // OSMO workload identity
@@ -167,14 +167,14 @@ module "sil" {
 
   // AKS system node pool configuration
   aks_config = {
-    system_node_pool_vm_size             = var.system_node_pool_vm_size
-    system_node_pool_node_count          = var.system_node_pool_node_count
-    system_node_pool_enable_auto_scaling = var.system_node_pool_enable_auto_scaling
-    system_node_pool_min_count           = var.system_node_pool_min_count
-    system_node_pool_max_count           = var.system_node_pool_max_count
-    is_private_cluster                   = var.should_enable_private_aks_cluster
-    system_node_pool_zones               = var.system_node_pool_zones
-    should_enable_microsoft_defender     = var.should_enable_microsoft_defender
+    system_node_pool_vm_size                    = var.system_node_pool_vm_size
+    system_node_pool_node_count                 = var.system_node_pool_node_count
+    should_enable_system_node_pool_auto_scaling = var.should_enable_system_node_pool_auto_scaling
+    system_node_pool_min_count                  = var.system_node_pool_min_count
+    system_node_pool_max_count                  = var.system_node_pool_max_count
+    is_private_cluster                          = var.should_enable_private_aks_cluster
+    system_node_pool_zones                      = var.system_node_pool_zones
+    should_enable_microsoft_defender            = var.should_enable_microsoft_defender
   }
 
   node_pools = var.node_pools

--- a/infrastructure/terraform/modules/automation/main.tf
+++ b/infrastructure/terraform/modules/automation/main.tf
@@ -11,7 +11,7 @@ locals {
   location                = coalesce(var.location, var.resource_group.location)
 
   # Construct schedule start_time: tomorrow at the configured time (RFC3339 format)
-  tomorrow_date = formatdate("YYYY-MM-DD", timeadd(timestamp(), "24h"))
+  tomorrow_date = formatdate("YYYY-MM-DD", timeadd(plantimestamp(), "24h"))
   schedule_time = "${local.tomorrow_date}T${var.schedule_config.start_time}:00+00:00"
 }
 

--- a/infrastructure/terraform/modules/sil/aks.tf
+++ b/infrastructure/terraform/modules/sil/aks.tf
@@ -50,10 +50,10 @@ resource "azurerm_kubernetes_cluster" "main" {
   default_node_pool {
     name                        = "system"
     vm_size                     = var.aks_config.system_node_pool_vm_size
-    node_count                  = var.aks_config.system_node_pool_enable_auto_scaling ? null : var.aks_config.system_node_pool_node_count
-    auto_scaling_enabled        = var.aks_config.system_node_pool_enable_auto_scaling
-    min_count                   = var.aks_config.system_node_pool_enable_auto_scaling ? var.aks_config.system_node_pool_min_count : null
-    max_count                   = var.aks_config.system_node_pool_enable_auto_scaling ? var.aks_config.system_node_pool_max_count : null
+    node_count                  = var.aks_config.should_enable_system_node_pool_auto_scaling ? null : var.aks_config.system_node_pool_node_count
+    auto_scaling_enabled        = var.aks_config.should_enable_system_node_pool_auto_scaling
+    min_count                   = var.aks_config.should_enable_system_node_pool_auto_scaling ? var.aks_config.system_node_pool_min_count : null
+    max_count                   = var.aks_config.should_enable_system_node_pool_auto_scaling ? var.aks_config.system_node_pool_max_count : null
     vnet_subnet_id              = azurerm_subnet.aks.id
     os_disk_size_gb             = 128
     os_disk_type                = "Ephemeral"

--- a/infrastructure/terraform/modules/sil/variables.tf
+++ b/infrastructure/terraform/modules/sil/variables.tf
@@ -59,24 +59,24 @@ variable "aks_subnet_config" {
 
 variable "aks_config" {
   type = object({
-    system_node_pool_vm_size             = string
-    system_node_pool_node_count          = number
-    system_node_pool_enable_auto_scaling = bool
-    system_node_pool_min_count           = optional(number)
-    system_node_pool_max_count           = optional(number)
-    is_private_cluster                   = bool
-    system_node_pool_zones               = optional(list(string))
-    should_enable_microsoft_defender     = optional(bool, false)
+    system_node_pool_vm_size                    = string
+    system_node_pool_node_count                 = number
+    should_enable_system_node_pool_auto_scaling = bool
+    system_node_pool_min_count                  = optional(number)
+    system_node_pool_max_count                  = optional(number)
+    is_private_cluster                          = bool
+    system_node_pool_zones                      = optional(list(string))
+    should_enable_microsoft_defender            = optional(bool, false)
   })
   description = "AKS cluster configuration for the system node pool"
   default = {
-    system_node_pool_vm_size             = "Standard_D8ds_v5"
-    system_node_pool_node_count          = 2
-    system_node_pool_enable_auto_scaling = false
-    system_node_pool_min_count           = null
-    system_node_pool_max_count           = null
-    is_private_cluster                   = true
-    system_node_pool_zones               = null
+    system_node_pool_vm_size                    = "Standard_D8ds_v5"
+    system_node_pool_node_count                 = 2
+    should_enable_system_node_pool_auto_scaling = false
+    system_node_pool_min_count                  = null
+    system_node_pool_max_count                  = null
+    is_private_cluster                          = true
+    system_node_pool_zones                      = null
   }
 }
 

--- a/infrastructure/terraform/variables.tf
+++ b/infrastructure/terraform/variables.tf
@@ -161,7 +161,7 @@ variable "redis_clustering_policy" {
   }
 }
 
-variable "redis_high_availability_enabled" {
+variable "should_enable_redis_high_availability" {
   type        = bool
   description = "Enable high availability for Redis. Increases cost but provides zone redundancy"
   default     = false
@@ -257,7 +257,7 @@ variable "system_node_pool_node_count" {
   default     = 1
 }
 
-variable "system_node_pool_enable_auto_scaling" {
+variable "should_enable_system_node_pool_auto_scaling" {
   type        = bool
   description = "Enable auto-scaling for the AKS system node pool"
   default     = false


### PR DESCRIPTION
This PR resolves TFLint violations flagged in the root Terraform module and the automation submodule. Three discrete fixes were applied: replacing `timestamp()` with `plantimestamp()` in the automation schedule locals to eliminate perpetual plan diffs, and renaming two boolean variables to comply with the repository's `should_` prefix convention. All references — variable declarations, module pass-throughs, object types, ternary expressions, example configs, and documentation — were updated consistently with zero stale references remaining.

## Description

> TFLint flagged `timestamp()` usage and boolean variables not following the `should_` prefix convention established in the codebase. These are mechanical fixes with no functional behavior changes.

- Replaced **`timestamp()`** with **`plantimestamp()`** in *infrastructure/terraform/modules/automation/main.tf* to prevent perpetual diffs caused by apply-time evaluation
- Renamed **`redis_high_availability_enabled`** to **`should_enable_redis_high_availability`** across variable declaration, module reference, and production tfvars example
- Renamed **`system_node_pool_enable_auto_scaling`** to **`should_enable_system_node_pool_auto_scaling`** across variable declaration, module reference, SIL module object type definition, default values, and four ternary expressions in the AKS resource
  - Realigned `=` signs in `aks_config` blocks for consistent Terraform formatting
- Updated *docs/infrastructure/infrastructure.md* variable table to reflect the renamed auto-scaling variable

## Type of Change

- [x] 🐛 Bug fix (non-breaking change fixing an issue)
- [ ] ✨ New feature (non-breaking change adding functionality)
- [ ] 💥 Breaking change (fix or feature causing existing functionality to change)
- [ ] 📚 Documentation update
- [x] 🏗️ Infrastructure change (Terraform/IaC)
- [x] ♻️ Refactoring (no functional changes)

## Component(s) Affected

- [x] `infrastructure/terraform/` - Terraform infrastructure
- [x] `docs/` - Documentation

## Testing Performed

- [x] Terraform `plan` reviewed (no unexpected changes)
- [ ] Terraform `apply` tested in dev environment
- [ ] Training scripts tested locally with Isaac Sim
- [ ] OSMO workflow submitted successfully
- [ ] Smoke tests passed (`smoke_test_azure.py`)

## Documentation Impact

- [ ] No documentation changes needed
- [x] Documentation updated in this PR
- [ ] Documentation issue filed

## Checklist

- [x] My code follows the [project conventions](copilot-instructions.md)
- [x] Commit messages follow [conventional commit format](instructions/commit-message.instructions.md)
- [x] I have performed a self-review
- [x] Documentation impact assessed above
- [x] No new linting warnings introduced

## Related Issues

Closes #203