### PR TITLE
fix(terraform): gate observability with feature flags

### DIFF
--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -37,13 +37,15 @@ The reference architecture deploys configurable monitoring components through Te
 | Application Insights             | Application performance monitoring | Always deployed                   |
 | Azure Monitor workspace          | Prometheus metrics backend         | `should_deploy_monitor_workspace` |
 | Managed Grafana                  | Visualization dashboards           | `should_deploy_grafana`           |
-| Container Insights               | AKS container telemetry            | `should_deploy_monitor_workspace` |
-| Prometheus data collection rules | Metric scraping configuration      | `should_deploy_monitor_workspace` |
+| Container Insights               | AKS container telemetry            | `should_deploy_dce`               |
+| Prometheus data collection rules | Metric scraping configuration      | `should_deploy_dce` and `should_deploy_monitor_workspace` |
 | Azure Monitor Private Link Scope | Private network monitoring         | `should_deploy_ampls`             |
 | Data collection endpoint         | Private ingestion endpoint         | `should_deploy_dce`               |
 
 > [!IMPORTANT]
 > The default configuration deploys a **private AKS cluster**. Connect through the VPN Gateway before running any `kubectl` or Helm commands. See [VPN Gateway](../infrastructure/vpn.md) for setup instructions.
+
+Container Insights data collection rules are created when `should_deploy_dce` is enabled. Prometheus metrics collection rules require both `should_deploy_dce` and `should_deploy_monitor_workspace`.
 
 ## 🔗 Related Resources
 

--- a/infrastructure/terraform/main.tf
+++ b/infrastructure/terraform/main.tf
@@ -149,16 +149,18 @@ module "sil" {
   current_user_oid = local.current_user_oid
 
   // Dependencies from platform module (passed as typed objects)
-  virtual_network           = module.platform.virtual_network
-  subnets                   = module.platform.subnets
-  network_security_group    = module.platform.network_security_group
-  nat_gateway               = module.platform.nat_gateway
-  should_enable_nat_gateway = var.should_enable_nat_gateway
-  log_analytics_workspace   = module.platform.log_analytics_workspace
-  monitor_workspace         = module.platform.monitor_workspace
-  data_collection_endpoint  = module.platform.data_collection_endpoint
-  container_registry        = module.platform.container_registry
-  private_dns_zones         = module.platform.private_dns_zones
+  virtual_network                 = module.platform.virtual_network
+  subnets                         = module.platform.subnets
+  network_security_group          = module.platform.network_security_group
+  nat_gateway                     = module.platform.nat_gateway
+  should_enable_nat_gateway       = var.should_enable_nat_gateway
+  log_analytics_workspace         = module.platform.log_analytics_workspace
+  monitor_workspace               = module.platform.monitor_workspace
+  data_collection_endpoint        = module.platform.data_collection_endpoint
+  container_registry              = module.platform.container_registry
+  private_dns_zones               = module.platform.private_dns_zones
+  should_deploy_monitor_workspace = var.should_deploy_monitor_workspace
+  should_deploy_dce               = var.should_deploy_dce
 
   // AKS subnet configuration - uses module defaults when null
   aks_subnet_config = {

--- a/infrastructure/terraform/modules/sil/observability.tf
+++ b/infrastructure/terraform/modules/sil/observability.tf
@@ -15,7 +15,7 @@
 
 // DCR for AKS Container Insights Logs (requires DCE)
 resource "azurerm_monitor_data_collection_rule" "logs" {
-  count = var.data_collection_endpoint != null ? 1 : 0
+  count = var.should_deploy_dce ? 1 : 0
 
   name                        = "dcr-logs-${local.resource_name_suffix}"
   location                    = var.resource_group.location
@@ -54,7 +54,7 @@ resource "azurerm_monitor_data_collection_rule" "logs" {
 
 // DCR for AKS Prometheus Metrics (requires DCE and Monitor Workspace)
 resource "azurerm_monitor_data_collection_rule" "metrics" {
-  count = var.data_collection_endpoint != null && var.monitor_workspace != null ? 1 : 0
+  count = var.should_deploy_dce && var.should_deploy_monitor_workspace ? 1 : 0
 
   name                        = "dcr-metrics-${local.resource_name_suffix}"
   location                    = var.resource_group.location
@@ -88,7 +88,7 @@ resource "azurerm_monitor_data_collection_rule" "metrics" {
 
 // Associate Container Insights logs DCR with AKS
 resource "azurerm_monitor_data_collection_rule_association" "logs" {
-  count = var.data_collection_endpoint != null ? 1 : 0
+  count = var.should_deploy_dce ? 1 : 0
 
   name                    = "dcra-logs-${local.resource_name_suffix}"
   target_resource_id      = azurerm_kubernetes_cluster.main.id
@@ -97,7 +97,7 @@ resource "azurerm_monitor_data_collection_rule_association" "logs" {
 
 // Associate Prometheus metrics DCR with AKS
 resource "azurerm_monitor_data_collection_rule_association" "metrics" {
-  count = var.data_collection_endpoint != null && var.monitor_workspace != null ? 1 : 0
+  count = var.should_deploy_dce && var.should_deploy_monitor_workspace ? 1 : 0
 
   name                    = "dcra-metrics-${local.resource_name_suffix}"
   target_resource_id      = azurerm_kubernetes_cluster.main.id
@@ -110,7 +110,7 @@ resource "azurerm_monitor_data_collection_rule_association" "metrics" {
 
 // Required for Container Insights MSI authentication mode
 resource "azurerm_monitor_data_collection_rule_association" "dce" {
-  count = var.data_collection_endpoint != null ? 1 : 0
+  count = var.should_deploy_dce ? 1 : 0
 
   target_resource_id          = azurerm_kubernetes_cluster.main.id
   data_collection_endpoint_id = var.data_collection_endpoint.id

--- a/infrastructure/terraform/modules/sil/tests/aks-config.tftest.hcl
+++ b/infrastructure/terraform/modules/sil/tests/aks-config.tftest.hcl
@@ -8,8 +8,10 @@ mock_provider "tls" {}
 mock_provider "random" {}
 
 variables {
-  should_assign_cluster_admin    = false
-  should_enable_private_endpoint = false
+  should_assign_cluster_admin     = false
+  should_enable_private_endpoint  = false
+  should_deploy_dce               = false
+  should_deploy_monitor_workspace = false
 }
 
 run "setup" {

--- a/infrastructure/terraform/modules/sil/tests/conditionals.tftest.hcl
+++ b/infrastructure/terraform/modules/sil/tests/conditionals.tftest.hcl
@@ -8,7 +8,9 @@ mock_provider "tls" {}
 mock_provider "random" {}
 
 variables {
-  should_assign_cluster_admin = false
+  should_assign_cluster_admin     = false
+  should_deploy_dce               = false
+  should_deploy_monitor_workspace = false
 }
 
 run "setup" {
@@ -319,20 +321,22 @@ run "observability_with_dce" {
   command = plan
 
   variables {
-    resource_prefix                = run.setup.resource_prefix
-    environment                    = run.setup.environment
-    instance                       = run.setup.instance
-    location                       = run.setup.location
-    resource_group                 = run.setup.resource_group
-    virtual_network                = run.setup.virtual_network
-    subnets                        = run.setup.subnets
-    network_security_group         = run.setup.network_security_group
-    nat_gateway                    = run.setup.nat_gateway
-    log_analytics_workspace        = run.setup.log_analytics_workspace
-    container_registry             = run.setup.container_registry
-    data_collection_endpoint       = run.setup.data_collection_endpoint
-    monitor_workspace              = run.setup.monitor_workspace
-    should_enable_private_endpoint = false
+    resource_prefix                 = run.setup.resource_prefix
+    environment                     = run.setup.environment
+    instance                        = run.setup.instance
+    location                        = run.setup.location
+    resource_group                  = run.setup.resource_group
+    virtual_network                 = run.setup.virtual_network
+    subnets                         = run.setup.subnets
+    network_security_group          = run.setup.network_security_group
+    nat_gateway                     = run.setup.nat_gateway
+    log_analytics_workspace         = run.setup.log_analytics_workspace
+    container_registry              = run.setup.container_registry
+    data_collection_endpoint        = run.setup.data_collection_endpoint
+    monitor_workspace               = run.setup.monitor_workspace
+    should_deploy_dce               = true
+    should_deploy_monitor_workspace = true
+    should_enable_private_endpoint  = false
     aks_config = {
       system_node_pool_vm_size                    = "Standard_D8ds_v5"
       system_node_pool_node_count                 = 2
@@ -343,27 +347,27 @@ run "observability_with_dce" {
 
   assert {
     condition     = length(azurerm_monitor_data_collection_rule.logs) == 1
-    error_message = "Logs DCR should be created when DCE is provided"
+    error_message = "Logs DCR should be created when DCE deployment is enabled"
   }
 
   assert {
     condition     = length(azurerm_monitor_data_collection_rule.metrics) == 1
-    error_message = "Metrics DCR should be created when both DCE and monitor workspace are provided"
+    error_message = "Metrics DCR should be created when DCE and monitor workspace deployments are enabled"
   }
 
   assert {
     condition     = length(azurerm_monitor_data_collection_rule_association.logs) == 1
-    error_message = "Logs DCRA should be created when DCE is provided"
+    error_message = "Logs DCRA should be created when DCE deployment is enabled"
   }
 
   assert {
     condition     = length(azurerm_monitor_data_collection_rule_association.metrics) == 1
-    error_message = "Metrics DCRA should be created when both DCE and monitor workspace are provided"
+    error_message = "Metrics DCRA should be created when DCE and monitor workspace deployments are enabled"
   }
 
   assert {
     condition     = length(azurerm_monitor_data_collection_rule_association.dce) == 1
-    error_message = "DCE association should be created when DCE is provided"
+    error_message = "DCE association should be created when DCE deployment is enabled"
   }
 }
 
@@ -371,20 +375,22 @@ run "observability_without_dce" {
   command = plan
 
   variables {
-    resource_prefix                = run.setup.resource_prefix
-    environment                    = run.setup.environment
-    instance                       = run.setup.instance
-    location                       = run.setup.location
-    resource_group                 = run.setup.resource_group
-    virtual_network                = run.setup.virtual_network
-    subnets                        = run.setup.subnets
-    network_security_group         = run.setup.network_security_group
-    nat_gateway                    = run.setup.nat_gateway
-    log_analytics_workspace        = run.setup.log_analytics_workspace
-    container_registry             = run.setup.container_registry
-    data_collection_endpoint       = null
-    monitor_workspace              = null
-    should_enable_private_endpoint = false
+    resource_prefix                 = run.setup.resource_prefix
+    environment                     = run.setup.environment
+    instance                        = run.setup.instance
+    location                        = run.setup.location
+    resource_group                  = run.setup.resource_group
+    virtual_network                 = run.setup.virtual_network
+    subnets                         = run.setup.subnets
+    network_security_group          = run.setup.network_security_group
+    nat_gateway                     = run.setup.nat_gateway
+    log_analytics_workspace         = run.setup.log_analytics_workspace
+    container_registry              = run.setup.container_registry
+    data_collection_endpoint        = run.setup.data_collection_endpoint
+    monitor_workspace               = run.setup.monitor_workspace
+    should_deploy_dce               = false
+    should_deploy_monitor_workspace = true
+    should_enable_private_endpoint  = false
     aks_config = {
       system_node_pool_vm_size                    = "Standard_D8ds_v5"
       system_node_pool_node_count                 = 2
@@ -395,27 +401,27 @@ run "observability_without_dce" {
 
   assert {
     condition     = length(azurerm_monitor_data_collection_rule.logs) == 0
-    error_message = "Logs DCR should not be created when DCE is null"
+    error_message = "Logs DCR should not be created when DCE deployment is disabled"
   }
 
   assert {
     condition     = length(azurerm_monitor_data_collection_rule.metrics) == 0
-    error_message = "Metrics DCR should not be created when DCE is null"
+    error_message = "Metrics DCR should not be created when DCE deployment is disabled"
   }
 
   assert {
     condition     = length(azurerm_monitor_data_collection_rule_association.logs) == 0
-    error_message = "Logs DCRA should not be created when DCE is null"
+    error_message = "Logs DCRA should not be created when DCE deployment is disabled"
   }
 
   assert {
     condition     = length(azurerm_monitor_data_collection_rule_association.metrics) == 0
-    error_message = "Metrics DCRA should not be created when DCE is null"
+    error_message = "Metrics DCRA should not be created when DCE deployment is disabled"
   }
 
   assert {
     condition     = length(azurerm_monitor_data_collection_rule_association.dce) == 0
-    error_message = "DCE association should not be created when DCE is null"
+    error_message = "DCE association should not be created when DCE deployment is disabled"
   }
 }
 
@@ -427,20 +433,22 @@ run "metrics_with_dce_without_monitor" {
   command = plan
 
   variables {
-    resource_prefix                = run.setup.resource_prefix
-    environment                    = run.setup.environment
-    instance                       = run.setup.instance
-    location                       = run.setup.location
-    resource_group                 = run.setup.resource_group
-    virtual_network                = run.setup.virtual_network
-    subnets                        = run.setup.subnets
-    network_security_group         = run.setup.network_security_group
-    nat_gateway                    = run.setup.nat_gateway
-    log_analytics_workspace        = run.setup.log_analytics_workspace
-    container_registry             = run.setup.container_registry
-    data_collection_endpoint       = run.setup.data_collection_endpoint
-    monitor_workspace              = null
-    should_enable_private_endpoint = false
+    resource_prefix                 = run.setup.resource_prefix
+    environment                     = run.setup.environment
+    instance                        = run.setup.instance
+    location                        = run.setup.location
+    resource_group                  = run.setup.resource_group
+    virtual_network                 = run.setup.virtual_network
+    subnets                         = run.setup.subnets
+    network_security_group          = run.setup.network_security_group
+    nat_gateway                     = run.setup.nat_gateway
+    log_analytics_workspace         = run.setup.log_analytics_workspace
+    container_registry              = run.setup.container_registry
+    data_collection_endpoint        = run.setup.data_collection_endpoint
+    monitor_workspace               = run.setup.monitor_workspace
+    should_deploy_dce               = true
+    should_deploy_monitor_workspace = false
+    should_enable_private_endpoint  = false
     aks_config = {
       system_node_pool_vm_size                    = "Standard_D8ds_v5"
       system_node_pool_node_count                 = 2
@@ -451,17 +459,17 @@ run "metrics_with_dce_without_monitor" {
 
   assert {
     condition     = length(azurerm_monitor_data_collection_rule.logs) == 1
-    error_message = "Logs DCR should still be created when DCE is provided (monitor workspace not required)"
+    error_message = "Logs DCR should still be created when DCE deployment is enabled"
   }
 
   assert {
     condition     = length(azurerm_monitor_data_collection_rule.metrics) == 0
-    error_message = "Metrics DCR should not be created when monitor workspace is null"
+    error_message = "Metrics DCR should not be created when monitor workspace deployment is disabled"
   }
 
   assert {
     condition     = length(azurerm_monitor_data_collection_rule_association.metrics) == 0
-    error_message = "Metrics DCRA should not be created when monitor workspace is null"
+    error_message = "Metrics DCRA should not be created when monitor workspace deployment is disabled"
   }
 }
 
@@ -469,20 +477,22 @@ run "metrics_without_dce_with_monitor" {
   command = plan
 
   variables {
-    resource_prefix                = run.setup.resource_prefix
-    environment                    = run.setup.environment
-    instance                       = run.setup.instance
-    location                       = run.setup.location
-    resource_group                 = run.setup.resource_group
-    virtual_network                = run.setup.virtual_network
-    subnets                        = run.setup.subnets
-    network_security_group         = run.setup.network_security_group
-    nat_gateway                    = run.setup.nat_gateway
-    log_analytics_workspace        = run.setup.log_analytics_workspace
-    container_registry             = run.setup.container_registry
-    data_collection_endpoint       = null
-    monitor_workspace              = run.setup.monitor_workspace
-    should_enable_private_endpoint = false
+    resource_prefix                 = run.setup.resource_prefix
+    environment                     = run.setup.environment
+    instance                        = run.setup.instance
+    location                        = run.setup.location
+    resource_group                  = run.setup.resource_group
+    virtual_network                 = run.setup.virtual_network
+    subnets                         = run.setup.subnets
+    network_security_group          = run.setup.network_security_group
+    nat_gateway                     = run.setup.nat_gateway
+    log_analytics_workspace         = run.setup.log_analytics_workspace
+    container_registry              = run.setup.container_registry
+    data_collection_endpoint        = run.setup.data_collection_endpoint
+    monitor_workspace               = run.setup.monitor_workspace
+    should_deploy_dce               = false
+    should_deploy_monitor_workspace = true
+    should_enable_private_endpoint  = false
     aks_config = {
       system_node_pool_vm_size                    = "Standard_D8ds_v5"
       system_node_pool_node_count                 = 2
@@ -493,11 +503,11 @@ run "metrics_without_dce_with_monitor" {
 
   assert {
     condition     = length(azurerm_monitor_data_collection_rule.logs) == 0
-    error_message = "Logs DCR should not be created when DCE is null"
+    error_message = "Logs DCR should not be created when DCE deployment is disabled"
   }
 
   assert {
     condition     = length(azurerm_monitor_data_collection_rule.metrics) == 0
-    error_message = "Metrics DCR should not be created when DCE is null even if monitor workspace is provided"
+    error_message = "Metrics DCR should not be created when DCE deployment is disabled even if monitor workspace deployment is enabled"
   }
 }

--- a/infrastructure/terraform/modules/sil/tests/osmo.tftest.hcl
+++ b/infrastructure/terraform/modules/sil/tests/osmo.tftest.hcl
@@ -8,8 +8,10 @@ mock_provider "tls" {}
 mock_provider "random" {}
 
 variables {
-  should_assign_cluster_admin    = false
-  should_enable_private_endpoint = false
+  should_assign_cluster_admin     = false
+  should_enable_private_endpoint  = false
+  should_deploy_dce               = false
+  should_deploy_monitor_workspace = false
 }
 
 run "setup" {

--- a/infrastructure/terraform/modules/sil/tests/outputs.tftest.hcl
+++ b/infrastructure/terraform/modules/sil/tests/outputs.tftest.hcl
@@ -8,8 +8,10 @@ mock_provider "tls" {}
 mock_provider "random" {}
 
 variables {
-  should_assign_cluster_admin    = false
-  should_enable_private_endpoint = false
+  should_assign_cluster_admin     = false
+  should_enable_private_endpoint  = false
+  should_deploy_dce               = false
+  should_deploy_monitor_workspace = false
 }
 
 run "setup" {

--- a/infrastructure/terraform/modules/sil/variables.deps.tf
+++ b/infrastructure/terraform/modules/sil/variables.deps.tf
@@ -68,6 +68,18 @@ variable "data_collection_endpoint" {
   default     = null
 }
 
+variable "should_deploy_monitor_workspace" {
+  type        = bool
+  description = "Whether Azure Monitor Workspace is enabled for AKS observability"
+  default     = true
+}
+
+variable "should_deploy_dce" {
+  type        = bool
+  description = "Whether Data Collection Endpoint is enabled for AKS observability"
+  default     = true
+}
+
 variable "container_registry" {
   type = object({
     id           = string


### PR DESCRIPTION
## Description

Switch observability resource gating from apply-time dependency object checks to explicit plan-time feature flags.

This change passes `should_deploy_monitor_workspace` and `should_deploy_dce` into `module.sil`, then uses those booleans to control creation of AKS data collection rules and associations. That removes the invalid `count` expressions that depended on `module.platform` outputs only known after apply.

The PR also updates the operations guide so the observability feature-flag documentation matches the Terraform behavior:

- Container Insights is gated by `should_deploy_dce`
- Prometheus metrics rules require both `should_deploy_dce` and `should_deploy_monitor_workspace`

Closes #302

## Type of Change
<!-- Mark relevant options with [x] -->

- [x] 🐛 Bug fix (non-breaking change fixing an issue)
- [ ] ✨ New feature (non-breaking change adding functionality)
- [ ] 💥 Breaking change (fix or feature causing existing functionality to change)
- [x] 📚 Documentation update
- [x] 🏗️ Infrastructure change (Terraform/IaC)
- [ ] ♻️ Refactoring (no functional changes)

## Component(s) Affected
<!-- Mark all that apply -->

- [ ] `infrastructure/terraform/prerequisites/` - Azure subscription setup
- [x] `infrastructure/terraform/` - Terraform infrastructure
- [ ] `infrastructure/setup/` - OSMO control plane / Helm
- [ ] `workflows/` - Training and evaluation workflows
- [ ] `training/` - Training pipelines and scripts
- [x] `docs/` - Documentation

## Testing Performed
<!-- Describe testing. Check applicable items -->

- [ ] Terraform `plan` reviewed (no unexpected changes)
- [ ] Terraform `apply` tested in dev environment
- [ ] Training scripts tested locally with Isaac Sim
- [ ] OSMO workflow submitted successfully
- [ ] Smoke tests passed (`smoke_test_azure.py`)

Notes:
- PR description is based on the last commit contents. No additional Terraform validation results were available in the commit metadata, so testing items remain unchecked.

## Documentation Impact
<!-- Select one -->

- [ ] No documentation changes needed
- [x] Documentation updated in this PR
- [ ] Documentation issue filed

## Bug Fix Checklist

*Complete this section for bug fix PRs. Skip for other contribution types.*

- [x] Linked to issue being fixed
- [ ] Regression test included, OR
- [x] Justification for no regression test: This change fixes Terraform planning logic in infrastructure code. The repository guidance for this area relies on Terraform validation and environment applies rather than automated regression tests for provider planning behavior.

## Checklist

- [x] My code follows the [project conventions](.github/copilot-instructions.md)
- [x] Commit messages follow [conventional commit format](.github/instructions/commit-message.instructions.md)
- [x] I have performed a self-review
- [x] Documentation impact assessed above
- [ ] No new linting warnings introduced