### PR TITLE
fix(workflows): correct branches filter on AW Dependabot PR Review workflow_run trigger

### DIFF
--- a/.github/workflows/aw-dependabot-pr-review.lock.yml
+++ b/.github/workflows/aw-dependabot-pr-review.lock.yml
@@ -1,4 +1,4 @@
-# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"c966d2851ca55ead0d96c99a3a2459006eedf6227325f83cb4414955742356d2","compiler_version":"v0.68.3","strict":true,"agent_id":"copilot"}
+# gh-aw-metadata: {"schema_version":"v3","frontmatter_hash":"1d81d143bd1c13d909c7d8a74d360316fb897b7a2ea7b6645ba7b4e88bd2b701","compiler_version":"v0.68.3","strict":true,"agent_id":"copilot"}
 # gh-aw-manifest: {"version":1,"secrets":["COPILOT_GITHUB_TOKEN","GH_AW_GITHUB_MCP_SERVER_TOKEN","GH_AW_GITHUB_TOKEN","GITHUB_TOKEN"],"actions":[{"repo":"actions/checkout","sha":"de0fac2e4500dabe0009e67214ff5f5447ce83dd","version":"v6.0.2"},{"repo":"actions/download-artifact","sha":"3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c","version":"v8.0.1"},{"repo":"actions/github-script","sha":"373c709c69115d41ff229c7e5df9f8788daa9553","version":"v9"},{"repo":"actions/setup-go","sha":"4a3601121dd01d1626a1e23e37211e3254c1c06c","version":"v6.4.0"},{"repo":"actions/setup-node","sha":"53b83947a5a98c8d113130e565377fae1a50d02f","version":"v6.3.0"},{"repo":"actions/setup-python","sha":"a309ff8b426b58ec0e2a45f0f869d46889d02405","version":"v6.2.0"},{"repo":"actions/upload-artifact","sha":"043fb46d1a93c77aae656e7c1c64a875d1fc6a0a","version":"v7.0.1"},{"repo":"astral-sh/setup-uv","sha":"cec208311dfd045dd5311c1add060b2062131d57","version":"v8.0.0"},{"repo":"github/gh-aw-actions/setup","sha":"ba90f2186d7ad780ec640f364005fa24e797b360","version":"v0.68.3"},{"repo":"hashicorp/setup-terraform","sha":"5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85","version":"5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85"},{"repo":"terraform-linters/setup-tflint","sha":"b480b8fcdaa6f2c577f8e4fa799e89e756bb7c93","version":"b480b8fcdaa6f2c577f8e4fa799e89e756bb7c93"}],"containers":[{"image":"ghcr.io/github/gh-aw-firewall/agent:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/api-proxy:0.25.20"},{"image":"ghcr.io/github/gh-aw-firewall/squid:0.25.20"},{"image":"ghcr.io/github/gh-aw-mcpg:v0.2.19"},{"image":"ghcr.io/github/github-mcp-server:v0.32.0"},{"image":"node:lts-alpine"}]}
 #    ___                   _   _      
 #   / _ \                 | | (_)     
@@ -60,7 +60,7 @@ name: "AW Dependabot PR Review"
   workflow_run:
     # zizmor: ignore[dangerous-triggers] - workflow_run trigger is secured with role and fork validation
     branches:
-    - main
+    - dependabot/**
     types:
     - completed
     workflows:
@@ -179,14 +179,14 @@ jobs:
         run: |
           bash "${RUNNER_TEMP}/gh-aw/actions/create_prompt_first.sh"
           {
-          cat << 'GH_AW_PROMPT_1179d66472df9aa2_EOF'
+          cat << 'GH_AW_PROMPT_562b73f91f8b944b_EOF'
           <system>
-          GH_AW_PROMPT_1179d66472df9aa2_EOF
+          GH_AW_PROMPT_562b73f91f8b944b_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/xpia.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/temp_folder_prompt.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/markdown.md"
           cat "${RUNNER_TEMP}/gh-aw/prompts/safe_outputs_prompt.md"
-          cat << 'GH_AW_PROMPT_1179d66472df9aa2_EOF'
+          cat << 'GH_AW_PROMPT_562b73f91f8b944b_EOF'
           <safe-output-tools>
           Tools: add_comment(max:2), create_pull_request_review_comment(max:5), submit_pull_request_review, missing_tool, missing_data, noop
           </safe-output-tools>
@@ -218,13 +218,13 @@ jobs:
           {{/if}}
           </github-context>
           
-          GH_AW_PROMPT_1179d66472df9aa2_EOF
+          GH_AW_PROMPT_562b73f91f8b944b_EOF
           cat "${RUNNER_TEMP}/gh-aw/prompts/github_mcp_tools_with_safeoutputs_prompt.md"
-          cat << 'GH_AW_PROMPT_1179d66472df9aa2_EOF'
+          cat << 'GH_AW_PROMPT_562b73f91f8b944b_EOF'
           </system>
           {{#runtime-import .github/agents/dependabot-pr-reviewer.agent.md}}
           {{#runtime-import .github/workflows/aw-dependabot-pr-review.md}}
-          GH_AW_PROMPT_1179d66472df9aa2_EOF
+          GH_AW_PROMPT_562b73f91f8b944b_EOF
           } > "$GH_AW_PROMPT"
       - name: Interpolate variables and render templates
         uses: actions/github-script@373c709c69115d41ff229c7e5df9f8788daa9553 # v9
@@ -450,9 +450,9 @@ jobs:
           mkdir -p "${RUNNER_TEMP}/gh-aw/safeoutputs"
           mkdir -p /tmp/gh-aw/safeoutputs
           mkdir -p /tmp/gh-aw/mcp-logs/safeoutputs
-          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_08db9facaf83d198_EOF'
+          cat > "${RUNNER_TEMP}/gh-aw/safeoutputs/config.json" << 'GH_AW_SAFE_OUTPUTS_CONFIG_7a25c6a5690ed163_EOF'
           {"add_comment":{"max":2,"target":"triggering"},"create_pull_request_review_comment":{"max":5,"side":"RIGHT"},"create_report_incomplete_issue":{},"missing_data":{},"missing_tool":{},"noop":{"max":1,"report-as-issue":"true"},"report_incomplete":{},"submit_pull_request_review":{"max":1}}
-          GH_AW_SAFE_OUTPUTS_CONFIG_08db9facaf83d198_EOF
+          GH_AW_SAFE_OUTPUTS_CONFIG_7a25c6a5690ed163_EOF
       - name: Write Safe Outputs Tools
         env:
           GH_AW_TOOLS_META_JSON: |
@@ -693,7 +693,7 @@ jobs:
           export MCP_GATEWAY_DOCKER_COMMAND='docker run -i --rm --network host -v /var/run/docker.sock:/var/run/docker.sock -e MCP_GATEWAY_PORT -e MCP_GATEWAY_DOMAIN -e MCP_GATEWAY_API_KEY -e MCP_GATEWAY_PAYLOAD_DIR -e MCP_GATEWAY_PAYLOAD_SIZE_THRESHOLD -e DEBUG -e MCP_GATEWAY_LOG_DIR -e GH_AW_MCP_LOG_DIR -e GH_AW_SAFE_OUTPUTS -e GH_AW_SAFE_OUTPUTS_CONFIG_PATH -e GH_AW_SAFE_OUTPUTS_TOOLS_PATH -e GH_AW_ASSETS_BRANCH -e GH_AW_ASSETS_MAX_SIZE_KB -e GH_AW_ASSETS_ALLOWED_EXTS -e DEFAULT_BRANCH -e GITHUB_MCP_SERVER_TOKEN -e GITHUB_MCP_GUARD_MIN_INTEGRITY -e GITHUB_MCP_GUARD_REPOS -e GITHUB_REPOSITORY -e GITHUB_SERVER_URL -e GITHUB_SHA -e GITHUB_WORKSPACE -e GITHUB_TOKEN -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RUN_ATTEMPT -e GITHUB_JOB -e GITHUB_ACTION -e GITHUB_EVENT_NAME -e GITHUB_EVENT_PATH -e GITHUB_ACTOR -e GITHUB_ACTOR_ID -e GITHUB_TRIGGERING_ACTOR -e GITHUB_WORKFLOW -e GITHUB_WORKFLOW_REF -e GITHUB_WORKFLOW_SHA -e GITHUB_REF -e GITHUB_REF_NAME -e GITHUB_REF_TYPE -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GH_AW_SAFE_OUTPUTS_PORT -e GH_AW_SAFE_OUTPUTS_API_KEY -v /tmp/gh-aw/mcp-payloads:/tmp/gh-aw/mcp-payloads:rw -v /opt:/opt:ro -v /tmp:/tmp:rw -v '"${GITHUB_WORKSPACE}"':'"${GITHUB_WORKSPACE}"':rw ghcr.io/github/gh-aw-mcpg:v0.2.19'
           
           mkdir -p /home/runner/.copilot
-          cat << GH_AW_MCP_CONFIG_a078df3ff30c98cc_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
+          cat << GH_AW_MCP_CONFIG_f189eb930e066421_EOF | bash "${RUNNER_TEMP}/gh-aw/actions/start_mcp_gateway.sh"
           {
             "mcpServers": {
               "github": {
@@ -734,7 +734,7 @@ jobs:
               "payloadDir": "${MCP_GATEWAY_PAYLOAD_DIR}"
             }
           }
-          GH_AW_MCP_CONFIG_a078df3ff30c98cc_EOF
+          GH_AW_MCP_CONFIG_f189eb930e066421_EOF
       - name: Download activation artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/aw-dependabot-pr-review.md
+++ b/.github/workflows/aw-dependabot-pr-review.md
@@ -11,7 +11,7 @@ on:
     workflows: ["PR Validation"]
     types: [completed]
     branches:
-      - main
+      - "dependabot/**"
 permissions:
   contents: read
   pull-requests: read


### PR DESCRIPTION
## Description

The **AW Dependabot PR Review** workflow stopped firing for every Dependabot PR after PR #580 introduced the `pull_request` → `workflow_run` trigger migration. The `branches:` filter was set to `main`, but for `workflow_run` events GitHub matches that filter against the *triggering run's `head_branch`*, not its base. *PR Validation* always runs on the PR's head branch (for example `dependabot/docker/data-management/viewer/frontend/node-e49fd70`), so `main` never matched and the reviewer never triggered.

This PR scopes the trigger to all Dependabot head branches by replacing the filter with a `dependabot/**` glob. The existing `resolve-pr` step still gates downstream on `pr.user.login === 'dependabot[bot]'`, so the broader trigger surface stays gated.

Fixes #583

## Type of Change

- [x] 🐛 Bug fix (non-breaking change fixing an issue)
- [ ] ✨ New feature (non-breaking change adding functionality)
- [ ] 💥 Breaking change (fix or feature causing existing functionality to change)
- [ ] 📚 Documentation update
- [ ] 🏗️ Infrastructure change (Terraform/IaC)
- [ ] ♻️ Refactoring (no functional changes)

## Component(s) Affected

- [ ] `infrastructure/terraform/prerequisites/` - Azure subscription setup
- [ ] `infrastructure/terraform/` - Terraform infrastructure
- [ ] `infrastructure/setup/` - OSMO control plane / Helm
- [ ] `workflows/` - Training and evaluation workflows
- [ ] `training/` - Training pipelines and scripts
- [ ] `docs/` - Documentation

## Changes

- Replaced **`branches: [main]`** with **`branches: ["dependabot/**"]`** on the `workflow_run` trigger in *.github/workflows/aw-dependabot-pr-review.md*.
- Recompiled *.github/workflows/aw-dependabot-pr-review.lock.yml* via `gh aw compile` (frontmatter hash and prompt heredoc markers updated; no semantic changes outside the trigger filter).

## Testing Performed

- [ ] Terraform `plan` reviewed (no unexpected changes)
- [ ] Terraform `apply` tested in dev environment
- [ ] Training scripts tested locally with Isaac Sim
- [ ] OSMO workflow submitted successfully
- [ ] Smoke tests passed (`smoke_test_azure.py`)

Validated locally:

- `gh aw compile aw-dependabot-pr-review` → 0 errors, 0 warnings.
- `npm run lint:yaml` → actionlint found 0 issues.

End-to-end verification requires merging and observing the next Dependabot PR's *PR Validation* completion trigger an `aw-dependabot-pr-review` `workflow_run` event.

## Documentation Impact

- [x] No documentation changes needed
- [ ] Documentation updated in this PR
- [ ] Documentation issue filed

## Bug Fix Checklist

- [x] Linked to issue being fixed
- [ ] Regression test included, OR
- [x] Justification for no regression test: trigger semantics live in workflow YAML and are not exercisable from repo-local test harnesses; verification is observational against the next Dependabot PR.

## Checklist

- [x] My code follows the [project conventions](copilot-instructions.md)
- [x] Commit messages follow [conventional commit format](instructions/commit-message.instructions.md)
- [x] I have performed a self-review
- [x] Documentation impact assessed above
- [x] No new linting warnings introduced

## Follow-up Tasks

- After merge, push an empty commit (or rebase) on existing open Dependabot PRs such as #560 to re-run *PR Validation* and trigger the reviewer for backlog coverage.
