### PR TITLE
build(build): split terraform test into dedicated workflow with codecov

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -203,7 +203,7 @@ Terraform validation is per-directory — each deployment directory has its own 
 * CI: `.github/workflows/terraform-validation.yml` reusable workflow runs `lint:tf:validate` with `soft-fail: true`
 * `npm run test:tf` — `terraform test` across all modules with `tests/` directories; uses `mock_provider` and `command = plan` — no Azure credentials required
 * Per-module: `cd infrastructure/terraform/modules/<name> && terraform init -backend=false && terraform test`
-* CI: `terraform-validation.yml` runs tests alongside fmt and validate checks
+* CI: `.github/workflows/terraform-tests.yml` reusable workflow runs `terraform test` independently from validation
 
 ### Shell Scripts
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -148,6 +148,17 @@ jobs:
     permissions:
       contents: read
 
+  # Terraform test execution with Codecov Test Analytics
+  terraform-tests:
+    name: Terraform Tests
+    uses: ./.github/workflows/terraform-tests.yml
+    with:
+      soft-fail: true
+      code-coverage: true
+    permissions:
+      contents: read
+      id-token: write
+
   # CodeQL security analysis
   codeql-analysis:
     name: CodeQL Analysis
@@ -176,6 +187,7 @@ jobs:
       - python-lint
       - terraform-lint
       - terraform-validation
+      - terraform-tests
       - codeql-analysis
     name: Release Please
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -168,6 +168,18 @@ jobs:
     permissions:
       contents: read
 
+  # Terraform test execution with Codecov Test Analytics
+  terraform-tests:
+    name: Terraform Tests
+    uses: ./.github/workflows/terraform-tests.yml
+    with:
+      soft-fail: true
+      changed-files-only: true
+      code-coverage: true
+    permissions:
+      contents: read
+      id-token: write
+
   # CodeQL security analysis
   codeql-analysis:
     name: CodeQL Analysis

--- a/.github/workflows/terraform-tests.yml
+++ b/.github/workflows/terraform-tests.yml
@@ -1,0 +1,149 @@
+name: Terraform Tests
+
+on:
+  workflow_call:
+    inputs:
+      soft-fail:
+        description: 'Whether to continue on Terraform test failures'
+        required: false
+        type: boolean
+        default: false
+      changed-files-only:
+        description: 'Only test modules with changed Terraform files'
+        required: false
+        type: boolean
+        default: false
+      code-coverage:
+        description: 'Whether to upload test results to Codecov'
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: pwsh
+
+jobs:
+  terraform-tests:
+    name: Terraform Tests
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          fetch-depth: ${{ inputs.changed-files-only && '0' || '1' }}
+
+      - name: Create logs directory
+        run: New-Item -ItemType Directory -Force -Path logs | Out-Null
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3.1.2
+        with:
+          terraform_wrapper: false
+
+      - name: Run Terraform Tests
+        id: terraform-tests
+        continue-on-error: ${{ inputs.soft-fail }}
+        run: |
+          $params = @{}
+          if ('${{ inputs.changed-files-only }}' -eq 'true') {
+            $params['ChangedFilesOnly'] = $true
+          }
+          shared/ci/linting/Invoke-TerraformTest.ps1 @params
+
+      - name: Convert test results to JUnit XML
+        if: always() && steps.terraform-tests.outcome != 'skipped'
+        run: |
+          $jsonPath = 'logs/terraform-test-results.json'
+          $xmlPath = 'logs/terraform-test-results.xml'
+
+          if (-not (Test-Path $jsonPath)) {
+            Write-Warning "Test results not found at $jsonPath"
+            return
+          }
+
+          $results = Get-Content $jsonPath -Raw | ConvertFrom-Json
+          $totalTests = $results.summary.total_passed + $results.summary.total_failed + $results.summary.total_errors
+
+          $xml = [System.Xml.XmlDocument]::new()
+          $declaration = $xml.CreateXmlDeclaration('1.0', 'UTF-8', $null)
+          $xml.AppendChild($declaration) | Out-Null
+
+          $testsuites = $xml.CreateElement('testsuites')
+          $testsuites.SetAttribute('name', 'Terraform Tests')
+          $testsuites.SetAttribute('tests', $totalTests)
+          $testsuites.SetAttribute('failures', $results.summary.total_failed)
+          $testsuites.SetAttribute('errors', $results.summary.total_errors)
+          $xml.AppendChild($testsuites) | Out-Null
+
+          foreach ($module in $results.modules) {
+            $moduleTests = $module.passed + $module.failed + $module.errors
+            $testsuite = $xml.CreateElement('testsuite')
+            $testsuite.SetAttribute('name', $module.path)
+            $testsuite.SetAttribute('tests', $moduleTests)
+            $testsuite.SetAttribute('failures', $module.failed)
+            $testsuite.SetAttribute('errors', $module.errors)
+            $testsuites.AppendChild($testsuite) | Out-Null
+
+            # Emit one testcase per passed test
+            for ($i = 1; $i -le $module.passed; $i++) {
+              $testcase = $xml.CreateElement('testcase')
+              $testcase.SetAttribute('classname', $module.path)
+              $testcase.SetAttribute('name', "test_$i")
+              $testsuite.AppendChild($testcase) | Out-Null
+            }
+
+            # Emit one testcase per failed test
+            for ($i = 1; $i -le $module.failed; $i++) {
+              $testcase = $xml.CreateElement('testcase')
+              $testcase.SetAttribute('classname', $module.path)
+              $testcase.SetAttribute('name', "failed_$i")
+              $failure = $xml.CreateElement('failure')
+              $failure.SetAttribute('message', "Test failed in $($module.path)")
+              $testcase.AppendChild($failure) | Out-Null
+              $testsuite.AppendChild($testcase) | Out-Null
+            }
+
+            # Emit one testcase per errored test
+            for ($i = 1; $i -le $module.errors; $i++) {
+              $testcase = $xml.CreateElement('testcase')
+              $testcase.SetAttribute('classname', $module.path)
+              $testcase.SetAttribute('name', "error_$i")
+              $errorEl = $xml.CreateElement('error')
+              $errorEl.SetAttribute('message', "Test errored in $($module.path)")
+              $testcase.AppendChild($errorEl) | Out-Null
+              $testsuite.AppendChild($testcase) | Out-Null
+            }
+          }
+
+          $xml.Save($xmlPath)
+          Write-Host "JUnit XML written to $xmlPath"
+
+      - name: Upload Terraform test results
+        if: always() && steps.terraform-tests.outcome != 'skipped'
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        with:
+          name: terraform-test-results
+          path: |
+            logs/terraform-test-results.json
+            logs/terraform-test-results.xml
+          retention-days: 30
+
+      - name: Upload to Codecov
+        if: inputs.code-coverage && always() && steps.terraform-tests.outcome != 'skipped'
+        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
+        with:
+          use_oidc: true
+          report-type: test_results
+          files: logs/terraform-test-results.xml
+          flags: terraform
+          name: terraform-test-results
+          verbose: true
+          fail_ci_if_error: false

--- a/.github/workflows/terraform-validation.yml
+++ b/.github/workflows/terraform-validation.yml
@@ -51,21 +51,10 @@ jobs:
           }
           shared/ci/linting/Invoke-TerraformValidation.ps1 @params
 
-      - name: Run Terraform Tests
-        continue-on-error: ${{ inputs.soft-fail }}
-        run: |
-          $params = @{}
-          if ('${{ inputs.changed-files-only }}' -eq 'true') {
-            $params['ChangedFilesOnly'] = $true
-          }
-          pwsh -File shared/ci/linting/Invoke-TerraformTest.ps1 @params
-
       - name: Upload Terraform results
         if: always()
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
-          name: terraform-results
-          path: |
-            logs/terraform-validation-results.json
-            logs/terraform-test-results.json
+          name: terraform-validation-results
+          path: logs/terraform-validation-results.json
           retention-days: 30


### PR DESCRIPTION
Separated Terraform test execution from the combined validation workflow into its own reusable workflow, *terraform-tests.yml*. The new workflow runs `terraform test` via *Invoke-TerraformTest.ps1*, converts results to JUnit XML, and uploads them to **Codecov Test Analytics** using OIDC authentication. Both *main.yml* and *pr-validation.yml* now call the validation and test workflows in parallel.

## Description

Extracted Terraform test execution from the combined *terraform-validation.yml* workflow into a dedicated *terraform-tests.yml* reusable workflow. Validation and testing now run as independent parallel jobs in both the main and PR pipelines, improving separation of concerns and enabling focused test reporting.

### Workflow Structure

- Added *terraform-tests.yml* as a new reusable workflow accepting `soft-fail`, `changed-files-only`, and `code-coverage` boolean inputs. The workflow runs **Invoke-TerraformTest.ps1**, converts JSON results to JUnit XML, and uploads test artifacts.
- Integrated the new workflow into *main.yml* and *pr-validation.yml* as a parallel `terraform-tests` job alongside the existing `terraform-validation` job. Added the job to the `release-please` dependency chain in *main.yml*.
- Cleaned up *terraform-validation.yml* by removing the embedded test step and narrowing its artifact scope to validation-only results. Renamed the artifact from `terraform-results` to `terraform-validation-results`.

### Codecov Test Analytics

- Configured **Codecov** upload with `report-type: test_results` and `flags: terraform`, gated by the `code-coverage` input.
- Authentication uses **OIDC** (`use_oidc: true` with `id-token: write` permission) instead of stored secrets, following the repository's tokenless authentication pattern.
- Upload is non-blocking (`fail_ci_if_error: false`) to prevent Codecov outages from breaking the pipeline.

### JUnit XML Conversion

- Implemented inline PowerShell conversion from the `Invoke-TerraformTest.ps1` JSON output schema to JUnit XML format. The conversion maps `$results.summary` totals and `$results.modules` entries to `<testsuite>` and `<testcase>` elements.

### Documentation

- Updated the CI reference in *copilot-instructions.md* to reflect the new workflow structure.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change fixing an issue)
- [ ] ✨ New feature (non-breaking change adding functionality)
- [ ] 💥 Breaking change (fix or feature causing existing functionality to change)
- [ ] 📚 Documentation update
- [x] 🏗️ Infrastructure change (Terraform/IaC)
- [ ] ♻️ Refactoring (no functional changes)

## Component(s) Affected

- [ ] `infrastructure/terraform/prerequisites/` - Azure subscription setup
- [ ] `infrastructure/terraform/` - Terraform infrastructure
- [ ] `infrastructure/setup/` - OSMO control plane / Helm
- [ ] `workflows/` - Training and evaluation workflows
- [ ] `training/` - Training pipelines and scripts
- [ ] `docs/` - Documentation

## Testing Performed

- [ ] Terraform `plan` reviewed (no unexpected changes)
- [ ] Terraform `apply` tested in dev environment
- [ ] Training scripts tested locally with Isaac Sim
- [ ] OSMO workflow submitted successfully
- [ ] Smoke tests passed (`smoke_test_azure.py`)

## Documentation Impact

- [x] Documentation updated in this PR

## Bug Fix Checklist

*Complete this section for bug fix PRs. Skip for other contribution types.*

- [ ] Linked to issue being fixed
- [ ] Regression test included, OR
- [ ] Justification for no regression test:

## Checklist

- [x] My code follows the [project conventions](copilot-instructions.md)
- [x] Commit messages follow [conventional commit format](instructions/commit-message.instructions.md)
- [x] I have performed a self-review
- [x] Documentation impact assessed above
- [x] No new linting warnings introduced