### PR TITLE
chore(build): exclude auto-generated CHANGELOG.md from cspell and seed dictionary

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -38,7 +38,9 @@
 		"**/.terraform/**",
 		"**/.terraform.lock.hcl",
 		"**/scripts/tests/Fixtures/**",
-		"**/TERRAFORM.md"
+		"**/TERRAFORM.md",
+		"CHANGELOG.md",
+		"**/CHANGELOG.md"
 	],
 	"dictionaryDefinitions": [
 		{

--- a/.cspell/general-technical.txt
+++ b/.cspell/general-technical.txt
@@ -879,6 +879,7 @@ onpremisesstorage
 openapi
 opencencus
 openid
+openmpi
 openpgp
 openrowset
 openshift
@@ -1108,6 +1109,10 @@ reimplementing
 reintegrate
 reintegrating
 relabelling
+remediations
+repoint
+repointed
+repointing
 Rekor
 Remotable
 renumbered


### PR DESCRIPTION
The `Spell Check` job on `main` was failing against *CHANGELOG.md* because **release-please** regenerates that file mechanically from merged PR titles, including titles authored by Dependabot and other automation that embed package names cspell will never recognize. Auditing PR titles is not a durable fix, so this change excludes the derived changelog from spell checking and seeds a few legitimate English words that flagged in the latest run.

## Description

Excluded **CHANGELOG.md** (root and any nested copies) from cspell scanning and added the three real words flagged by [run 25040872895](https://github.com/microsoft/physical-ai-toolchain/actions/runs/25040872895/job/73343530517) to the project dictionary. The changelog is a generated artifact, so the right boundary for spell checking is its inputs (PR titles, source docs), not the output.

Closes #581

## Changes

- Added `CHANGELOG.md` and `**/CHANGELOG.md` to `ignorePaths` in *.cspell.json* so the generated changelog is no longer scanned.
- Added `openmpi`, `remediations`, and `repoint` (with `repointed` and `repointing`) to *.cspell/general-technical.txt* in alphabetical position within the lowercase block.

## Type of Change
<!-- Mark relevant options with [x] -->

- [x] 🐛 Bug fix (non-breaking change fixing an issue)
- [ ] ✨ New feature (non-breaking change adding functionality)
- [ ] 💥 Breaking change (fix or feature causing existing functionality to change)
- [ ] 📚 Documentation update
- [ ] 🏗️ Infrastructure change (Terraform/IaC)
- [ ] ♻️ Refactoring (no functional changes)

> Build/CI configuration change — none of the listed types apply directly.

## Component(s) Affected
<!-- Mark all that apply -->

- [ ] `infrastructure/terraform/prerequisites/` - Azure subscription setup
- [ ] `infrastructure/terraform/` - Terraform infrastructure
- [ ] `infrastructure/setup/` - OSMO control plane / Helm
- [ ] `workflows/` - Training and evaluation workflows
- [ ] `training/` - Training pipelines and scripts
- [ ] `docs/` - Documentation

> Affects repository-level cspell configuration only (*.cspell.json*, *.cspell/general-technical.txt*).

## Testing Performed
<!-- Describe testing. Check applicable items -->

- [ ] Terraform `plan` reviewed (no unexpected changes)
- [ ] Terraform `apply` tested in dev environment
- [ ] Training scripts tested locally with Isaac Sim
- [ ] OSMO workflow submitted successfully
- [ ] Smoke tests passed (`smoke_test_azure.py`)

Run `npm run spell-check` locally to confirm the tree is clean.

## Documentation Impact
<!-- Select one -->

- [x] No documentation changes needed
- [ ] Documentation updated in this PR
- [ ] Documentation issue filed

## Bug Fix Checklist

*Not applicable — build/CI configuration change.*

- [x] Linked to issue being fixed
- [ ] Regression test included, OR
- [ ] Justification for no regression test:

## Checklist

- [x] My code follows the [project conventions](copilot-instructions.md)
- [x] Commit messages follow [conventional commit format](instructions/commit-message.instructions.md)
- [x] I have performed a self-review
- [x] Documentation impact assessed above
- [x] No new linting warnings introduced
