### PR TITLE
feat(build): add terraform-docs freshness check CI workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -151,6 +151,15 @@ jobs:
     permissions:
       contents: read
 
+  # Terraform docs freshness check
+  terraform-docs-check:
+    name: Terraform Docs Check
+    uses: ./.github/workflows/terraform-docs-check.yml
+    with:
+      break-build: true
+    permissions:
+      contents: read
+
   # Terraform test execution with Codecov Test Analytics
   terraform-tests:
     name: Terraform Tests
@@ -211,6 +220,7 @@ jobs:
       - terraform-lint
       - terraform-validation
       - terraform-tests
+      - terraform-docs-check
       - go-lint
       - go-tests
       - codeql-analysis

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -184,6 +184,15 @@ jobs:
       contents: read
       id-token: write
 
+  # Terraform docs freshness check
+  terraform-docs-check:
+    name: Terraform Docs Check
+    uses: ./.github/workflows/terraform-docs-check.yml
+    with:
+      break-build: true
+    permissions:
+      contents: read
+
   # Go linting using golangci-lint
   go-lint:
     name: Go Lint

--- a/.github/workflows/terraform-docs-check.yml
+++ b/.github/workflows/terraform-docs-check.yml
@@ -1,0 +1,57 @@
+name: Terraform Docs Check
+
+on:
+  workflow_call:
+    inputs:
+      terraform-docs-version:
+        description: 'Version of terraform-docs to install'
+        required: false
+        type: string
+        default: 'v0.21.0'
+      break-build:
+        description: 'Whether to fail the workflow when documentation is out of date'
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: pwsh
+
+jobs:
+  terraform-docs-check:
+    name: Terraform Docs Freshness
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
+        with:
+          node-version: 20
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Install terraform-docs
+        shell: bash
+        run: |
+          version="${{ inputs.terraform-docs-version }}"
+          version="${version#v}"
+          curl -sSLo /tmp/terraform-docs.tar.gz \
+            "https://github.com/terraform-docs/terraform-docs/releases/download/v${version}/terraform-docs-v${version}-linux-amd64.tar.gz"
+          tar -xzf /tmp/terraform-docs.tar.gz -C /tmp terraform-docs
+          sudo install /tmp/terraform-docs /usr/local/bin/terraform-docs
+          terraform-docs --version
+
+      - name: Check terraform-docs freshness
+        continue-on-error: ${{ !inputs.break-build }}
+        run: scripts/Update-TerraformDocs.ps1 -Check


### PR DESCRIPTION
# Pull Request

## Description

Add a reusable CI workflow that verifies terraform-docs output is fresh, and wire it into both CI orchestrators so PRs and main-branch pushes fail when Terraform documentation drifts from source.

- Create `.github/workflows/terraform-docs-check.yml` as a `workflow_call` workflow with parameterized `terraform-docs-version` (default `v0.21.0`) and `break-build` inputs
- Wire into `main.yml` and `pr-validation.yml` orchestrators
- Fail build when generated docs don't match source via `Update-TerraformDocs.ps1 -Check`

Closes #327

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change fixing an issue)
- [x] ✨ New feature (non-breaking change adding functionality)
- [ ] 💥 Breaking change (fix or feature causing existing functionality to change)
- [ ] 📚 Documentation update
- [x] 🏗️ Infrastructure change (Terraform/IaC)
- [ ] ♻️ Refactoring (no functional changes)

## Component(s) Affected

- [ ] `infrastructure/terraform/prerequisites/` - Azure subscription setup
- [ ] `infrastructure/terraform/` - Terraform infrastructure
- [ ] `infrastructure/setup/` - OSMO control plane / Helm
- [ ] `workflows/` - Training and evaluation workflows
- [ ] `training/` - Training pipelines and scripts
- [ ] `docs/` - Documentation

## Testing Performed

- [x] `npm run lint:yaml` — actionlint 0 issues across all workflows
- [x] YAML lint validated on both new and modified files

## Documentation Impact

- [x] No documentation changes needed
- [ ] Documentation updated in this PR
- [ ] Documentation issue filed

## Checklist

- [x] My code follows the [project conventions](copilot-instructions.md)
- [x] Commit messages follow [conventional commit format](instructions/commit-message.instructions.md)
- [x] I have performed a self-review
- [x] Documentation impact assessed above
- [x] No new linting warnings introduced