### PR TITLE
fix(infrastructure): OSMO workflow execution, PostgreSQL public access, and quickstart corrections

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -155,16 +155,16 @@ For Terraform and shell script validation, see the [Prerequisites](docs/contribu
 
 All CI linters enforce warnings-as-errors. PRs that introduce new warnings will not merge.
 
-| Linter               | Enforcement       | Configuration                                 |
-|----------------------|-------------------|-----------------------------------------------|
-| Markdown (lint:md)   | Errors block      | .markdownlint-cli2.jsonc                      |
+| Linter               | Enforcement       | Configuration                               |
+|----------------------|-------------------|---------------------------------------------|
+| Markdown (lint:md)   | Errors block      | .markdownlint-cli2.jsonc                    |
 | PowerShell (lint:ps) | Errors + warnings | scripts/linting/Invoke-PSScriptAnalyzer.ps1 |
-| YAML (lint:yaml)     | Errors + warnings | .yamllint.yml                                 |
-| Terraform (lint:tf)  | Errors block      | .tflint.hcl                                   |
-| Go (lint:go)         | Errors block      | .golangci.yml                                 |
-| ShellCheck (lint:sh) | Warnings + errors | .shellcheckrc                                 |
-| Python (lint:py)     | Errors block      | pyproject.toml [tool.ruff]                    |
-| Link check           | Errors block      | .markdownlint-cli2.jsonc                      |
+| YAML (lint:yaml)     | Errors + warnings | .yamllint.yml                               |
+| Terraform (lint:tf)  | Errors block      | .tflint.hcl                                 |
+| Go (lint:go)         | Errors block      | .golangci.yml                               |
+| ShellCheck (lint:sh) | Warnings + errors | .shellcheckrc                               |
+| Python (lint:py)     | Errors block      | pyproject.toml [tool.ruff]                  |
+| Link check           | Errors block      | .markdownlint-cli2.jsonc                    |
 
 To suppress a specific warning locally, use the linter's inline suppression syntax. Do not change CI configuration to suppress warnings globally without team discussion.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 title: Contributing
 description: How to contribute to the Physical AI Toolchain
 author: Microsoft Robotics-AI Team
-ms.date: 2026-03-11
+ms.date: 2026-04-15
 ms.topic: how-to
 keywords:
   - contributing

--- a/docs/README.md
+++ b/docs/README.md
@@ -44,10 +44,10 @@ Documentation spans the full lifecycle — from provisioning Azure infrastructur
 
 Standalone guides available now. These cover common tasks and will move into their respective topic sections as the documentation structure expands.
 
-| Guide                                                                              | Description                                                                                                         |
-|------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------|
-| [MLflow Integration](training/mlflow-integration.md)                               | Configuring MLflow experiment tracking for SKRL training agents with automatic metric logging to Azure ML           |
-| [Security Guide](operations/security-guide.md)                                     | Security configuration inventory, deployment responsibilities, and hardening checklist for robotics workloads       |
+| Guide                                                | Description                                                                                                   |
+|------------------------------------------------------|---------------------------------------------------------------------------------------------------------------|
+| [MLflow Integration](training/mlflow-integration.md) | Configuring MLflow experiment tracking for SKRL training agents with automatic metric logging to Azure ML     |
+| [Security Guide](operations/security-guide.md)       | Security configuration inventory, deployment responsibilities, and hardening checklist for robotics workloads |
 
 ## 🚀 Next Steps
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@ slug: /documentation
 title: Documentation
 description: Index of all documentation for the Physical AI Toolchain
 author: Edge AI Team
-ms.date: 2026-02-22
+ms.date: 2026-04-15
 ms.topic: overview
 keywords:
   - documentation

--- a/docs/cloud/blob-storage-structure.md
+++ b/docs/cloud/blob-storage-structure.md
@@ -4,10 +4,10 @@ Storage architecture for robotics data across two Azure Storage accounts: an ML 
 
 ## Storage Accounts
 
-| Account                  | Naming Pattern                                | Type                       | Purpose                                      | Terraform Variable                |
-|--------------------------|-----------------------------------------------|----------------------------|----------------------------------------------|-----------------------------------|
-| ML Workspace Storage     | `st{prefix}{env}{instance}`                   | Standard Blob (StorageV2)  | AzureML system data (logs, snapshots, files)  | Always created                    |
-| Data Lake Storage (Gen2) | `stdl{prefix}{env}{instance}`                 | ADLS Gen2 (HNS enabled)   | Domain data (datasets, model checkpoints)    | `should_create_data_lake_storage` |
+| Account                  | Naming Pattern                | Type                      | Purpose                                      | Terraform Variable                |
+|--------------------------|-------------------------------|---------------------------|----------------------------------------------|-----------------------------------|
+| ML Workspace Storage     | `st{prefix}{env}{instance}`   | Standard Blob (StorageV2) | AzureML system data (logs, snapshots, files) | Always created                    |
+| Data Lake Storage (Gen2) | `stdl{prefix}{env}{instance}` | ADLS Gen2 (HNS enabled)   | Domain data (datasets, model checkpoints)    | `should_create_data_lake_storage` |
 
 The data lake uses hierarchical namespace (HNS), which provides atomic directory renames required by checkpoint libraries and POSIX-style ACLs for fine-grained access control.
 
@@ -21,13 +21,13 @@ Used internally by AzureML for run metadata, code snapshots, and workspace file 
 
 ### Data Lake Storage
 
-| Container    | Subfolder            | Purpose                             | Lifecycle Policy            |
-|--------------|----------------------|-------------------------------------|-----------------------------|
-| `datasets`   | `raw/`               | Raw ROS bag files from edge devices | Auto-delete after 30 days   |
-| `datasets`   | `converted/`         | LeRobot datasets in v0.3.x format   | Tier to cool after 90 days  |
-| `models`     | `base-models/`       | Pre-trained foundation model weights | Retained indefinitely (Hot) |
-| `models`     | `checkpoints/`       | Training checkpoint outputs         | Retained indefinitely (Hot) |
-| `evaluation` | `reports/`           | Validation reports and metrics      | Cool (30d) → Archive (180d) |
+| Container    | Subfolder      | Purpose                              | Lifecycle Policy            |
+|--------------|----------------|--------------------------------------|-----------------------------|
+| `datasets`   | `raw/`         | Raw ROS bag files from edge devices  | Auto-delete after 30 days   |
+| `datasets`   | `converted/`   | LeRobot datasets in v0.3.x format    | Tier to cool after 90 days  |
+| `models`     | `base-models/` | Pre-trained foundation model weights | Retained indefinitely (Hot) |
+| `models`     | `checkpoints/` | Training checkpoint outputs          | Retained indefinitely (Hot) |
+| `evaluation` | `reports/`     | Validation reports and metrics       | Cool (30d) → Archive (180d) |
 
 ## Naming Conventions
 
@@ -135,12 +135,12 @@ Lifecycle policies on the data lake storage account automatically manage storage
 
 ### Policy Details
 
-| Folder Prefix  | Container    | Action          | Timing                | Configurable                              |
-|----------------|--------------|-----------------|---------------------- |-------------------------------------------|
-| `raw/`         | `datasets`   | Delete          | After 30 days         | Yes (`raw_bags_retention_days`)           |
-| `converted/`   | `datasets`   | Tier to Cool    | After 90 days         | Yes (`converted_datasets_cool_tier_days`) |
-| `reports/`     | `evaluation` | Tier to Cool    | After 30 days         | Yes (`reports_cool_tier_days`)            |
-| `reports/`     | `evaluation` | Tier to Archive | After 180 days        | Yes (`reports_archive_tier_days`)         |
+| Folder Prefix | Container    | Action          | Timing         | Configurable                              |
+|---------------|--------------|-----------------|----------------|-------------------------------------------|
+| `raw/`        | `datasets`   | Delete          | After 30 days  | Yes (`raw_bags_retention_days`)           |
+| `converted/`  | `datasets`   | Tier to Cool    | After 90 days  | Yes (`converted_datasets_cool_tier_days`) |
+| `reports/`    | `evaluation` | Tier to Cool    | After 30 days  | Yes (`reports_cool_tier_days`)            |
+| `reports/`    | `evaluation` | Tier to Archive | After 180 days | Yes (`reports_archive_tier_days`)         |
 
 ### Configuration
 

--- a/docs/contributing/fuzzing.md
+++ b/docs/contributing/fuzzing.md
@@ -19,11 +19,11 @@ This repository uses fuzz testing and property-based testing to find edge cases 
 
 ## Architecture
 
-| Layer | Framework | Scope |
-|---|---|---|
-| Coverage-guided fuzzing | [Atheris](https://github.com/google/atheris) | Python functions handling untrusted input |
-| Python property tests | [Hypothesis](https://hypothesis.readthedocs.io/) | Deterministic pytest classes in the fuzz harness |
-| TypeScript property tests | [fast-check](https://fast-check.dev/) | Pure utility functions in the dataviewer frontend |
+| Layer                     | Framework                                        | Scope                                             |
+|---------------------------|--------------------------------------------------|---------------------------------------------------|
+| Coverage-guided fuzzing   | [Atheris](https://github.com/google/atheris)     | Python functions handling untrusted input         |
+| Python property tests     | [Hypothesis](https://hypothesis.readthedocs.io/) | Deterministic pytest classes in the fuzz harness  |
+| TypeScript property tests | [fast-check](https://fast-check.dev/)            | Pure utility functions in the dataviewer frontend |
 
 Python fuzz regression tests run in a dedicated CI workflow that uploads coverage under the `pytest-fuzz` Codecov flag. TypeScript property tests run through the existing vitest workflow and merge into the `vitest` flag.
 
@@ -31,10 +31,10 @@ Python fuzz regression tests run in a dedicated CI workflow that uploads coverag
 
 The fuzz harness at `tests/fuzz_harness.py` operates in dual mode:
 
-| Mode | Trigger | Behavior |
-|---|---|---|
-| Pytest | `uv run pytest` | Deterministic test classes exercise targets with controlled inputs |
-| Atheris | `python tests/fuzz_harness.py` | Coverage-guided fuzzing with randomized byte streams |
+| Mode    | Trigger                        | Behavior                                                           |
+|---------|--------------------------------|--------------------------------------------------------------------|
+| Pytest  | `uv run pytest`                | Deterministic test classes exercise targets with controlled inputs |
+| Atheris | `python tests/fuzz_harness.py` | Coverage-guided fuzzing with randomized byte streams               |
 
 ### Running Pytest Mode
 
@@ -72,29 +72,29 @@ This creates 48 seed files covering all 9 targets with valid inputs, boundary va
 
 #### Seed Organization
 
-| Prefix | Target |
-|---|---|
-| `t0_` | `fuzz_validate_blob_path` |
-| `t1_` | `fuzz_get_validation_error` |
-| `t2_` | `fuzz_extract_from_value` |
-| `t3_` | `fuzz_extract_from_tracking_data` |
-| `t4_` | `fuzz_sanitize_user_string` |
-| `t5_` | `fuzz_sanitize_nested_value` |
-| `t6_` | `fuzz_validate_safe_string` |
-| `t7_` | `fuzz_dataset_id_to_blob_prefix` |
-| `t8_` | `fuzz_datetime_encoder` |
+| Prefix | Target                            |
+|--------|-----------------------------------|
+| `t0_`  | `fuzz_validate_blob_path`         |
+| `t1_`  | `fuzz_get_validation_error`       |
+| `t2_`  | `fuzz_extract_from_value`         |
+| `t3_`  | `fuzz_extract_from_tracking_data` |
+| `t4_`  | `fuzz_sanitize_user_string`       |
+| `t5_`  | `fuzz_sanitize_nested_value`      |
+| `t6_`  | `fuzz_validate_safe_string`       |
+| `t7_`  | `fuzz_dataset_id_to_blob_prefix`  |
+| `t8_`  | `fuzz_datetime_encoder`           |
 
 When adding a new fuzz target, add corresponding seeds in `generate_fuzz_corpus.py` and re-run the generator.
 
 ### Current Targets
 
-| Target | Module | Function |
-|---|---|---|
-| Blob path validation | `data-management/tools/blob_path_validator.py` | `validate_blob_path`, `get_validation_error` |
-| Metrics extraction | `training/utils/metrics.py` | `_extract_from_value`, `_extract_from_tracking_data` |
-| Input sanitization | `data-management/viewer/backend/src/api/validation.py` | `sanitize_user_string`, `_sanitize_nested_value`, `validate_safe_string` |
-| Storage paths | `data-management/viewer/backend/src/api/storage/paths.py` | `dataset_id_to_blob_prefix` |
-| JSON serialization | `data-management/viewer/backend/src/api/storage/serializers.py` | `DateTimeEncoder` |
+| Target               | Module                                                          | Function                                                                 |
+|----------------------|-----------------------------------------------------------------|--------------------------------------------------------------------------|
+| Blob path validation | `data-management/tools/blob_path_validator.py`                  | `validate_blob_path`, `get_validation_error`                             |
+| Metrics extraction   | `training/utils/metrics.py`                                     | `_extract_from_value`, `_extract_from_tracking_data`                     |
+| Input sanitization   | `data-management/viewer/backend/src/api/validation.py`          | `sanitize_user_string`, `_sanitize_nested_value`, `validate_safe_string` |
+| Storage paths        | `data-management/viewer/backend/src/api/storage/paths.py`       | `dataset_id_to_blob_prefix`                                              |
+| JSON serialization   | `data-management/viewer/backend/src/api/storage/serializers.py` | `DateTimeEncoder`                                                        |
 
 ### Adding a Fuzz Target
 
@@ -142,13 +142,13 @@ Property tests run as part of the standard vitest suite and contribute to the `v
 
 ### Current Test Files
 
-| File | Module Under Test |
-|---|---|
-| `src/lib/__tests__/api-client.property.test.ts` | `snakeToCamel`, `transformKeys` |
-| `src/lib/__tests__/api-client-fuzz.test.ts` | `snakeToCamel`, `transformKeys` (adversarial Unicode, deep nesting) |
-| `src/lib/__tests__/playback-utils.property.test.ts` | Playback range resolution, frame clamping, FPS computation |
-| `src/lib/__tests__/edit-store-frame-utils.property.test.ts` | Frame index conversion with insertions and removals |
-| `src/lib/__tests__/trajectory-graph-geometry.property.test.ts` | Coordinate math for trajectory visualization |
+| File                                                           | Module Under Test                                                   |
+|----------------------------------------------------------------|---------------------------------------------------------------------|
+| `src/lib/__tests__/api-client.property.test.ts`                | `snakeToCamel`, `transformKeys`                                     |
+| `src/lib/__tests__/api-client-fuzz.test.ts`                    | `snakeToCamel`, `transformKeys` (adversarial Unicode, deep nesting) |
+| `src/lib/__tests__/playback-utils.property.test.ts`            | Playback range resolution, frame clamping, FPS computation          |
+| `src/lib/__tests__/edit-store-frame-utils.property.test.ts`    | Frame index conversion with insertions and removals                 |
+| `src/lib/__tests__/trajectory-graph-geometry.property.test.ts` | Coordinate math for trajectory visualization                        |
 
 ### Writing a Property Test
 
@@ -171,13 +171,13 @@ describe('myFunction', () => {
 
 Prefer these property patterns:
 
-| Pattern | Description |
-|---|---|
-| Invariant | Output always satisfies a constraint |
-| Idempotence | Applying the function twice gives the same result |
-| Roundtrip | Encode then decode returns the original value |
-| Monotonicity | Larger input produces larger or equal output |
-| Bounds | Output stays within a known range |
+| Pattern      | Description                                       |
+|--------------|---------------------------------------------------|
+| Invariant    | Output always satisfies a constraint              |
+| Idempotence  | Applying the function twice gives the same result |
+| Roundtrip    | Encode then decode returns the original value     |
+| Monotonicity | Larger input produces larger or equal output      |
+| Bounds       | Output stays within a known range                 |
 
 ## Hypothesis Configuration
 
@@ -195,11 +195,11 @@ These settings apply to all Hypothesis-based tests. `max_examples` controls the 
 
 Fuzz and property test coverage merges into existing Codecov flags:
 
-| Test type | Codecov flag | Coverage file |
-|---|---|---|
-| Python fuzz harness | `pytest-fuzz` | `logs/coverage-fuzz.xml` |
-| Dataviewer backend | `pytest-dataviewer` | `logs/coverage-dataviewer.xml` |
-| TypeScript property tests | `vitest` | `coverage/cobertura-coverage.xml` |
+| Test type                 | Codecov flag        | Coverage file                     |
+|---------------------------|---------------------|-----------------------------------|
+| Python fuzz harness       | `pytest-fuzz`       | `logs/coverage-fuzz.xml`          |
+| Dataviewer backend        | `pytest-dataviewer` | `logs/coverage-dataviewer.xml`    |
+| TypeScript property tests | `vitest`            | `coverage/cobertura-coverage.xml` |
 
 Per-flag patch coverage status is set to `informational: true` so fuzz coverage differences never block PRs. This follows the pattern used in [microsoft/hve-core](https://github.com/microsoft/hve-core).
 

--- a/docs/contributing/fuzzing.md
+++ b/docs/contributing/fuzzing.md
@@ -3,7 +3,7 @@ sidebar_position: 12
 title: Fuzzing and Property-Based Testing
 description: Running fuzz targets and property-based tests for Python and TypeScript code
 author: Microsoft Robotics-AI Team
-ms.date: 2026-07-18
+ms.date: 2026-04-15
 ms.topic: how-to
 keywords:
   - fuzzing

--- a/docs/fleet-intelligence/README.md
+++ b/docs/fleet-intelligence/README.md
@@ -25,8 +25,8 @@ Fleet-wide telemetry collection, operational dashboards, drift detection, and au
 
 ## 📖 Related Documentation
 
-| Guide                                                                                                     | Description                           |
-|-----------------------------------------------------------------------------------------------------------|---------------------------------------|
+| Guide                                                                                                                                                            | Description                           |
+|------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------|
 | [Telemetry Specification](https://github.com/microsoft/physical-ai-toolchain/blob/main/fleet-intelligence/specifications/telemetry.specification.md)             | Schema and routing architecture       |
 | [Dashboard Specification](https://github.com/microsoft/physical-ai-toolchain/blob/main/fleet-intelligence/specifications/dashboards.specification.md)            | Fleet dashboard and alerting design   |
 | [Drift Detection Specification](https://github.com/microsoft/physical-ai-toolchain/blob/main/fleet-intelligence/specifications/drift-detection.specification.md) | Detection algorithms and thresholds   |

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -3,7 +3,7 @@ sidebar_position: 2
 title: "Quickstart: Clone to First Training Job"
 description: Deploy infrastructure and submit your first robotics training job in 9 steps
 author: Microsoft Robotics-AI Team
-ms.date: 2026-02-22
+ms.date: 2026-04-15
 ms.topic: tutorial
 keywords:
   - quickstart

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -1,7 +1,7 @@
 ---
 sidebar_position: 2
 title: "Quickstart: Clone to First Training Job"
-description: Deploy infrastructure and submit your first robotics training job in 8 steps
+description: Deploy infrastructure and submit your first robotics training job in 9 steps
 author: Microsoft Robotics-AI Team
 ms.date: 2026-02-22
 ms.topic: tutorial
@@ -19,12 +19,12 @@ Deploy the full Azure NVIDIA Robotics stack and submit a training job in ~1.5-2 
 
 ## Prerequisites
 
-| Requirement             | Details                                          |
-|-------------------------|--------------------------------------------------|
-| Azure subscription      | Contributor + User Access Administrator roles    |
-| GPU quota               | `Standard_NC24ads_A100_v4` in target region      |
-| NVIDIA NGC account      | Sign up at <https://ngc.nvidia.com/> for API key |
-| Development environment | Devcontainer (recommended) or local tools        |
+| Requirement             | Details                                                                                             |
+|-------------------------|-----------------------------------------------------------------------------------------------------|
+| Azure subscription      | Contributor + User Access Administrator roles                                                       |
+| GPU quota               | `Standard_NV36ads_A10_v5` (A10 Spot, default) or `Standard_NC40ads_H100_v5` (H100) in target region |
+| NVIDIA NGC account      | Sign up at <https://ngc.nvidia.com/> for API key                                                    |
+| Development environment | Devcontainer (recommended) or local tools                                                           |
 
 See [Prerequisites](../contributing/prerequisites.md) for installation commands and version requirements.
 
@@ -67,22 +67,52 @@ cd infrastructure/terraform
 cp terraform.tfvars.example terraform.tfvars
 ```
 
-Edit `terraform.tfvars` with these values:
+Edit `terraform.tfvars` with your values:
 
 ```hcl
-project_name = "robotics"
-environment  = "dev"
-location     = "eastus"
-gpu_vm_size  = "Standard_NC24ads_A100_v4"
+environment     = "dev"
+location        = "westus3"
+resource_prefix = "yourprefix"
+instance        = "001"
 
-enable_azure_ml    = true
-enable_osmo        = true
-enable_vpn_gateway = false
-enable_private_dns = false
+// Full-public networking (simplest path for inner developer loop)
+should_enable_private_endpoint      = false
+should_enable_private_aks_cluster   = false
+should_enable_public_network_access = true
+
+// Single GPU pool (Spot A10)
+node_pools = {
+  gpu = {
+    vm_size                    = "Standard_NV36ads_A10_v5"
+    subnet_address_prefixes    = ["10.0.7.0/24"]
+    node_taints                = ["nvidia.com/gpu:NoSchedule", "kubernetes.azure.com/scalesetpriority=spot:NoSchedule"]
+    gpu_driver                 = "Install"
+    priority                   = "Spot"
+    should_enable_auto_scaling = true
+    min_count                  = 1
+    max_count                  = 1
+    zones                      = []
+    eviction_policy            = "Delete"
+  }
+}
+
+// System node pool — enable autoscaling for OSMO workloads
+should_enable_system_node_pool_auto_scaling = true
+system_node_pool_min_count                  = 1
+system_node_pool_max_count                  = 3
+
+// OSMO Backend Services
+should_deploy_postgresql = true
+should_deploy_redis      = true
 ```
 
+> [!WARNING]
+> `resource_prefix` must be lowercase, alphanumeric, and short (6-8 characters recommended). It feeds into Key Vault (`kv{prefix}{env}{instance}`) and Storage Account names that have 24-character limits and must be globally unique.
+
+<!-- markdownlint-disable-next-line MD028 -->
+
 > [!TIP]
-> For private networking, set `enable_vpn_gateway = true` and `enable_private_dns = true`. See the [Infrastructure Guide](https://github.com/microsoft/physical-ai-toolchain/blob/main/infrastructure/terraform/README.md) for details.
+> For private networking, set `should_enable_private_endpoint = true` and `should_enable_private_aks_cluster = true`, then deploy the VPN from `infrastructure/terraform/vpn/` before running any `kubectl` commands. See the [Infrastructure Guide](../infrastructure/README.md) for details.
 
 ## Step 4: Deploy Infrastructure
 
@@ -104,19 +134,32 @@ Connect to the AKS cluster:
 
 ```bash
 az aks get-credentials \
-  --resource-group "$(terraform output -raw resource_group_name)" \
-  --name "$(terraform output -raw aks_cluster_name)"
+  --resource-group "$(terraform output -json resource_group | jq -r '.name')" \
+  --name "$(terraform output -json aks_cluster | jq -r '.name')"
 ```
 
-## Step 5: Configure AKS Cluster
+## Step 5: Set NGC API Key
+
+Export your NVIDIA NGC API key for OSMO backend deployment. Obtain a key from <https://ngc.nvidia.com/>.
+
+```bash
+export NGC_API_KEY="<your-ngc-api-key>"
+```
+
+## Step 6: Configure AKS Cluster
 
 Deploy GPU Operator, KAI Scheduler, and the AzureML extension. From the repository root:
 
 ```bash
 cd infrastructure/setup
+bash 01-deploy-robotics-charts.sh --config-preview
 bash 01-deploy-robotics-charts.sh
+bash 02-deploy-azureml-extension.sh --config-preview
 bash 02-deploy-azureml-extension.sh
 ```
+
+> [!TIP]
+> All setup scripts support `--config-preview` to print configuration and exit without changes. Run it before each real deployment to verify values.
 
 Verify GPU operator pods:
 
@@ -124,47 +167,69 @@ Verify GPU operator pods:
 kubectl get pods -n gpu-operator
 ```
 
-## Step 6: Deploy OSMO Components
+## Step 7: Deploy OSMO Components
 
 Deploy the OSMO control plane and backend using Access Keys authentication.
 
 ```bash
+bash 03-deploy-osmo-control-plane.sh --config-preview
 bash 03-deploy-osmo-control-plane.sh
-bash 04-deploy-osmo-backend.sh --use-access-keys
+```
+
+> [!IMPORTANT]
+> When running from a **devcontainer or codespace**, the OSMO service URL is an internal load balancer IP only reachable from within the AKS VNet. Set up a port-forward before running the backend script:
+>
+> ```bash
+> kubectl port-forward svc/osmo-service -n osmo-control-plane 8080:80 &
+> ```
+>
+> Then pass `--service-url http://localhost:8080` to both scripts 03 and 04. The scripts detect unreachable URLs and print this guidance automatically.
+
+```bash
+bash 04-deploy-osmo-backend.sh --use-access-keys --service-url http://localhost:8080 --config-preview
+bash 04-deploy-osmo-backend.sh --use-access-keys --service-url http://localhost:8080
 ```
 
 Verify OSMO pods:
 
 ```bash
 kubectl get pods -n osmo-control-plane
+kubectl get pods -n osmo-operator
 ```
 
-## Step 7: Submit First Training Job
+## Step 8: Submit First Training Job
 
-Navigate to the scripts directory and submit a training job. From the repository root:
+Submit a training job from the repository root:
 
 ```bash
-cd scripts
-bash submit-osmo-training.sh
+bash training/rl/scripts/submit-osmo-training.sh
 ```
 
 Scripts auto-detect configuration from Terraform outputs. Override values with CLI arguments or environment variables as needed. See [Scripts Reference](../reference/scripts.md) for all submission options.
 
-## Step 8: Verify Results
+## Step 9: Verify Results
 
 Confirm the training job is running:
 
 ```bash
-kubectl get pods -n osmo-control-plane --watch
+kubectl get pods -n osmo-workflows --watch
 ```
 
 Check OSMO training status through the OSMO web UI or query pod logs:
 
 ```bash
-kubectl logs -n osmo-control-plane -l app=osmo-training --tail=50
+kubectl logs -n osmo-workflows -l app=osmo-training --tail=50
 ```
 
 ## Cleanup
+
+Remove OSMO Helm releases before destroying infrastructure to avoid orphaned resources:
+
+```bash
+cd infrastructure/setup
+helm uninstall osmo-operator -n osmo-operator --ignore-not-found
+helm uninstall service router ui -n osmo-control-plane --ignore-not-found
+```
 
 Destroy all infrastructure when finished to stop incurring costs. From the repository root:
 
@@ -177,8 +242,8 @@ See [Cost Considerations](../contributing/cost-considerations.md) for detailed p
 
 ## Next Steps
 
-| Resource                                                                                          | Description                               |
-|---------------------------------------------------------------------------------------------------|-------------------------------------------|
-| [MLflow Integration](../training/mlflow-integration.md)                                           | Track experiments with MLflow             |
-| [Deployment Guide](https://github.com/microsoft/physical-ai-toolchain/blob/main/deploy/README.md) | Full deployment reference and options     |
-| [Contributing Guide](../contributing/README.md)                                                   | Development workflow and code standards   |
+| Resource                                                | Description                             |
+|---------------------------------------------------------|-----------------------------------------|
+| [MLflow Integration](../training/mlflow-integration.md) | Track experiments with MLflow           |
+| [Infrastructure Guide](../infrastructure/README.md)     | Full deployment reference and options   |
+| [Contributing Guide](../contributing/README.md)         | Development workflow and code standards |

--- a/docs/infrastructure/cluster-setup-advanced.md
+++ b/docs/infrastructure/cluster-setup-advanced.md
@@ -27,12 +27,12 @@ When connected to VPN, OSMO services are accessible via the internal load balanc
 
 | Service      | URL                   |
 |--------------|-----------------------|
-| UI Dashboard | `http://10.0.5.7`     |
-| API Service  | `http://10.0.5.7/api` |
+| UI Dashboard | `http://10.0.5.6`     |
+| API Service  | `http://10.0.5.6/api` |
 
 ```bash
 # Login to OSMO via internal load balancer
-osmo login http://10.0.5.7 --method=dev --username=testuser
+osmo login http://10.0.5.6 --method=dev --username=testuser
 
 # Verify connection
 osmo info
@@ -40,7 +40,22 @@ osmo backend list
 ```
 
 > [!NOTE]
-> The internal load balancer IP (`10.0.5.7`) is assigned by the AzureML nginx ingress controller. Verify the actual IP with: `kubectl get svc -n azureml azureml-nginx-ingress -o jsonpath='{.status.loadBalancer.ingress[0].ip}'`
+> The internal load balancer IP is assigned by the AzureML nginx ingress controller. Verify the actual IP with:
+>
+> ```bash
+> kubectl get svc azureml-ingress-nginx-internal-lb -n azureml \
+>   -o jsonpath='{.status.loadBalancer.ingress[0].ip}'
+> ```
+
+<!-- markdownlint-disable-next-line MD028 -->
+
+> [!IMPORTANT]
+> The OSMO `SERVICE` config `service_base_url` controls both workflow pod routing (osmo-ctrl sidecar) and UI workflow links. For full functionality:
+>
+> - **With VPN:** Set `service_base_url` to the internal LB IP (e.g., `http://10.0.5.6`). Workflow execution and UI log viewing both work.
+> - **Without VPN:** Set `service_base_url` to the in-cluster ingress FQDN (`http://azureml-ingress-nginx-controller.azureml.svc.cluster.local`). Workflow execution works, but the UI cannot display logs or events (the browser cannot resolve the FQDN). Use `osmo workflow logs <id>` instead.
+>
+> See [Troubleshooting](../operations/troubleshooting.md#osmo-workflow-completes-task-but-workflow-status-stays-running-or-fails) for details.
 
 ### Via Port-Forward (Public Cluster without VPN)
 

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -3,7 +3,7 @@ sidebar_position: 1
 title: Operations Hub
 description: Centralized guide for operating, monitoring, and troubleshooting the robotics reference architecture on Azure and NVIDIA infrastructure
 author: Microsoft Robotics-AI Team
-ms.date: 2026-03-09
+ms.date: 2026-04-15
 ms.topic: overview
 keywords:
   - operations

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -18,13 +18,13 @@ Centralized hub for operational documentation covering monitoring, troubleshooti
 
 ## 📖 Operations Guides
 
-| Guide                                                                     | Description                                                              |
-|---------------------------------------------------------------------------|--------------------------------------------------------------------------|
-| [Troubleshooting](troubleshooting.md)                                     | Symptom-based resolution for common deployment, GPU, and workflow errors |
-| [Security Guide](security-guide.md)                                       | Security configuration inventory and deployment checklist                |
-| [GPU Configuration](../reference/gpu-configuration.md)                    | Driver selection, MIG strategy, and GPU Operator configuration           |
-| [Deployment Validation](../contributing/deployment-validation.md)         | Post-deployment verification steps                                       |
-| [Cost Considerations](../contributing/cost-considerations.md)             | Azure resource cost guidance                                             |
+| Guide                                                             | Description                                                              |
+|-------------------------------------------------------------------|--------------------------------------------------------------------------|
+| [Troubleshooting](troubleshooting.md)                             | Symptom-based resolution for common deployment, GPU, and workflow errors |
+| [Security Guide](security-guide.md)                               | Security configuration inventory and deployment checklist                |
+| [GPU Configuration](../reference/gpu-configuration.md)            | Driver selection, MIG strategy, and GPU Operator configuration           |
+| [Deployment Validation](../contributing/deployment-validation.md) | Post-deployment verification steps                                       |
+| [Cost Considerations](../contributing/cost-considerations.md)     | Azure resource cost guidance                                             |
 
 ## 📋 Operational Overview
 

--- a/docs/operations/troubleshooting.md
+++ b/docs/operations/troubleshooting.md
@@ -272,6 +272,65 @@ Convert all template expressions to Jinja syntax. For variable substitution, use
 2. Verify node taints and tolerations match the pod spec.
 3. Check namespace resource quotas: `kubectl get resourcequota -n osmo-workflows`.
 
+### OSMO workflow completes task but workflow status stays RUNNING or fails
+
+**Cause:** The `service_base_url` field in the OSMO `SERVICE` config is empty or points to a service that does not route `/api/logger` paths. The osmo-ctrl sidecar in workflow pods uses this URL to connect via WebSocket to the logger service and to refresh auth tokens. When misconfigured, the sidecar logs `websocket: bad handshake` or connection refused errors, preventing the workflow from reporting completion.
+
+**Resolution:**
+
+1. Inspect the osmo-ctrl sidecar arguments on a workflow pod:
+
+   ```bash
+   kubectl get pod <pod> -n osmo-workflows -o json | \
+     python3 -c "import sys,json; [print(a) for c in json.load(sys.stdin)['spec']['containers'] if c['name']=='osmo-ctrl' for a in c.get('args',[])]"
+   ```
+
+2. If `-host` is empty (`""`), the `service_base_url` in the SERVICE config is not set:
+
+   ```bash
+   osmo config show SERVICE | grep service_base_url
+   ```
+
+3. Set `service_base_url` to the AzureML ingress controller ClusterIP FQDN:
+
+   ```bash
+   osmo config show SERVICE | python3 -c "
+   import sys, json
+   c = json.load(sys.stdin)
+   c['service_base_url'] = 'http://azureml-ingress-nginx-controller.azureml.svc.cluster.local'
+   json.dump(c, sys.stdout, indent=2)" > /tmp/service-config.json
+   osmo config update SERVICE --file /tmp/service-config.json --description "Set service base URL"
+   ```
+
+4. Cancel and resubmit the workflow. New pods pick up the updated `service_base_url`.
+
+> [!WARNING]
+> Do not set `service_base_url` to `osmo-router`. The router only handles `/api/router/` paths. The ingress controller routes all API paths (`/api/logger`, `/api/agent`, `/api/auth`, `/api`) to the correct backend services.
+
+### OSMO UI shows "server IP address could not be found" for workflow logs
+
+**Cause:** The `service_base_url` is set to an in-cluster FQDN (e.g., `azureml-ingress-nginx-controller.azureml.svc.cluster.local`) that the browser cannot resolve. The OSMO UI constructs workflow overview URLs from this value.
+
+**Resolution:**
+
+Connect via VPN and set `service_base_url` to the internal load balancer IP, which is reachable from both in-cluster pods and the VPN-connected browser:
+
+```bash
+# Find the internal LB IP
+kubectl get svc azureml-ingress-nginx-internal-lb -n azureml \
+  -o jsonpath='{.status.loadBalancer.ingress[0].ip}'
+
+# Update service_base_url to the internal LB IP
+osmo config show SERVICE | python3 -c "
+import sys, json
+c = json.load(sys.stdin)
+c['service_base_url'] = 'http://10.0.5.6'  # replace with actual IP
+json.dump(c, sys.stdout, indent=2)" > /tmp/service-config.json
+osmo config update SERVICE --file /tmp/service-config.json --description "Set service base URL to internal LB"
+```
+
+Without VPN, use the CLI to view workflow logs: `osmo workflow logs <workflow-id>`.
+
 ## Additional Resources
 
 - [GPU Configuration](../reference/gpu-configuration.md)

--- a/docs/operations/troubleshooting.md
+++ b/docs/operations/troubleshooting.md
@@ -3,7 +3,7 @@ sidebar_position: 4
 title: Troubleshooting Guide
 description: Symptom-based resolution guide for common errors in the robotics reference architecture
 author: Microsoft Robotics-AI Team
-ms.date: 2026-03-09
+ms.date: 2026-04-15
 ms.topic: troubleshooting
 keywords:
   - troubleshooting

--- a/infrastructure/setup/03-deploy-osmo-control-plane.sh
+++ b/infrastructure/setup/03-deploy-osmo-control-plane.sh
@@ -339,13 +339,15 @@ if [[ "$skip_service_config" == "false" ]]; then
   kubectl wait --for=condition=available deployment/osmo-service -n "$NS_OSMO_CONTROL_PLANE" --timeout=120s
 
   service_url=$(detect_service_url)
-  if [[ -n "$service_url" ]]; then
+  ingress_base_url=$(detect_ingress_base_url "$NS_AZUREML")
+  if [[ -n "$service_url" && -n "$ingress_base_url" ]]; then
+    validate_service_url_reachable "$service_url"
     [[ -f "$service_config_template" ]] || fatal "Service config template not found: $service_config_template"
-    export SERVICE_BASE_URL="$service_url"
+    export SERVICE_BASE_URL="$ingress_base_url"
     envsubst < "$service_config_template" > "$CONFIG_DIR/out/service-config.json"
     osmo_login_and_setup "$service_url"
-    info "Applying service configuration (service_base_url: $service_url)..."
-    osmo config update SERVICE --file "$CONFIG_DIR/out/service-config.json" --description "Set service base URL for UI"
+    info "Applying service configuration (service_base_url: $ingress_base_url)..."
+    osmo config update SERVICE --file "$CONFIG_DIR/out/service-config.json" --description "Set service base URL to ingress controller FQDN"
   else
     warn "Could not determine service base URL - OSMO UI may show errors"
   fi

--- a/infrastructure/setup/04-deploy-osmo-backend.sh
+++ b/infrastructure/setup/04-deploy-osmo-backend.sh
@@ -112,11 +112,21 @@ az account show &>/dev/null || fatal "Azure CLI not logged in; run 'az login'"
 # Gather Configuration
 #------------------------------------------------------------------------------
 
+# Resolve in-cluster URL (for Helm/pods) separately from CLI URL (for osmo commands).
+# When --service-url points to a port-forward (localhost), detect the real in-cluster URL.
+cluster_service_url=$(detect_service_url)
+
 if [[ -z "$service_url" ]]; then
   info "Auto-detecting OSMO service URL..."
-  service_url=$(detect_service_url)
+  service_url="${cluster_service_url}"
   [[ -z "$service_url" ]] && fatal "Could not detect service URL. Run 03-deploy-osmo-control-plane.sh first or provide --service-url"
+  validate_service_url_reachable "$service_url"
   info "Detected: $service_url"
+else
+  # --service-url provided (likely port-forward); use detected in-cluster URL for Helm
+  if [[ -z "$cluster_service_url" ]]; then
+    cluster_service_url="$service_url"
+  fi
 fi
 
 info "Reading terraform outputs from $tf_dir..."
@@ -229,15 +239,16 @@ kubectl get secret "$account_secret" -n "$NS_OSMO_OPERATOR" &>/dev/null && token
 
 if [[ "$regenerate_token" == "true" || "$token_exists" == "false" ]]; then
   token_name="backend-token-$(date -u +%Y%m%d%H%M%S)"
-  info "Generating OSMO service token $token_name..."
+  info "Generating OSMO service token $token_name (expires $expiry_date)..."
 
-  token_json=$(osmo token set "$token_name" \
-    --expires-at "$expiry_date" \
-    --description "Backend Operator Token" \
-    --roles osmo-backend -t json)
+  # Create service access token via OSMO API (works with auth.enabled=false via x-osmo-user header)
+  OSMO_SERVICE_TOKEN=$(curl -sf -X POST \
+    "${service_url}/api/auth/access_token/service/${token_name}?expires_at=${expiry_date}&roles=osmo-backend" \
+    -H "x-osmo-user: admin")
 
-  OSMO_SERVICE_TOKEN=$(echo "$token_json" | jq -r '.token // empty')
-  [[ -z "$OSMO_SERVICE_TOKEN" ]] && fatal "Failed to obtain service token"
+  # Strip surrounding quotes from JSON string response
+  OSMO_SERVICE_TOKEN="${OSMO_SERVICE_TOKEN//\"/}"
+  [[ -z "$OSMO_SERVICE_TOKEN" ]] && fatal "Failed to obtain service token from ${service_url}"
   export OSMO_SERVICE_TOKEN
 
   kubectl create secret generic "$account_secret" \
@@ -277,6 +288,10 @@ fi
 #------------------------------------------------------------------------------
 section "Deploy Backend Operator"
 
+# Backend operator connects to the agent service (which has both auth and WebSocket endpoints)
+agent_service_url="http://osmo-agent.${NS_OSMO_CONTROL_PLANE}.svc.cluster.local"
+info "Agent service URL: $agent_service_url"
+
 if [[ "$use_acr" == "true" ]]; then
   login_acr "$acr_name"
 else
@@ -296,7 +311,7 @@ helm_args=(
   --version "$chart_version"
   --namespace "$NS_OSMO_OPERATOR"
   --set-string "global.osmoImageTag=$image_version"
-  --set-string "global.serviceUrl=$service_url"
+  --set-string "global.serviceUrl=$agent_service_url"
   --set-string "global.agentNamespace=$NS_OSMO_OPERATOR"
   --set-string "global.backendNamespace=$NS_OSMO_WORKFLOWS"
   --set-string "global.backendName=$backend_name"

--- a/infrastructure/setup/values/osmo-backend-operator.yaml
+++ b/infrastructure/setup/values/osmo-backend-operator.yaml
@@ -1,6 +1,6 @@
 global:
-  osmoImageTag: "<osmo-image-tag>"
-  serviceUrl: "https://<your-domain>"
+  osmoImageTag: "6.0.0"
+  serviceUrl: "http://osmo-agent.osmo-control-plane.svc.cluster.local"
   agentNamespace: "osmo-operator"
   backendNamespace: "osmo-workflows"
   backendName: "default"

--- a/infrastructure/terraform/modules/platform/postgresql.tf
+++ b/infrastructure/terraform/modules/platform/postgresql.tf
@@ -58,7 +58,7 @@ resource "azurerm_postgresql_flexible_server" "main" {
   zone                          = var.postgresql_config.zone
   backup_retention_days         = 7
   geo_redundant_backup_enabled  = false
-  public_network_access_enabled = false
+  public_network_access_enabled = var.should_enable_public_network_access
 
   dynamic "high_availability" {
     for_each = var.postgresql_config.should_enable_high_availability ? [1] : []
@@ -99,6 +99,32 @@ resource "azurerm_private_endpoint" "postgresql" {
 }
 
 // ============================================================
+// PostgreSQL Firewall Rules
+// ============================================================
+
+// Allow Azure services (0.0.0.0/0.0.0.0) when public network access is enabled.
+// Required for AKS pods to reach PostgreSQL without private endpoints.
+resource "azurerm_postgresql_flexible_server_firewall_rule" "allow_azure_services" {
+  count = var.should_deploy_postgresql && var.should_enable_public_network_access ? 1 : 0
+
+  name             = "AllowAzureServices"
+  server_id        = azurerm_postgresql_flexible_server.main[0].id
+  start_ip_address = "0.0.0.0"
+  end_ip_address   = "0.0.0.0"
+}
+
+// Allow only the AKS NAT Gateway egress IP when private endpoints are disabled.
+// Tighter than AllowAzureServices; both rules coexist for defense-in-depth.
+resource "azurerm_postgresql_flexible_server_firewall_rule" "aks_egress" {
+  count = var.should_deploy_postgresql && var.should_enable_public_network_access && !local.pe_enabled && var.should_enable_nat_gateway ? 1 : 0
+
+  name             = "aks-nat-gateway-egress"
+  server_id        = azurerm_postgresql_flexible_server.main[0].id
+  start_ip_address = azurerm_public_ip.nat_gateway[0].ip_address
+  end_ip_address   = azurerm_public_ip.nat_gateway[0].ip_address
+}
+
+// ============================================================
 // PostgreSQL Configuration - Required Extensions
 // ============================================================
 
@@ -109,7 +135,11 @@ resource "azurerm_postgresql_flexible_server_configuration" "extensions" {
   server_id = azurerm_postgresql_flexible_server.main[0].id
   value     = "HSTORE,UUID-OSSP,PG_STAT_STATEMENTS"
 
-  depends_on = [azurerm_private_endpoint.postgresql]
+  depends_on = [
+    azurerm_private_endpoint.postgresql,
+    azurerm_postgresql_flexible_server_firewall_rule.allow_azure_services,
+    azurerm_postgresql_flexible_server_firewall_rule.aks_egress
+  ]
 }
 
 // ============================================================

--- a/infrastructure/terraform/terraform.tfvars.example
+++ b/infrastructure/terraform/terraform.tfvars.example
@@ -106,6 +106,10 @@ should_deploy_redis      = true
 should_enable_private_endpoint    = true
 should_enable_private_aks_cluster = true
 
+// Public network access: Controls public access to Azure ML, Storage, Key Vault, ACR,
+// Redis, PostgreSQL, and observability resources. When true, also creates a PostgreSQL
+// firewall rule to allow Azure services (required for AKS-to-PostgreSQL connectivity
+// without private endpoints).
 should_enable_public_network_access     = true
 should_add_current_user_key_vault_admin = true
 should_enable_microsoft_defender        = true

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -142,7 +142,7 @@ detect_osmo_identity() {
   echo "$client_id"
 }
 
-# Detect OSMO service URL from cluster
+# Detect OSMO service URL from cluster (for CLI and external access)
 detect_service_url() {
   local url=""
   # Try internal load balancer first
@@ -161,6 +161,36 @@ detect_service_url() {
     fi
   fi
   echo "$url"
+}
+
+# Detect in-cluster ingress FQDN for service_base_url (used by osmo-ctrl sidecars in workflow pods)
+detect_ingress_base_url() {
+  local ns="${1:-azureml}"
+  local svc="azureml-ingress-nginx-controller"
+  if kubectl get svc "$svc" -n "$ns" &>/dev/null; then
+    echo "http://${svc}.${ns}.svc.cluster.local"
+  fi
+}
+
+# Validate that the OSMO service URL is reachable from the current host.
+# Internal load balancer IPs are only accessible from within the VNet; when running
+# from a devcontainer or codespace, users must port-forward instead.
+validate_service_url_reachable() {
+  local url="${1:?service URL required}"
+
+  if curl -sf --connect-timeout 5 "${url}/api/version" >/dev/null 2>&1; then
+    return 0
+  fi
+
+  warn "OSMO service URL $url is not reachable from this host"
+  warn "The auto-detected URL is an internal load balancer IP only accessible from within the AKS VNet."
+  echo >&2
+  warn "If running from a devcontainer or codespace, use kubectl port-forward:"
+  warn "  kubectl port-forward svc/osmo-service -n osmo-control-plane 8080:80 &"
+  warn "Then re-run this script with:"
+  warn "  --service-url http://localhost:8080"
+  echo >&2
+  fatal "Cannot reach OSMO service at $url"
 }
 
 detect_default_storage_class() {
@@ -276,8 +306,9 @@ apply_secret_provider_class() {
   local include_redis_secret="${5:-true}"
 
   local manifest_dir
-  # BASH_SOURCE preserves the symlinked setup/lib path, so ../manifests resolves correctly.
-  manifest_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/manifests"
+  local _repo_root
+  _repo_root="$(git rev-parse --show-toplevel 2>/dev/null || (cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd))"
+  manifest_dir="${_repo_root}/infrastructure/setup/manifests"
   local manifest_name="aks-secret-provider-class.yaml"
 
   [[ "$include_redis_secret" == "true" ]] && manifest_name="aks-secret-provider-class-external-redis.yaml"


### PR DESCRIPTION
Fixed end-to-end OSMO workflow execution by resolving the empty `service_base_url` that prevented osmo-ctrl sidecars from connecting to the logger WebSocket. Added PostgreSQL public network access support driven by `should_enable_public_network_access`, and corrected the quickstart guide with accurate variables, paths, namespaces, and deployment steps validated against a live cluster.

Closes #476
Closes #470

## Type of Change

- [x] 🐛 Bug fix (non-breaking change fixing an issue)
- [ ] ✨ New feature (non-breaking change adding functionality)
- [ ] 💥 Breaking change (fix or feature causing existing functionality to change)
- [x] 📚 Documentation update
- [x] 🏗️ Infrastructure change (Terraform/IaC)
- [ ] ♻️ Refactoring (no functional changes)

## Component(s) Affected

- [ ] `infrastructure/terraform/prerequisites/` - Azure subscription setup
- [x] `infrastructure/terraform/` - Terraform infrastructure
- [x] `infrastructure/setup/` - OSMO control plane / Helm
- [ ] `workflows/` - Training and evaluation workflows
- [ ] `training/` - Training pipelines and scripts
- [x] `docs/` - Documentation

## Testing Performed

- [x] Terraform `plan` reviewed (no unexpected changes)
- [x] Terraform `apply` tested in dev environment
- [ ] Training scripts tested locally with Isaac Sim
- [x] OSMO workflow submitted successfully
- [ ] Smoke tests passed (`smoke_test_azure.py`)

Validated against live cluster `aks-osmo-dev-001` with OSMO v6.0.0 in `westus2`. Workflow `hello-osmo-7` completed successfully after the `service_base_url` fix. PostgreSQL connectivity verified from AKS pods with public access enabled. All Terraform, shellcheck, and markdownlint validations pass.

## Documentation Impact

- [ ] No documentation changes needed
- [x] Documentation updated in this PR
- [ ] Documentation issue filed

## Bug Fix Checklist

- [x] Linked to issue being fixed
- [ ] Regression test included, OR
- [x] Justification for no regression test: Infrastructure and deploy script changes validated via live cluster deployment and `terraform validate`. Quickstart corrections verified by cross-referencing against actual source files.

## Description

### OSMO Service URL and Workflow Execution

> Workflow pods failed silently because the `service_base_url` in the OSMO SERVICE config was empty, leaving the osmo-ctrl sidecar's `-host` argument blank and preventing WebSocket connections to the logger service.

- Added **`detect_ingress_base_url()`** to *scripts/lib/common.sh* — returns the AzureML nginx ingress controller in-cluster FQDN (`http://azureml-ingress-nginx-controller.azureml.svc.cluster.local`) for osmo-ctrl sidecar routing
- Updated *03-deploy-osmo-control-plane.sh* to set `SERVICE_BASE_URL` from the ingress FQDN instead of the external LB IP, ensuring workflow pods route `/api/logger`, `/api/auth`, and `/api` paths correctly
- Added **`validate_service_url_reachable()`** to *scripts/lib/common.sh* — probes the service URL with a 5-second timeout and prints actionable `kubectl port-forward` guidance when unreachable
- Wired `validate_service_url_reachable` into both *03-deploy-osmo-control-plane.sh* and *04-deploy-osmo-backend.sh*
- Split **`cluster_service_url`** from CLI URL in *04-deploy-osmo-backend.sh* so `--service-url http://localhost:8080` works for port-forwarded CLI calls while Helm uses the in-cluster `agent_service_url` for pods

### PostgreSQL Public Network Access

- Changed `public_network_access_enabled` in *infrastructure/terraform/modules/platform/postgresql.tf* from hardcoded `false` to `var.should_enable_public_network_access`, aligning with other resources (Storage, Redis, Key Vault, ACR)
- Added **`AllowAzureServices`** firewall rule (0.0.0.0/0.0.0.0) when public access is enabled, allowing AKS pods to reach PostgreSQL without private endpoints
- Added **`aks_egress`** firewall rule scoped to the NAT Gateway public IP when `!pe_enabled && nat_gw`, for tighter production configurations
- Documented `should_enable_public_network_access` behavior in both *terraform.tfvars* and *terraform.tfvars.example*

### Quickstart Guide Corrections

Rewrote *docs/getting-started/quickstart.md* with corrections validated against the actual codebase:

- Replaced fictional Terraform variables (`project_name`, `enable_*`) with actual inputs (`resource_prefix`, `should_*`)
- Fixed **Terraform output access** from `-raw resource_group_name` to `-json resource_group | jq -r '.name'`
- Corrected **training script path** from `scripts/submit-osmo-training.sh` to `training/rl/scripts/submit-osmo-training.sh`
- Changed training pod **namespace** from `osmo-control-plane` to `osmo-workflows`
- Updated default **GPU SKU** to `Standard_NV36ads_A10_v5` (A10 Spot)
- Added **Step 5: Set NGC API Key** and `--config-preview` dry-run commands
- Added `resource_prefix` naming constraints warning and Helm cleanup before `terraform destroy`
- Added devcontainer port-forward guidance for scripts 03 and 04

### Troubleshooting and Operations Docs

- Added two entries to *docs/operations/troubleshooting.md*: "workflow completes but status stays RUNNING" (empty `service_base_url`) and "UI shows server IP not found" (FQDN vs browser resolution)
- Corrected internal LB IP from `10.0.5.7` to `10.0.5.6` in *docs/infrastructure/cluster-setup-advanced.md* and fixed the service name reference
- Added `[!IMPORTANT]` callout explaining `service_base_url` VPN vs non-VPN behavior

### Table Formatting

Ran `npm run format:tables` across 6 documentation files — column-width normalization only, no content changes.

## Related Issues

Closes #476
Closes #470
Subsumes PR #471 by @katriendg

## Notes

- The `AllowAzureServices` PostgreSQL firewall rule is intentionally broad for development scenarios. For production, disable it and rely on the NAT Gateway egress rule or private endpoints.
- The OSMO backend values file (*osmo-backend-operator.yaml*) was updated from placeholder values to concrete `6.0.0` image tag and in-cluster agent URL. These are overridden by Helm `--set-string` flags at deploy time.

## Checklist

- [x] My code follows the [project conventions](copilot-instructions.md)
- [x] Commit messages follow [conventional commit format](instructions/commit-message.instructions.md)
- [x] I have performed a self-review
- [x] Documentation impact assessed above
- [x] No new linting warnings introduced
