### PR TITLE
fix(docs): correct quickstart variables, paths, namespaces, and add missing steps

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -155,16 +155,16 @@ For Terraform and shell script validation, see the [Prerequisites](docs/contribu
 
 All CI linters enforce warnings-as-errors. PRs that introduce new warnings will not merge.
 
-| Linter               | Enforcement       | Configuration                                 |
-|----------------------|-------------------|-----------------------------------------------|
-| Markdown (lint:md)   | Errors block      | .markdownlint-cli2.jsonc                      |
+| Linter               | Enforcement       | Configuration                               |
+|----------------------|-------------------|---------------------------------------------|
+| Markdown (lint:md)   | Errors block      | .markdownlint-cli2.jsonc                    |
 | PowerShell (lint:ps) | Errors + warnings | scripts/linting/Invoke-PSScriptAnalyzer.ps1 |
-| YAML (lint:yaml)     | Errors + warnings | .yamllint.yml                                 |
-| Terraform (lint:tf)  | Errors block      | .tflint.hcl                                   |
-| Go (lint:go)         | Errors block      | .golangci.yml                                 |
-| ShellCheck (lint:sh) | Warnings + errors | .shellcheckrc                                 |
-| Python (lint:py)     | Errors block      | pyproject.toml [tool.ruff]                    |
-| Link check           | Errors block      | .markdownlint-cli2.jsonc                      |
+| YAML (lint:yaml)     | Errors + warnings | .yamllint.yml                               |
+| Terraform (lint:tf)  | Errors block      | .tflint.hcl                                 |
+| Go (lint:go)         | Errors block      | .golangci.yml                               |
+| ShellCheck (lint:sh) | Warnings + errors | .shellcheckrc                               |
+| Python (lint:py)     | Errors block      | pyproject.toml [tool.ruff]                  |
+| Link check           | Errors block      | .markdownlint-cli2.jsonc                    |
 
 To suppress a specific warning locally, use the linter's inline suppression syntax. Do not change CI configuration to suppress warnings globally without team discussion.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -44,10 +44,10 @@ Documentation spans the full lifecycle — from provisioning Azure infrastructur
 
 Standalone guides available now. These cover common tasks and will move into their respective topic sections as the documentation structure expands.
 
-| Guide                                                                              | Description                                                                                                         |
-|------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------|
-| [MLflow Integration](training/mlflow-integration.md)                               | Configuring MLflow experiment tracking for SKRL training agents with automatic metric logging to Azure ML           |
-| [Security Guide](operations/security-guide.md)                                     | Security configuration inventory, deployment responsibilities, and hardening checklist for robotics workloads       |
+| Guide                                                | Description                                                                                                   |
+|------------------------------------------------------|---------------------------------------------------------------------------------------------------------------|
+| [MLflow Integration](training/mlflow-integration.md) | Configuring MLflow experiment tracking for SKRL training agents with automatic metric logging to Azure ML     |
+| [Security Guide](operations/security-guide.md)       | Security configuration inventory, deployment responsibilities, and hardening checklist for robotics workloads |
 
 ## 🚀 Next Steps
 

--- a/docs/cloud/blob-storage-structure.md
+++ b/docs/cloud/blob-storage-structure.md
@@ -4,10 +4,10 @@ Storage architecture for robotics data across two Azure Storage accounts: an ML 
 
 ## Storage Accounts
 
-| Account                  | Naming Pattern                                | Type                       | Purpose                                      | Terraform Variable                |
-|--------------------------|-----------------------------------------------|----------------------------|----------------------------------------------|-----------------------------------|
-| ML Workspace Storage     | `st{prefix}{env}{instance}`                   | Standard Blob (StorageV2)  | AzureML system data (logs, snapshots, files)  | Always created                    |
-| Data Lake Storage (Gen2) | `stdl{prefix}{env}{instance}`                 | ADLS Gen2 (HNS enabled)   | Domain data (datasets, model checkpoints)    | `should_create_data_lake_storage` |
+| Account                  | Naming Pattern                | Type                      | Purpose                                      | Terraform Variable                |
+|--------------------------|-------------------------------|---------------------------|----------------------------------------------|-----------------------------------|
+| ML Workspace Storage     | `st{prefix}{env}{instance}`   | Standard Blob (StorageV2) | AzureML system data (logs, snapshots, files) | Always created                    |
+| Data Lake Storage (Gen2) | `stdl{prefix}{env}{instance}` | ADLS Gen2 (HNS enabled)   | Domain data (datasets, model checkpoints)    | `should_create_data_lake_storage` |
 
 The data lake uses hierarchical namespace (HNS), which provides atomic directory renames required by checkpoint libraries and POSIX-style ACLs for fine-grained access control.
 
@@ -21,13 +21,13 @@ Used internally by AzureML for run metadata, code snapshots, and workspace file 
 
 ### Data Lake Storage
 
-| Container    | Subfolder            | Purpose                             | Lifecycle Policy            |
-|--------------|----------------------|-------------------------------------|-----------------------------|
-| `datasets`   | `raw/`               | Raw ROS bag files from edge devices | Auto-delete after 30 days   |
-| `datasets`   | `converted/`         | LeRobot datasets in v0.3.x format   | Tier to cool after 90 days  |
-| `models`     | `base-models/`       | Pre-trained foundation model weights | Retained indefinitely (Hot) |
-| `models`     | `checkpoints/`       | Training checkpoint outputs         | Retained indefinitely (Hot) |
-| `evaluation` | `reports/`           | Validation reports and metrics      | Cool (30d) → Archive (180d) |
+| Container    | Subfolder      | Purpose                              | Lifecycle Policy            |
+|--------------|----------------|--------------------------------------|-----------------------------|
+| `datasets`   | `raw/`         | Raw ROS bag files from edge devices  | Auto-delete after 30 days   |
+| `datasets`   | `converted/`   | LeRobot datasets in v0.3.x format    | Tier to cool after 90 days  |
+| `models`     | `base-models/` | Pre-trained foundation model weights | Retained indefinitely (Hot) |
+| `models`     | `checkpoints/` | Training checkpoint outputs          | Retained indefinitely (Hot) |
+| `evaluation` | `reports/`     | Validation reports and metrics       | Cool (30d) → Archive (180d) |
 
 ## Naming Conventions
 
@@ -135,12 +135,12 @@ Lifecycle policies on the data lake storage account automatically manage storage
 
 ### Policy Details
 
-| Folder Prefix  | Container    | Action          | Timing                | Configurable                              |
-|----------------|--------------|-----------------|---------------------- |-------------------------------------------|
-| `raw/`         | `datasets`   | Delete          | After 30 days         | Yes (`raw_bags_retention_days`)           |
-| `converted/`   | `datasets`   | Tier to Cool    | After 90 days         | Yes (`converted_datasets_cool_tier_days`) |
-| `reports/`     | `evaluation` | Tier to Cool    | After 30 days         | Yes (`reports_cool_tier_days`)            |
-| `reports/`     | `evaluation` | Tier to Archive | After 180 days        | Yes (`reports_archive_tier_days`)         |
+| Folder Prefix | Container    | Action          | Timing         | Configurable                              |
+|---------------|--------------|-----------------|----------------|-------------------------------------------|
+| `raw/`        | `datasets`   | Delete          | After 30 days  | Yes (`raw_bags_retention_days`)           |
+| `converted/`  | `datasets`   | Tier to Cool    | After 90 days  | Yes (`converted_datasets_cool_tier_days`) |
+| `reports/`    | `evaluation` | Tier to Cool    | After 30 days  | Yes (`reports_cool_tier_days`)            |
+| `reports/`    | `evaluation` | Tier to Archive | After 180 days | Yes (`reports_archive_tier_days`)         |
 
 ### Configuration
 

--- a/docs/contributing/fuzzing.md
+++ b/docs/contributing/fuzzing.md
@@ -19,11 +19,11 @@ This repository uses fuzz testing and property-based testing to find edge cases 
 
 ## Architecture
 
-| Layer | Framework | Scope |
-|---|---|---|
-| Coverage-guided fuzzing | [Atheris](https://github.com/google/atheris) | Python functions handling untrusted input |
-| Python property tests | [Hypothesis](https://hypothesis.readthedocs.io/) | Deterministic pytest classes in the fuzz harness |
-| TypeScript property tests | [fast-check](https://fast-check.dev/) | Pure utility functions in the dataviewer frontend |
+| Layer                     | Framework                                        | Scope                                             |
+|---------------------------|--------------------------------------------------|---------------------------------------------------|
+| Coverage-guided fuzzing   | [Atheris](https://github.com/google/atheris)     | Python functions handling untrusted input         |
+| Python property tests     | [Hypothesis](https://hypothesis.readthedocs.io/) | Deterministic pytest classes in the fuzz harness  |
+| TypeScript property tests | [fast-check](https://fast-check.dev/)            | Pure utility functions in the dataviewer frontend |
 
 Python fuzz regression tests run in a dedicated CI workflow that uploads coverage under the `pytest-fuzz` Codecov flag. TypeScript property tests run through the existing vitest workflow and merge into the `vitest` flag.
 
@@ -31,10 +31,10 @@ Python fuzz regression tests run in a dedicated CI workflow that uploads coverag
 
 The fuzz harness at `tests/fuzz_harness.py` operates in dual mode:
 
-| Mode | Trigger | Behavior |
-|---|---|---|
-| Pytest | `uv run pytest` | Deterministic test classes exercise targets with controlled inputs |
-| Atheris | `python tests/fuzz_harness.py` | Coverage-guided fuzzing with randomized byte streams |
+| Mode    | Trigger                        | Behavior                                                           |
+|---------|--------------------------------|--------------------------------------------------------------------|
+| Pytest  | `uv run pytest`                | Deterministic test classes exercise targets with controlled inputs |
+| Atheris | `python tests/fuzz_harness.py` | Coverage-guided fuzzing with randomized byte streams               |
 
 ### Running Pytest Mode
 
@@ -72,29 +72,29 @@ This creates 48 seed files covering all 9 targets with valid inputs, boundary va
 
 #### Seed Organization
 
-| Prefix | Target |
-|---|---|
-| `t0_` | `fuzz_validate_blob_path` |
-| `t1_` | `fuzz_get_validation_error` |
-| `t2_` | `fuzz_extract_from_value` |
-| `t3_` | `fuzz_extract_from_tracking_data` |
-| `t4_` | `fuzz_sanitize_user_string` |
-| `t5_` | `fuzz_sanitize_nested_value` |
-| `t6_` | `fuzz_validate_safe_string` |
-| `t7_` | `fuzz_dataset_id_to_blob_prefix` |
-| `t8_` | `fuzz_datetime_encoder` |
+| Prefix | Target                            |
+|--------|-----------------------------------|
+| `t0_`  | `fuzz_validate_blob_path`         |
+| `t1_`  | `fuzz_get_validation_error`       |
+| `t2_`  | `fuzz_extract_from_value`         |
+| `t3_`  | `fuzz_extract_from_tracking_data` |
+| `t4_`  | `fuzz_sanitize_user_string`       |
+| `t5_`  | `fuzz_sanitize_nested_value`      |
+| `t6_`  | `fuzz_validate_safe_string`       |
+| `t7_`  | `fuzz_dataset_id_to_blob_prefix`  |
+| `t8_`  | `fuzz_datetime_encoder`           |
 
 When adding a new fuzz target, add corresponding seeds in `generate_fuzz_corpus.py` and re-run the generator.
 
 ### Current Targets
 
-| Target | Module | Function |
-|---|---|---|
-| Blob path validation | `data-management/tools/blob_path_validator.py` | `validate_blob_path`, `get_validation_error` |
-| Metrics extraction | `training/utils/metrics.py` | `_extract_from_value`, `_extract_from_tracking_data` |
-| Input sanitization | `data-management/viewer/backend/src/api/validation.py` | `sanitize_user_string`, `_sanitize_nested_value`, `validate_safe_string` |
-| Storage paths | `data-management/viewer/backend/src/api/storage/paths.py` | `dataset_id_to_blob_prefix` |
-| JSON serialization | `data-management/viewer/backend/src/api/storage/serializers.py` | `DateTimeEncoder` |
+| Target               | Module                                                          | Function                                                                 |
+|----------------------|-----------------------------------------------------------------|--------------------------------------------------------------------------|
+| Blob path validation | `data-management/tools/blob_path_validator.py`                  | `validate_blob_path`, `get_validation_error`                             |
+| Metrics extraction   | `training/utils/metrics.py`                                     | `_extract_from_value`, `_extract_from_tracking_data`                     |
+| Input sanitization   | `data-management/viewer/backend/src/api/validation.py`          | `sanitize_user_string`, `_sanitize_nested_value`, `validate_safe_string` |
+| Storage paths        | `data-management/viewer/backend/src/api/storage/paths.py`       | `dataset_id_to_blob_prefix`                                              |
+| JSON serialization   | `data-management/viewer/backend/src/api/storage/serializers.py` | `DateTimeEncoder`                                                        |
 
 ### Adding a Fuzz Target
 
@@ -142,13 +142,13 @@ Property tests run as part of the standard vitest suite and contribute to the `v
 
 ### Current Test Files
 
-| File | Module Under Test |
-|---|---|
-| `src/lib/__tests__/api-client.property.test.ts` | `snakeToCamel`, `transformKeys` |
-| `src/lib/__tests__/api-client-fuzz.test.ts` | `snakeToCamel`, `transformKeys` (adversarial Unicode, deep nesting) |
-| `src/lib/__tests__/playback-utils.property.test.ts` | Playback range resolution, frame clamping, FPS computation |
-| `src/lib/__tests__/edit-store-frame-utils.property.test.ts` | Frame index conversion with insertions and removals |
-| `src/lib/__tests__/trajectory-graph-geometry.property.test.ts` | Coordinate math for trajectory visualization |
+| File                                                           | Module Under Test                                                   |
+|----------------------------------------------------------------|---------------------------------------------------------------------|
+| `src/lib/__tests__/api-client.property.test.ts`                | `snakeToCamel`, `transformKeys`                                     |
+| `src/lib/__tests__/api-client-fuzz.test.ts`                    | `snakeToCamel`, `transformKeys` (adversarial Unicode, deep nesting) |
+| `src/lib/__tests__/playback-utils.property.test.ts`            | Playback range resolution, frame clamping, FPS computation          |
+| `src/lib/__tests__/edit-store-frame-utils.property.test.ts`    | Frame index conversion with insertions and removals                 |
+| `src/lib/__tests__/trajectory-graph-geometry.property.test.ts` | Coordinate math for trajectory visualization                        |
 
 ### Writing a Property Test
 
@@ -171,13 +171,13 @@ describe('myFunction', () => {
 
 Prefer these property patterns:
 
-| Pattern | Description |
-|---|---|
-| Invariant | Output always satisfies a constraint |
-| Idempotence | Applying the function twice gives the same result |
-| Roundtrip | Encode then decode returns the original value |
-| Monotonicity | Larger input produces larger or equal output |
-| Bounds | Output stays within a known range |
+| Pattern      | Description                                       |
+|--------------|---------------------------------------------------|
+| Invariant    | Output always satisfies a constraint              |
+| Idempotence  | Applying the function twice gives the same result |
+| Roundtrip    | Encode then decode returns the original value     |
+| Monotonicity | Larger input produces larger or equal output      |
+| Bounds       | Output stays within a known range                 |
 
 ## Hypothesis Configuration
 
@@ -195,11 +195,11 @@ These settings apply to all Hypothesis-based tests. `max_examples` controls the 
 
 Fuzz and property test coverage merges into existing Codecov flags:
 
-| Test type | Codecov flag | Coverage file |
-|---|---|---|
-| Python fuzz harness | `pytest-fuzz` | `logs/coverage-fuzz.xml` |
-| Dataviewer backend | `pytest-dataviewer` | `logs/coverage-dataviewer.xml` |
-| TypeScript property tests | `vitest` | `coverage/cobertura-coverage.xml` |
+| Test type                 | Codecov flag        | Coverage file                     |
+|---------------------------|---------------------|-----------------------------------|
+| Python fuzz harness       | `pytest-fuzz`       | `logs/coverage-fuzz.xml`          |
+| Dataviewer backend        | `pytest-dataviewer` | `logs/coverage-dataviewer.xml`    |
+| TypeScript property tests | `vitest`            | `coverage/cobertura-coverage.xml` |
 
 Per-flag patch coverage status is set to `informational: true` so fuzz coverage differences never block PRs. This follows the pattern used in [microsoft/hve-core](https://github.com/microsoft/hve-core).
 

--- a/docs/fleet-intelligence/README.md
+++ b/docs/fleet-intelligence/README.md
@@ -25,8 +25,8 @@ Fleet-wide telemetry collection, operational dashboards, drift detection, and au
 
 ## 📖 Related Documentation
 
-| Guide                                                                                                     | Description                           |
-|-----------------------------------------------------------------------------------------------------------|---------------------------------------|
+| Guide                                                                                                                                                            | Description                           |
+|------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------|
 | [Telemetry Specification](https://github.com/microsoft/physical-ai-toolchain/blob/main/fleet-intelligence/specifications/telemetry.specification.md)             | Schema and routing architecture       |
 | [Dashboard Specification](https://github.com/microsoft/physical-ai-toolchain/blob/main/fleet-intelligence/specifications/dashboards.specification.md)            | Fleet dashboard and alerting design   |
 | [Drift Detection Specification](https://github.com/microsoft/physical-ai-toolchain/blob/main/fleet-intelligence/specifications/drift-detection.specification.md) | Detection algorithms and thresholds   |

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -75,9 +75,10 @@ location        = "westus3"
 resource_prefix = "yourprefix"
 instance        = "001"
 
-// Full-public networking (simplest path)
-should_enable_private_endpoint    = false
-should_enable_private_aks_cluster = false
+// Full-public networking (simplest path for inner developer loop)
+should_enable_private_endpoint      = false
+should_enable_private_aks_cluster   = false
+should_enable_public_network_access = true
 
 // Single GPU pool (Spot A10)
 node_pools = {
@@ -94,6 +95,11 @@ node_pools = {
     eviction_policy            = "Delete"
   }
 }
+
+// System node pool — enable autoscaling for OSMO workloads
+should_enable_system_node_pool_auto_scaling = true
+system_node_pool_min_count                  = 1
+system_node_pool_max_count                  = 3
 
 // OSMO Backend Services
 should_deploy_postgresql = true
@@ -168,14 +174,27 @@ Deploy the OSMO control plane and backend using Access Keys authentication.
 ```bash
 bash 03-deploy-osmo-control-plane.sh --config-preview
 bash 03-deploy-osmo-control-plane.sh
-bash 04-deploy-osmo-backend.sh --use-access-keys --config-preview
-bash 04-deploy-osmo-backend.sh --use-access-keys
+```
+
+> [!IMPORTANT]
+> When running from a **devcontainer or codespace**, the OSMO service URL is an internal load balancer IP only reachable from within the AKS VNet. Set up a port-forward before running the backend script:
+>
+> ```bash
+> kubectl port-forward svc/osmo-service -n osmo-control-plane 8080:80 &
+> ```
+>
+> Then pass `--service-url http://localhost:8080` to both scripts 03 and 04. The scripts detect unreachable URLs and print this guidance automatically.
+
+```bash
+bash 04-deploy-osmo-backend.sh --use-access-keys --service-url http://localhost:8080 --config-preview
+bash 04-deploy-osmo-backend.sh --use-access-keys --service-url http://localhost:8080
 ```
 
 Verify OSMO pods:
 
 ```bash
 kubectl get pods -n osmo-control-plane
+kubectl get pods -n osmo-operator
 ```
 
 ## Step 8: Submit First Training Job
@@ -208,8 +227,8 @@ Remove OSMO Helm releases before destroying infrastructure to avoid orphaned res
 
 ```bash
 cd infrastructure/setup
-helm uninstall backend-operator -n osmo-operator --ignore-not-found
-helm uninstall osmo-service osmo-router osmo-web-ui -n osmo-control-plane --ignore-not-found
+helm uninstall osmo-operator -n osmo-operator --ignore-not-found
+helm uninstall service router ui -n osmo-control-plane --ignore-not-found
 ```
 
 Destroy all infrastructure when finished to stop incurring costs. From the repository root:

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 2
 title: "Quickstart: Clone to First Training Job"
-description: Deploy infrastructure and submit your first robotics training job in 8 steps
+description: Deploy infrastructure and submit your first robotics training job in 9 steps
 author: Microsoft Robotics-AI Team
 ms.date: 2026-02-22
 ms.topic: tutorial
@@ -19,12 +19,12 @@ Deploy the full Azure NVIDIA Robotics stack and submit a training job in ~1.5-2 
 
 ## Prerequisites
 
-| Requirement             | Details                                          |
-|-------------------------|--------------------------------------------------|
-| Azure subscription      | Contributor + User Access Administrator roles    |
-| GPU quota               | `Standard_NC24ads_A100_v4` in target region      |
-| NVIDIA NGC account      | Sign up at <https://ngc.nvidia.com/> for API key |
-| Development environment | Devcontainer (recommended) or local tools        |
+| Requirement             | Details                                                                                             |
+|-------------------------|-----------------------------------------------------------------------------------------------------|
+| Azure subscription      | Contributor + User Access Administrator roles                                                       |
+| GPU quota               | `Standard_NV36ads_A10_v5` (A10 Spot, default) or `Standard_NC40ads_H100_v5` (H100) in target region |
+| NVIDIA NGC account      | Sign up at <https://ngc.nvidia.com/> for API key                                                    |
+| Development environment | Devcontainer (recommended) or local tools                                                           |
 
 See [Prerequisites](../contributing/prerequisites.md) for installation commands and version requirements.
 
@@ -67,22 +67,46 @@ cd infrastructure/terraform
 cp terraform.tfvars.example terraform.tfvars
 ```
 
-Edit `terraform.tfvars` with these values:
+Edit `terraform.tfvars` with your values:
 
 ```hcl
-project_name = "robotics"
-environment  = "dev"
-location     = "eastus"
-gpu_vm_size  = "Standard_NC24ads_A100_v4"
+environment     = "dev"
+location        = "westus3"
+resource_prefix = "yourprefix"
+instance        = "001"
 
-enable_azure_ml    = true
-enable_osmo        = true
-enable_vpn_gateway = false
-enable_private_dns = false
+// Full-public networking (simplest path)
+should_enable_private_endpoint    = false
+should_enable_private_aks_cluster = false
+
+// Single GPU pool (Spot A10)
+node_pools = {
+  gpu = {
+    vm_size                    = "Standard_NV36ads_A10_v5"
+    subnet_address_prefixes    = ["10.0.7.0/24"]
+    node_taints                = ["nvidia.com/gpu:NoSchedule", "kubernetes.azure.com/scalesetpriority=spot:NoSchedule"]
+    gpu_driver                 = "Install"
+    priority                   = "Spot"
+    should_enable_auto_scaling = true
+    min_count                  = 1
+    max_count                  = 1
+    zones                      = []
+    eviction_policy            = "Delete"
+  }
+}
+
+// OSMO Backend Services
+should_deploy_postgresql = true
+should_deploy_redis      = true
 ```
 
+> [!WARNING]
+> `resource_prefix` must be lowercase, alphanumeric, and short (6-8 characters recommended). It feeds into Key Vault (`kv{prefix}{env}{instance}`) and Storage Account names that have 24-character limits and must be globally unique.
+
+<!-- markdownlint-disable-next-line MD028 -->
+
 > [!TIP]
-> For private networking, set `enable_vpn_gateway = true` and `enable_private_dns = true`. See the [Infrastructure Guide](https://github.com/microsoft/physical-ai-toolchain/blob/main/infrastructure/terraform/README.md) for details.
+> For private networking, set `should_enable_private_endpoint = true` and `should_enable_private_aks_cluster = true`, then deploy the VPN from `infrastructure/terraform/vpn/` before running any `kubectl` commands. See the [Infrastructure Guide](../infrastructure/README.md) for details.
 
 ## Step 4: Deploy Infrastructure
 
@@ -104,19 +128,32 @@ Connect to the AKS cluster:
 
 ```bash
 az aks get-credentials \
-  --resource-group "$(terraform output -raw resource_group_name)" \
-  --name "$(terraform output -raw aks_cluster_name)"
+  --resource-group "$(terraform output -json resource_group | jq -r '.name')" \
+  --name "$(terraform output -json aks_cluster | jq -r '.name')"
 ```
 
-## Step 5: Configure AKS Cluster
+## Step 5: Set NGC API Key
+
+Export your NVIDIA NGC API key for OSMO backend deployment. Obtain a key from <https://ngc.nvidia.com/>.
+
+```bash
+export NGC_API_KEY="<your-ngc-api-key>"
+```
+
+## Step 6: Configure AKS Cluster
 
 Deploy GPU Operator, KAI Scheduler, and the AzureML extension. From the repository root:
 
 ```bash
 cd infrastructure/setup
+bash 01-deploy-robotics-charts.sh --config-preview
 bash 01-deploy-robotics-charts.sh
+bash 02-deploy-azureml-extension.sh --config-preview
 bash 02-deploy-azureml-extension.sh
 ```
+
+> [!TIP]
+> All setup scripts support `--config-preview` to print configuration and exit without changes. Run it before each real deployment to verify values.
 
 Verify GPU operator pods:
 
@@ -124,12 +161,14 @@ Verify GPU operator pods:
 kubectl get pods -n gpu-operator
 ```
 
-## Step 6: Deploy OSMO Components
+## Step 7: Deploy OSMO Components
 
 Deploy the OSMO control plane and backend using Access Keys authentication.
 
 ```bash
+bash 03-deploy-osmo-control-plane.sh --config-preview
 bash 03-deploy-osmo-control-plane.sh
+bash 04-deploy-osmo-backend.sh --use-access-keys --config-preview
 bash 04-deploy-osmo-backend.sh --use-access-keys
 ```
 
@@ -139,32 +178,39 @@ Verify OSMO pods:
 kubectl get pods -n osmo-control-plane
 ```
 
-## Step 7: Submit First Training Job
+## Step 8: Submit First Training Job
 
-Navigate to the scripts directory and submit a training job. From the repository root:
+Submit a training job from the repository root:
 
 ```bash
-cd scripts
-bash submit-osmo-training.sh
+bash training/rl/scripts/submit-osmo-training.sh
 ```
 
 Scripts auto-detect configuration from Terraform outputs. Override values with CLI arguments or environment variables as needed. See [Scripts Reference](../reference/scripts.md) for all submission options.
 
-## Step 8: Verify Results
+## Step 9: Verify Results
 
 Confirm the training job is running:
 
 ```bash
-kubectl get pods -n osmo-control-plane --watch
+kubectl get pods -n osmo-workflows --watch
 ```
 
 Check OSMO training status through the OSMO web UI or query pod logs:
 
 ```bash
-kubectl logs -n osmo-control-plane -l app=osmo-training --tail=50
+kubectl logs -n osmo-workflows -l app=osmo-training --tail=50
 ```
 
 ## Cleanup
+
+Remove OSMO Helm releases before destroying infrastructure to avoid orphaned resources:
+
+```bash
+cd infrastructure/setup
+helm uninstall backend-operator -n osmo-operator --ignore-not-found
+helm uninstall osmo-service osmo-router osmo-web-ui -n osmo-control-plane --ignore-not-found
+```
 
 Destroy all infrastructure when finished to stop incurring costs. From the repository root:
 
@@ -177,8 +223,8 @@ See [Cost Considerations](../contributing/cost-considerations.md) for detailed p
 
 ## Next Steps
 
-| Resource                                                                                          | Description                               |
-|---------------------------------------------------------------------------------------------------|-------------------------------------------|
-| [MLflow Integration](../training/mlflow-integration.md)                                           | Track experiments with MLflow             |
-| [Deployment Guide](https://github.com/microsoft/physical-ai-toolchain/blob/main/deploy/README.md) | Full deployment reference and options     |
-| [Contributing Guide](../contributing/README.md)                                                   | Development workflow and code standards   |
+| Resource                                                | Description                             |
+|---------------------------------------------------------|-----------------------------------------|
+| [MLflow Integration](../training/mlflow-integration.md) | Track experiments with MLflow           |
+| [Infrastructure Guide](../infrastructure/README.md)     | Full deployment reference and options   |
+| [Contributing Guide](../contributing/README.md)         | Development workflow and code standards |

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -18,13 +18,13 @@ Centralized hub for operational documentation covering monitoring, troubleshooti
 
 ## 📖 Operations Guides
 
-| Guide                                                                     | Description                                                              |
-|---------------------------------------------------------------------------|--------------------------------------------------------------------------|
-| [Troubleshooting](troubleshooting.md)                                     | Symptom-based resolution for common deployment, GPU, and workflow errors |
-| [Security Guide](security-guide.md)                                       | Security configuration inventory and deployment checklist                |
-| [GPU Configuration](../reference/gpu-configuration.md)                    | Driver selection, MIG strategy, and GPU Operator configuration           |
-| [Deployment Validation](../contributing/deployment-validation.md)         | Post-deployment verification steps                                       |
-| [Cost Considerations](../contributing/cost-considerations.md)             | Azure resource cost guidance                                             |
+| Guide                                                             | Description                                                              |
+|-------------------------------------------------------------------|--------------------------------------------------------------------------|
+| [Troubleshooting](troubleshooting.md)                             | Symptom-based resolution for common deployment, GPU, and workflow errors |
+| [Security Guide](security-guide.md)                               | Security configuration inventory and deployment checklist                |
+| [GPU Configuration](../reference/gpu-configuration.md)            | Driver selection, MIG strategy, and GPU Operator configuration           |
+| [Deployment Validation](../contributing/deployment-validation.md) | Post-deployment verification steps                                       |
+| [Cost Considerations](../contributing/cost-considerations.md)     | Azure resource cost guidance                                             |
 
 ## 📋 Operational Overview
 

--- a/infrastructure/setup/03-deploy-osmo-control-plane.sh
+++ b/infrastructure/setup/03-deploy-osmo-control-plane.sh
@@ -340,6 +340,7 @@ if [[ "$skip_service_config" == "false" ]]; then
 
   service_url=$(detect_service_url)
   if [[ -n "$service_url" ]]; then
+    validate_service_url_reachable "$service_url"
     [[ -f "$service_config_template" ]] || fatal "Service config template not found: $service_config_template"
     export SERVICE_BASE_URL="$service_url"
     envsubst < "$service_config_template" > "$CONFIG_DIR/out/service-config.json"

--- a/infrastructure/setup/04-deploy-osmo-backend.sh
+++ b/infrastructure/setup/04-deploy-osmo-backend.sh
@@ -112,11 +112,21 @@ az account show &>/dev/null || fatal "Azure CLI not logged in; run 'az login'"
 # Gather Configuration
 #------------------------------------------------------------------------------
 
+# Resolve in-cluster URL (for Helm/pods) separately from CLI URL (for osmo commands).
+# When --service-url points to a port-forward (localhost), detect the real in-cluster URL.
+cluster_service_url=$(detect_service_url)
+
 if [[ -z "$service_url" ]]; then
   info "Auto-detecting OSMO service URL..."
-  service_url=$(detect_service_url)
+  service_url="${cluster_service_url}"
   [[ -z "$service_url" ]] && fatal "Could not detect service URL. Run 03-deploy-osmo-control-plane.sh first or provide --service-url"
+  validate_service_url_reachable "$service_url"
   info "Detected: $service_url"
+else
+  # --service-url provided (likely port-forward); use detected in-cluster URL for Helm
+  if [[ -z "$cluster_service_url" ]]; then
+    cluster_service_url="$service_url"
+  fi
 fi
 
 info "Reading terraform outputs from $tf_dir..."
@@ -296,7 +306,7 @@ helm_args=(
   --version "$chart_version"
   --namespace "$NS_OSMO_OPERATOR"
   --set-string "global.osmoImageTag=$image_version"
-  --set-string "global.serviceUrl=$service_url"
+  --set-string "global.serviceUrl=$cluster_service_url"
   --set-string "global.agentNamespace=$NS_OSMO_OPERATOR"
   --set-string "global.backendNamespace=$NS_OSMO_WORKFLOWS"
   --set-string "global.backendName=$backend_name"

--- a/infrastructure/terraform/modules/platform/postgresql.tf
+++ b/infrastructure/terraform/modules/platform/postgresql.tf
@@ -58,7 +58,7 @@ resource "azurerm_postgresql_flexible_server" "main" {
   zone                          = var.postgresql_config.zone
   backup_retention_days         = 7
   geo_redundant_backup_enabled  = false
-  public_network_access_enabled = false
+  public_network_access_enabled = var.should_enable_public_network_access
 
   dynamic "high_availability" {
     for_each = var.postgresql_config.should_enable_high_availability ? [1] : []

--- a/infrastructure/terraform/modules/platform/postgresql.tf
+++ b/infrastructure/terraform/modules/platform/postgresql.tf
@@ -74,6 +74,19 @@ resource "azurerm_postgresql_flexible_server" "main" {
 }
 
 // ============================================================
+// PostgreSQL Firewall Rules (public access without private endpoints)
+// ============================================================
+
+resource "azurerm_postgresql_flexible_server_firewall_rule" "aks_egress" {
+  count = var.should_deploy_postgresql && var.should_enable_public_network_access && !local.pe_enabled && var.should_enable_nat_gateway ? 1 : 0
+
+  name             = "aks-nat-gateway-egress"
+  server_id        = azurerm_postgresql_flexible_server.main[0].id
+  start_ip_address = azurerm_public_ip.nat_gateway[0].ip_address
+  end_ip_address   = azurerm_public_ip.nat_gateway[0].ip_address
+}
+
+// ============================================================
 // PostgreSQL Private Endpoint
 // ============================================================
 

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -276,8 +276,7 @@ apply_secret_provider_class() {
   local include_redis_secret="${5:-true}"
 
   local manifest_dir
-  # BASH_SOURCE preserves the symlinked setup/lib path, so ../manifests resolves correctly.
-  manifest_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/manifests"
+  manifest_dir="${REPO_ROOT:?REPO_ROOT must be set}/infrastructure/setup/manifests"
   local manifest_name="aks-secret-provider-class.yaml"
 
   [[ "$include_redis_secret" == "true" ]] && manifest_name="aks-secret-provider-class-external-redis.yaml"

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -163,6 +163,29 @@ detect_service_url() {
   echo "$url"
 }
 
+# Validate that the OSMO service URL is reachable from the current host.
+# Internal load balancer IPs are only accessible from within the VNet; when running
+# from a devcontainer or codespace, users must port-forward instead.
+validate_service_url_reachable() {
+  local url="${1:?service URL required}"
+  local host
+  host=$(echo "$url" | sed 's|https\?://||;s|/.*||;s|:.*||')
+
+  if curl -sf --connect-timeout 5 "${url}/api/version" >/dev/null 2>&1; then
+    return 0
+  fi
+
+  warn "OSMO service URL $url is not reachable from this host"
+  warn "The auto-detected URL is an internal load balancer IP only accessible from within the AKS VNet."
+  echo >&2
+  warn "If running from a devcontainer or codespace, use kubectl port-forward:"
+  warn "  kubectl port-forward svc/osmo-service -n osmo-control-plane 8080:80 &"
+  warn "Then re-run this script with:"
+  warn "  --service-url http://localhost:8080"
+  echo >&2
+  fatal "Cannot reach OSMO service at $url"
+}
+
 detect_default_storage_class() {
   local storage_class
 

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -168,8 +168,6 @@ detect_service_url() {
 # from a devcontainer or codespace, users must port-forward instead.
 validate_service_url_reachable() {
   local url="${1:?service URL required}"
-  local host
-  host=$(echo "$url" | sed 's|https\?://||;s|/.*||;s|:.*||')
 
   if curl -sf --connect-timeout 5 "${url}/api/version" >/dev/null 2>&1; then
     return 0


### PR DESCRIPTION
## Description

Audited *docs/getting-started/quickstart.md* against the actual infrastructure code on `main` and corrected all 11 issues identified in #470 — five critical blockers, three missing steps, and three minor issues.

The quickstart previously referenced Terraform variables, output names, script paths, and Kubernetes namespaces that did not exist in the codebase, making the guide impossible to follow end-to-end. The guide now aligns with `infrastructure/terraform/variables.tf`, `outputs.tf`, `terraform.tfvars.example`, and `infrastructure/setup/defaults.conf`.

Closes #470

## Type of Change

- [x] 🐛 Bug fix (non-breaking change fixing an issue)
- [ ] ✨ New feature (non-breaking change adding functionality)
- [ ] 💥 Breaking change (fix or feature causing existing functionality to change)
- [x] 📚 Documentation update
- [x] 🏗️ Infrastructure change (Terraform/IaC)
- [ ] ♻️ Refactoring (no functional changes)

## Component(s) Affected

- [ ] `infrastructure/terraform/prerequisites/` - Azure subscription setup
- [x] `infrastructure/terraform/` - Terraform infrastructure
- [x] `infrastructure/setup/` - OSMO control plane / Helm
- [ ] `workflows/` - Training and evaluation workflows
- [ ] `training/` - Training pipelines and scripts
- [x] `docs/` - Documentation

## Testing Performed

- [x] Terraform `plan` reviewed (no unexpected changes)
- [x] Terraform `apply` tested in dev environment
- [ ] Training scripts tested locally with Isaac Sim
- [ ] OSMO workflow submitted successfully
- [ ] Smoke tests passed (`smoke_test_azure.py`)

Documentation changes verified by cross-referencing every variable, output, path, and namespace against the actual source files. Infrastructure fixes validated through a full developer inner loop deployment (public access, no VPN/private endpoints):

- **Terraform variables** checked against `infrastructure/terraform/variables.tf` and `terraform.tfvars.example`
- **Terraform outputs** checked against `infrastructure/terraform/outputs.tf`
- **Script paths** confirmed via filesystem (`training/rl/scripts/submit-osmo-training.sh` exists)
- **Namespaces** confirmed via `infrastructure/setup/defaults.conf` (`NS_OSMO_WORKFLOWS=osmo-workflows`)
- **NGC_API_KEY** confirmed as required in `defaults.conf` and consumed by deploy scripts
- **PostgreSQL connectivity** verified end-to-end after enabling public network access and NAT Gateway firewall rule
- **Secret Provider Class** manifest resolution confirmed after `common.sh` path fix
- Markdown linting passed (`npm run lint:md`)
- Spell check passed (`npm run spell-check`)

## Documentation Impact

- [ ] No documentation changes needed
- [x] Documentation updated in this PR
- [ ] Documentation issue filed

## Bug Fix Checklist

- [x] Linked to issue being fixed
- [ ] Regression test included, OR
- [x] Justification for no regression test: Infrastructure changes are additive (new firewall rule, variable-driven toggle) and validated via `terraform plan` + live deployment.

## Checklist

- [x] My code follows the [project conventions](copilot-instructions.md)
- [x] Commit messages follow [conventional commit format](instructions/commit-message.instructions.md)
- [x] I have performed a self-review
- [x] Documentation impact assessed above
- [x] No new linting warnings introduced

## Changes

### Quickstart Corrections (*docs/getting-started/quickstart.md*)

> The quickstart guide contained incorrect variables, wrong output access patterns, a nonexistent script path, and the wrong Kubernetes namespace for training pods — all of which blocked users from completing the tutorial.

- Replaced fictional Terraform variables (`project_name`, `gpu_vm_size`, `enable_azure_ml`, `enable_osmo`, `enable_vpn_gateway`, `enable_private_dns`) with actual inputs: **`resource_prefix`**, **`instance`**, **`node_pools`** map, **`should_enable_private_endpoint`**, **`should_enable_private_aks_cluster`**, **`should_deploy_postgresql`**, **`should_deploy_redis`**
- Fixed **Terraform output access** from `terraform output -raw resource_group_name` to `terraform output -json resource_group | jq -r '.name'` (and similarly for `aks_cluster`), matching the object-typed outputs in *outputs.tf*
- Corrected **training script path** from `scripts/submit-osmo-training.sh` to `training/rl/scripts/submit-osmo-training.sh`
- Changed **training pod namespace** from `osmo-control-plane` to `osmo-workflows` across all `kubectl` commands
- Updated **GPU SKU** from `Standard_NC24ads_A100_v4` to `Standard_NV36ads_A10_v5` (A10 Spot, default) with `Standard_NC40ads_H100_v5` (H100) as an alternative, aligning with *terraform.tfvars.example*

### Missing Steps and Guidance

- Added **Step 5: Set NGC API Key** — exports `NGC_API_KEY` required by OSMO backend deployment scripts
- Added **`--config-preview`** dry-run commands before each setup script invocation, with a TIP callout explaining the flag
- Added **`resource_prefix` naming constraints** warning — lowercase, alphanumeric, 6-8 characters recommended due to Key Vault and Storage Account 24-character limits
- Added **OSMO Helm cleanup** commands (`helm uninstall`) before `terraform destroy` to prevent orphaned Kubernetes resources

### Minor Fixes

- Replaced broken **`deploy/README.md`** link in Next Steps with relative `../infrastructure/README.md`
- Updated frontmatter description from "8 steps" to "9 steps" to reflect the added NGC step
- Updated private networking TIP to reference correct `should_*` variables and VPN deployment directory

### Infrastructure Fixes from Developer Inner Loop Testing

> [!NOTE]
> While testing the updated quickstart in a developer inner loop deployment (public access, no private endpoints or VPN), two infrastructure issues surfaced that blocked the setup scripts from completing. These are included in this PR because they were discovered as a direct result of following the corrected guide.

- Fixed **PostgreSQL public network access** — `public_network_access_enabled` was hardcoded to `false` in *infrastructure/terraform/modules/platform/postgresql.tf*; changed to use `var.should_enable_public_network_access` so non-private-endpoint deployments can reach the database
- Added **PostgreSQL firewall rule** for AKS NAT Gateway egress — when deploying without private endpoints, AKS pods route through the NAT Gateway public IP; a new `azurerm_postgresql_flexible_server_firewall_rule` resource allows that IP, gated on `should_enable_public_network_access && !local.pe_enabled && should_enable_nat_gateway`
- Fixed **Secret Provider Class manifest path** in *scripts/lib/common.sh* — `BASH_SOURCE`-relative resolution (`../manifests`) failed when `common.sh` was sourced from a different working directory; replaced with `${REPO_ROOT}/infrastructure/setup/manifests` for reliable resolution regardless of caller location

### Script & Quickstart Fixes from OSMO Deployment Testing

> [!NOTE]
> While completing the OSMO control plane and backend deployment from a devcontainer, the internal load balancer IP auto-detected by the deploy scripts was unreachable outside the AKS VNet. The following changes add service URL validation, port-forward guidance, and quickstart corrections discovered during this testing pass.

- Added **`validate_service_url_reachable`** helper in *scripts/lib/common.sh* — probes the service URL with `curl` and, on failure, prints actionable `kubectl port-forward` instructions before exiting
- Wired `validate_service_url_reachable` into **`03-deploy-osmo-control-plane.sh`** and **`04-deploy-osmo-backend.sh`** so unreachable URLs are caught early with clear remediation steps
- Split **service URL resolution** in `04-deploy-osmo-backend.sh` — the in-cluster URL (for Helm `global.serviceUrl`) is now resolved separately from the CLI-reachable URL (`--service-url`), so port-forwarded localhost URLs are used for `osmo` CLI calls while pods still get the real internal IP
- Updated **quickstart guide** with devcontainer port-forward instructions (`kubectl port-forward svc/osmo-service -n osmo-control-plane 8080:80`), `--service-url http://localhost:8080` flags, `should_enable_public_network_access = true` in the tfvars example, system node pool autoscaling settings, and corrected Helm release names in the cleanup section

### Table Formatting (6 files)

Cosmetic table column-width normalization from `npm run format:tables` in *CONTRIBUTING.md*, *docs/README.md*, *docs/cloud/blob-storage-structure.md*, *docs/contributing/fuzzing.md*, *docs/fleet-intelligence/README.md*, and *docs/operations/README.md*. No content changes.

## Related Issues

Closes #470
