### PR TITLE
chore(build): add Go toolchain devcontainer feature and Dependabot gomod

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,6 +14,7 @@
 		},
 		"ghcr.io/devcontainers/features/github-cli:1": {},
 		"ghcr.io/devcontainers/features/node:1": {},
+		"ghcr.io/devcontainers/features/go:1": {},
 		"ghcr.io/devcontainers/features/terraform:1": {
 			"installTerraformDocs": true
 		},

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -199,3 +199,17 @@ updates:
     commit-message:
       prefix: "chore"
       include: "scope"
+
+  # Go module dependencies for Terraform e2e tests
+  - package-ecosystem: "gomod"
+    directory: "/infrastructure/terraform/e2e"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "infrastructure"
+    commit-message:
+      prefix: "chore"
+      include: "scope"


### PR DESCRIPTION
## Description

Adds Go toolchain support to the development container and configures Dependabot to track Go module dependencies for the Terraform end-to-end test suite.

Closes #329, #330

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change fixing an issue)
- [ ] ✨ New feature (non-breaking change adding functionality)
- [ ] 💥 Breaking change (fix or feature causing existing functionality to change)
- [ ] 📚 Documentation update
- [x] 🏗️ Infrastructure change (Terraform/IaC)
- [ ] ♻️ Refactoring (no functional changes)

## Component(s) Affected

- [ ] `infrastructure/terraform/prerequisites/` - Azure subscription setup
- [ ] `infrastructure/terraform/` - Terraform infrastructure
- [ ] `infrastructure/setup/` - OSMO control plane / Helm
- [ ] `workflows/` - Training and evaluation workflows
- [ ] `training/` - Training pipelines and scripts
- [ ] `docs/` - Documentation

<!-- Changes affect .devcontainer/ and .github/ which are not listed above -->

## Testing Performed

- [ ] Terraform `plan` reviewed (no unexpected changes)
- [ ] Terraform `apply` tested in dev environment
- [ ] Training scripts tested locally with Isaac Sim
- [ ] OSMO workflow submitted successfully
- [ ] Smoke tests passed (`smoke_test_azure.py`)

<!-- No automated tests apply: devcontainer feature and Dependabot config require rebuild/trigger to validate -->

## Documentation Impact

- [x] No documentation changes needed

> Note: documentation changes are part of a future issue (#335)

## Bug Fix Checklist

*Complete this section for bug fix PRs. Skip for other contribution types.*

- [ ] Linked to issue being fixed
- [ ] Regression test included, OR
- [ ] Justification for no regression test:

## Checklist

- [x] My code follows the [project conventions](copilot-instructions.md)
- [x] Commit messages follow [conventional commit format](instructions/commit-message.instructions.md)
- [x] I have performed a self-review
- [x] Documentation impact assessed above
- [x] No new linting warnings introduced
