### PR TITLE
docs(docs): Fix deployment guide links

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -21,7 +21,7 @@ Documentation spans the full lifecycle — from provisioning Azure infrastructur
 
 | Role                   | Start here                                                                                                                       |
 |------------------------|----------------------------------------------------------------------------------------------------------------------------------|
-| First-time deployer    | [Getting Started](getting-started/README.md), then [Deploy](https://github.com/microsoft/physical-ai-toolchain/tree/main/deploy) |
+| First-time deployer    | [Getting Started](getting-started/README.md), then [Deployment Guide](infrastructure/README.md) |
 | ML / Robotics engineer | [Training](training/lerobot-training.md) and Inference (coming soon)                                                             |
 | Platform operator      | [Operations](operations/README.md) and [Security Guide](operations/security-guide.md)                                            |
 | Contributor            | [Contributing](contributing/README.md)                                                                                           |
@@ -31,7 +31,7 @@ Documentation spans the full lifecycle — from provisioning Azure infrastructur
 | Section                                                                       | Description                                                                         | Status      |
 |-------------------------------------------------------------------------------|-------------------------------------------------------------------------------------|-------------|
 | [Getting Started](getting-started/README.md)                                  | Environment setup, prerequisites, and first deployment walkthrough                  | Available   |
-| [Deploy](https://github.com/microsoft/physical-ai-toolchain/tree/main/deploy) | Infrastructure provisioning with Terraform, AKS cluster setup, and networking       | Available   |
+| [Deployment Guide](infrastructure/README.md)                                  | Infrastructure provisioning with Terraform, AKS cluster setup, and networking       | Available   |
 | [Training](training/README.md)                                                | Model training pipelines with Isaac Lab, AzureML jobs, and OSMO orchestration       | Available   |
 | Inference                                                                     | Serving trained policies for real-time control on edge and cloud                    | Coming soon |
 | Workflows                                                                     | AzureML and OSMO job templates, pipeline configuration, and submission scripts      | Coming soon |
@@ -51,7 +51,7 @@ Standalone guides available now. These cover common tasks and will move into the
 
 ## 🚀 Next Steps
 
-* Review the [deployment guide](https://github.com/microsoft/physical-ai-toolchain/blob/main/deploy/README.md) for infrastructure provisioning and cluster setup
+* Review the [deployment guide](infrastructure/README.md) for infrastructure provisioning and cluster setup
 * Explore [MLflow Integration](training/mlflow-integration.md) to set up experiment tracking for training runs
 * Read the [Contributing](contributing/README.md) guide to get involved with the project
 


### PR DESCRIPTION
## Summary

Hi, Vandit here. This PR fixes the broken deployment guide links in `docs/README.md` by pointing them to the current `docs/infrastructure/README.md` deployment guide.

Fixes #134.

## Verification

- `npm run lint:links`
- `npx markdownlint-cli2 docs/README.md`
- `npx markdown-link-check docs/README.md -q`