### PR TITLE
fix(scripts): support OSMO control-plane deploys with in-cluster Redis

### DIFF
--- a/infrastructure/setup/03-deploy-osmo-control-plane.sh
+++ b/infrastructure/setup/03-deploy-osmo-control-plane.sh
@@ -60,6 +60,7 @@ use_local_osmo=false
 config_preview=false
 chart_version_set=false
 image_version_set=false
+redis_storage_class=""
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -206,7 +207,7 @@ fi
 
 if [[ -n "$osmo_identity_client_id" ]]; then
   info "Applying SecretProviderClass for Azure Key Vault CSI driver..."
-  apply_secret_provider_class "$NS_OSMO_CONTROL_PLANE" "$keyvault" "$osmo_identity_client_id" "$tenant_id"
+  apply_secret_provider_class "$NS_OSMO_CONTROL_PLANE" "$keyvault" "$osmo_identity_client_id" "$tenant_id" "$([[ "$use_incluster_redis" == "false" ]] && echo true || echo false)"
 else
   info "Workload identity not configured; retrieving secrets from Key Vault..."
   pg_password=$(az keyvault secret show --vault-name "$keyvault" --name "psql-admin-password" --query value -o tsv)
@@ -225,6 +226,15 @@ else
       --from-literal=redis-password="$redis_key" \
       --dry-run=client -o yaml | kubectl apply -f -
   fi
+fi
+
+if [[ "$use_incluster_redis" == "true" ]]; then
+  redis_storage_class=$(detect_default_storage_class)
+  info "Creating Redis secret for in-cluster Redis..."
+  kubectl create secret generic "$SECRET_REDIS" \
+    --namespace="$NS_OSMO_CONTROL_PLANE" \
+    --from-literal=redis-password="" \
+    --dry-run=client -o yaml | kubectl apply -f -
 fi
 
 # Apply internal LB ingress if present
@@ -277,7 +287,15 @@ base_helm_args=(
 # Deploy service
 info "Deploying osmo/service..."
 helm_args=("${base_helm_args[@]}" -f "$service_values" --set "services.postgres.serviceName=$pg_fqdn" --set "services.postgres.user=$pg_user")
-[[ "$use_incluster_redis" == "false" ]] && helm_args+=(--set "services.redis.serviceName=$redis_hostname" --set "services.redis.port=$redis_port")
+if [[ "$use_incluster_redis" == "true" ]]; then
+  helm_args+=(
+    --set "services.redis.enabled=true"
+    --set "services.redis.tlsEnabled=false"
+    --set-string "services.redis.storageClassName=$redis_storage_class"
+  )
+else
+  helm_args+=(--set "services.redis.serviceName=$redis_hostname" --set "services.redis.port=$redis_port")
+fi
 [[ -n "$osmo_identity_client_id" ]] && helm_args+=(-f "$service_identity_values" --set "serviceAccount.annotations.azure\.workload\.identity/client-id=$osmo_identity_client_id")
 
 if [[ "$use_acr" == "true" ]]; then

--- a/infrastructure/setup/03-deploy-osmo-control-plane.sh
+++ b/infrastructure/setup/03-deploy-osmo-control-plane.sh
@@ -27,6 +27,7 @@ OPTIONS:
     --use-acr               Pull images from ACR deployed by 001-iac
     --acr-name NAME         Pull images from specified ACR
     --use-incluster-redis   Use in-cluster Redis instead of Azure Managed Redis
+                            (unauthenticated, non-TLS; suitable for development)
     --skip-mek              Skip MEK configuration
     --force-mek             Replace existing MEK (data loss warning)
     --mek-config-file PATH  Use existing MEK config file
@@ -60,7 +61,7 @@ use_local_osmo=false
 config_preview=false
 chart_version_set=false
 image_version_set=false
-redis_storage_class=""
+redis_storage_class="" # Will be resolved if --use-incluster-redis is set using detect_default_storage_class (requires cluster connection)
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -207,7 +208,9 @@ fi
 
 if [[ -n "$osmo_identity_client_id" ]]; then
   info "Applying SecretProviderClass for Azure Key Vault CSI driver..."
-  apply_secret_provider_class "$NS_OSMO_CONTROL_PLANE" "$keyvault" "$osmo_identity_client_id" "$tenant_id" "$([[ "$use_incluster_redis" == "false" ]] && echo true || echo false)"
+  include_redis_secret=true
+  [[ "$use_incluster_redis" == "true" ]] && include_redis_secret=false
+  apply_secret_provider_class "$NS_OSMO_CONTROL_PLANE" "$keyvault" "$osmo_identity_client_id" "$tenant_id" "$include_redis_secret"
 else
   info "Workload identity not configured; retrieving secrets from Key Vault..."
   pg_password=$(az keyvault secret show --vault-name "$keyvault" --name "psql-admin-password" --query value -o tsv)
@@ -230,6 +233,7 @@ fi
 
 if [[ "$use_incluster_redis" == "true" ]]; then
   redis_storage_class=$(detect_default_storage_class)
+  warn "In-cluster Redis runs without TLS or authentication. Use it only for development environments."
   info "Creating Redis secret for in-cluster Redis..."
   kubectl create secret generic "$SECRET_REDIS" \
     --namespace="$NS_OSMO_CONTROL_PLANE" \

--- a/infrastructure/setup/manifests/aks-secret-provider-class-external-redis.yaml
+++ b/infrastructure/setup/manifests/aks-secret-provider-class-external-redis.yaml
@@ -1,8 +1,8 @@
 # SecretProviderClass for Azure Key Vault secrets sync via CSI driver
-# Syncs psql-admin-password from Key Vault to a Kubernetes secret.
+# Syncs psql-admin-password and redis-primary-key from Key Vault to Kubernetes secrets.
 #
 # Deployed by: 03-deploy-osmo-control-plane.sh (via common.sh apply_secret_provider_class)
-# Creates: db-secret (db-password key)
+# Creates: db-secret (db-password key), redis-secret (redis-password key)
 #
 # Secrets are created when pods mount the CSI volume (configured in osmo-control-plane-identity.yaml).
 #
@@ -26,9 +26,17 @@ spec:
         - |
           objectName: psql-admin-password
           objectType: secret
+        - |
+          objectName: redis-primary-key
+          objectType: secret
   secretObjects:
     - secretName: db-secret
       type: Opaque
       data:
         - objectName: psql-admin-password
           key: db-password
+    - secretName: redis-secret
+      type: Opaque
+      data:
+        - objectName: redis-primary-key
+          key: redis-password

--- a/shared/lib/common.sh
+++ b/shared/lib/common.sh
@@ -248,13 +248,21 @@ osmo_login_and_setup() {
   local service_url="${1:?service URL required}"
   local username="${2:-guest}"
   local roles="${3:-osmo-backend}"
+  local lookup_output=""
+  local lookup_status=0
+
   info "Logging into OSMO at ${service_url}..."
   osmo login "${service_url}/" --method dev --username "$username"
   info "Ensuring dev user '$username' exists with $roles role..."
-  if ! osmo user get "$username" &>/dev/null; then
-    osmo user create "$username" --roles "$roles" >/dev/null 2>&1 || warn "OSMO user management endpoint unavailable; skipping dev user setup"
+  lookup_output=$(osmo user get "$username" 2>&1) || lookup_status=$?
+
+  if [[ "$lookup_status" -eq 0 ]]; then
+    osmo user update "$username" --add-roles "$roles" >/dev/null || warn "Unable to update OSMO dev user roles; continuing"
+  elif [[ "$lookup_output" == *"404"* || "$lookup_output" == *"not found"* ]]; then
+    osmo user create "$username" --roles "$roles" >/dev/null || warn "OSMO user management endpoint unavailable; skipping dev user setup"
   else
-    osmo user update "$username" --add-roles "$roles" >/dev/null 2>&1 || warn "Unable to update OSMO dev user roles; continuing"
+    printf '%s\n' "$lookup_output" >&2
+    warn "Unable to query OSMO dev user '$username'; skipping dev user setup"
   fi
 }
 
@@ -268,6 +276,7 @@ apply_secret_provider_class() {
   local include_redis_secret="${5:-true}"
 
   local manifest_dir
+  # BASH_SOURCE preserves the symlinked setup/lib path, so ../manifests resolves correctly.
   manifest_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/manifests"
   local manifest_name="aks-secret-provider-class.yaml"
 

--- a/shared/lib/common.sh
+++ b/shared/lib/common.sh
@@ -163,6 +163,19 @@ detect_service_url() {
   echo "$url"
 }
 
+detect_default_storage_class() {
+  local storage_class
+
+  storage_class=$(kubectl get storageclass -o jsonpath='{range .items[?(@.metadata.annotations.storageclass\.kubernetes\.io/is-default-class=="true")]}{.metadata.name}{"\n"}{end}' 2>/dev/null | head -n 1)
+
+  if [[ -z "$storage_class" ]]; then
+    storage_class=$(kubectl get storageclass default -o jsonpath='{.metadata.name}' 2>/dev/null || true)
+  fi
+
+  [[ -n "$storage_class" ]] || fatal "No default StorageClass detected for in-cluster Redis"
+  echo "$storage_class"
+}
+
 # Print section header
 section() {
   echo
@@ -239,22 +252,26 @@ osmo_login_and_setup() {
   osmo login "${service_url}/" --method dev --username "$username"
   info "Ensuring dev user '$username' exists with $roles role..."
   if ! osmo user get "$username" &>/dev/null; then
-    osmo user create "$username" --roles "$roles"
+    osmo user create "$username" --roles "$roles" >/dev/null 2>&1 || warn "OSMO user management endpoint unavailable; skipping dev user setup"
   else
-    osmo user update "$username" --add-roles "$roles"
+    osmo user update "$username" --add-roles "$roles" >/dev/null 2>&1 || warn "Unable to update OSMO dev user roles; continuing"
   fi
 }
 
 # Apply SecretProviderClass for Azure Key Vault secrets sync
-# Usage: apply_secret_provider_class <namespace> <keyvault> <client_id> <tenant_id>
+# Usage: apply_secret_provider_class <namespace> <keyvault> <client_id> <tenant_id> [include_redis_secret]
 apply_secret_provider_class() {
   local namespace="${1:?namespace required}"
   local keyvault="${2:?keyvault name required}"
   local client_id="${3:?client_id required}"
   local tenant_id="${4:?tenant_id required}"
+  local include_redis_secret="${5:-true}"
 
   local manifest_dir
-  manifest_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)/infrastructure/setup/manifests"
+  manifest_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/manifests"
+  local manifest_name="aks-secret-provider-class.yaml"
+
+  [[ "$include_redis_secret" == "true" ]] && manifest_name="aks-secret-provider-class-external-redis.yaml"
 
   export NAMESPACE="$namespace"
   export KEY_VAULT_NAME="$keyvault"
@@ -262,5 +279,5 @@ apply_secret_provider_class() {
   export TENANT_ID="$tenant_id"
 
   info "Applying SecretProviderClass to namespace $namespace..."
-  envsubst < "$manifest_dir/aks-secret-provider-class.yaml" | kubectl apply -f -
+  envsubst < "$manifest_dir/$manifest_name" | kubectl apply -f -
 }


### PR DESCRIPTION
## Description

Fix the OSMO control-plane setup path so `./03-deploy-osmo-control-plane.sh --use-incluster-redis` works when Terraform is applied with managed Redis disabled.

This change:

- fixes the shared manifest path resolution for the Key Vault SecretProviderClass helper
- splits SecretProviderClass rendering so managed-Redis secrets are only requested when the deployment is actually using external Redis
- creates the `redis-secret` object expected by the `osmo/service` chart in the in-cluster Redis path
- detects a default Kubernetes `StorageClass` and passes it to the chart so the Redis PVC binds instead of staying pending
- disables Redis TLS for the in-cluster Redis chart deployment to match the chart’s bundled Redis container
- makes the dev-user bootstrap step best-effort when the OSMO user-management endpoint returns `404`, while still requiring a successful `osmo login` and applying the service configuration

This PR is intentionally scoped to deployment automation and setup manifests. It does not change Terraform resource provisioning or the upstream OSMO Helm chart.

Validation performed:

- `bash -n infrastructure/setup/03-deploy-osmo-control-plane.sh shared/lib/common.sh`
- rendered `osmo/service` locally with sanitized values to verify `services.redis.storageClassName`, `services.redis.tlsEnabled`, and `redis-secret` handling
- re-ran the sanitized deployment flow:

```bash
cd infrastructure/terraform
terraform init
terraform apply -var-file=<sanitized>.tfvars

cd ../setup
./03-deploy-osmo-control-plane.sh --use-incluster-redis
kubectl get pods -n osmo-control-plane
helm list -n osmo-control-plane
```

- confirmed `service`, `router`, and `ui` Helm releases reached `deployed`
- confirmed `osmo-agent`, `osmo-delayed-job-monitor`, `osmo-logger`, `osmo-router`, `osmo-service`, `osmo-ui`, `osmo-worker`, and `redis` were `Running`

Side-effect review:

- `shared/lib/common.sh` is shared through symlinks into both `infrastructure/setup` and `data-management/setup`
- the new SecretProviderClass argument only affects the OSMO control-plane deploy caller
- `osmo_login_and_setup` is also used by the OSMO backend deploy script; the change only converts optional dev-user setup into a warning when the endpoint is unavailable
- the uninstall script already cleans up `redis-secret`, so the new in-cluster secret does not add cleanup drift

Closes #316 

## Type Of Change

- [x] 🐛 Bug fix (non-breaking change fixing an issue)
- [ ] ✨ New feature (non-breaking change adding functionality)
- [ ] 💥 Breaking change (fix or feature causing existing functionality to change)
- [ ] 📚 Documentation update
- [ ] 🏗️ Infrastructure change (Terraform/IaC)
- [x] ♻️ Refactoring (no functional changes outside the deploy fix)

## Component(s) Affected

- [ ] `infrastructure/terraform/prerequisites/` - Azure subscription setup
- [ ] `infrastructure/terraform/` - Terraform infrastructure
- [x] `infrastructure/setup/` - OSMO control plane / Helm
- [ ] `workflows/` - Training and evaluation workflows
- [ ] `training/` - Training pipelines and scripts
- [ ] `docs/` - Documentation

## Testing Performed

- [ ] Terraform `plan` reviewed (no unexpected changes)
- [x] Terraform `apply` tested in a sanitized dev configuration
- [ ] Training scripts tested locally with Isaac Sim
- [ ] OSMO workflow submitted successfully
- [ ] Smoke tests passed (`smoke_test_azure.py`)

## Documentation Impact

- [x] No documentation changes needed
- [ ] Documentation updated in this PR
- [ ] Documentation issue filed

## Bug Fix Checklist

- [ ] Linked to issue being fixed
- [ ] Regression test included, OR
- [x] Justification for no regression test: this repository’s deploy automation is validated through script checks, chart rendering, and live environment deploy verification rather than an automated integration test for AKS + Helm + workload identity + OSMO.

## Checklist

- [x] My code follows the project conventions
- [ ] Commit messages follow conventional commit format
- [x] I have performed a self-review
- [x] Documentation impact assessed above
- [x] No new linting warnings introduced that are attributable to this change