### PR TITLE
fix(ci): restore data-pipeline and training broken tests by domain folder restructure

### DIFF
--- a/data-pipeline/capture/tests/test_config_models_hypothesis.py
+++ b/data-pipeline/capture/tests/test_config_models_hypothesis.py
@@ -1,9 +1,20 @@
 """Hypothesis property-based tests for ROS 2 edge recording configuration models."""
 
+import sys
 import tempfile
+from pathlib import Path
 
 import pytest
-from common.config_models import (
+from hypothesis import assume, given
+from hypothesis import strategies as st
+from pydantic import ValidationError
+
+# data-pipeline contains a hyphen, making it an invalid Python package name.
+_CAPTURE_DIR = str(Path(__file__).resolve().parent.parent)
+if _CAPTURE_DIR not in sys.path:
+    sys.path.insert(0, _CAPTURE_DIR)
+
+from models.config_models import (
     DiskThresholds,
     GapDetectionConfig,
     GpioTriggerConfig,
@@ -12,9 +23,6 @@ from common.config_models import (
     TopicConfig,
     VrTriggerConfig,
 )
-from hypothesis import assume, given
-from hypothesis import strategies as st
-from pydantic import ValidationError
 
 
 @given(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,7 @@ select = [
 "training/rl/scripts/rsl_rl/*.py" = ["E402"]
 "data-management/viewer/backend/tests/*.py" = ["E402"]
 "data-pipeline/capture/tests/test_config_models.py" = ["E402"]
+"data-pipeline/capture/tests/test_config_models_hypothesis.py" = ["E402"]
 
 [tool.ruff.lint.isort]
 known-first-party = ["training"]

--- a/training/tests/test_cli_args.py
+++ b/training/tests/test_cli_args.py
@@ -6,7 +6,12 @@ import argparse
 from types import SimpleNamespace
 
 import pytest
-from common.cli_args import add_rsl_rl_args, update_rsl_rl_cfg
+
+from .conftest import load_training_module
+
+_CLI_ARGS = load_training_module("training_rl_cli_args", "training/rl/cli_args.py")
+add_rsl_rl_args = _CLI_ARGS.add_rsl_rl_args
+update_rsl_rl_cfg = _CLI_ARGS.update_rsl_rl_cfg
 
 
 class TestAddRslRlArgs:


### PR DESCRIPTION
## Description

Restores `pytest-data-pipeline` and `pytest-training` CI workflows by fixing broken imports in two test modules. The failures originated from PR #270's domain-driven architecture refactor, which removed the `common/` package. PR validation missed the issue because the path filter gates `pytest-data-pipeline` on `data-pipeline/capture/` changes—subsequent PRs touching only `training/` skipped the job, but `main.yml` runs it unconditionally.

**Key changes:**
- Relocated `test_cli_args.py` from `data-pipeline/capture/tests/` to `training/tests/` (tests RSL-RL CLI, not data-pipeline)
- Fixed `test_config_models_hypothesis.py` import by switching to `sys.path` + `models.config_models` pattern used by sibling test
- Added matching E402 ruff exemption for the hypothesis test

Fixes #546

## Type of Change

- [x] 🐛 Bug fix (non-breaking change fixing an issue)
- [ ] ✨ New feature (non-breaking change adding functionality)
- [ ] 💥 Breaking change (fix or feature causing existing functionality to change)
- [ ] 📚 Documentation update
- [ ] 🏗️ Infrastructure change (Terraform/IaC)
- [ ] ♻️ Refactoring (no functional changes)

## Component(s) Affected

- [ ] `infrastructure/terraform/prerequisites/` - Azure subscription setup
- [ ] `infrastructure/terraform/` - Terraform infrastructure
- [ ] `infrastructure/setup/` - OSMO control plane / Helm
- [ ] `workflows/` - Training and evaluation workflows
- [x] `training/` - Training pipelines and scripts
- [ ] `docs/` - Documentation

## Testing Performed

- [ ] Training scripts tested locally with Isaac Sim
- [x] Smoke tests passed (`smoke_test_azure.py`)
- [ ] Terraform `plan` reviewed (no unexpected changes)
- [ ] Terraform `apply` tested in dev environment
- [ ] OSMO workflow submitted successfully

## Documentation Impact

- [x] No documentation changes needed
- [ ] Documentation updated in this PR
- [ ] Documentation issue filed

## Bug Fix Checklist

*Complete this section for bug fix PRs. Skip for other contribution types.*

- [x] Linked to issue being fixed
- [x] Regression test included, OR
- [ ] Justification for no regression test:

## Checklist

- [x] My code follows the [project conventions](copilot-instructions.md)
- [x] Commit messages follow [conventional commit format](instructions/commit-message.instructions.md)
- [x] I have performed a self-review
- [x] Documentation impact assessed above
- [x] No new linting warnings introduced
