### PR TITLE
fix(scripts): exclude CHANGELOG.md from changed-files msdate check

### DIFF
--- a/scripts/linting/Invoke-MsDateFreshnessCheck.ps1
+++ b/scripts/linting/Invoke-MsDateFreshnessCheck.ps1
@@ -63,13 +63,27 @@ function Get-MarkdownFiles {
         [string]$Base = 'origin/main'
     )
 
+    $excludePatterns = @('node_modules', '.git', 'logs', '.copilot-tracking', 'CHANGELOG.md', 'scripts/tests')
+
     if ($ChangedOnly) {
         Write-Verbose "Getting changed markdown files relative to $Base"
         $files = @(Get-ChangedFilesFromGit -BaseBranch $Base -FileExtensions @('*.md'))
-        return @($files | Where-Object { Test-Path $_ -PathType Leaf })
+        return @($files | Where-Object {
+                if (-not (Test-Path $_ -PathType Leaf)) { return $false }
+                $normalized = $_ -replace '\\', '/'
+                $name = Split-Path $_ -Leaf
+                foreach ($pattern in $excludePatterns) {
+                    if ($name -eq $pattern -or
+                        $normalized -like "$pattern/*" -or
+                        $normalized -like "*/$pattern/*" -or
+                        $normalized -like "*/$pattern") {
+                        return $false
+                    }
+                }
+                return $true
+            })
     }
 
-    $excludePatterns = @('node_modules', '.git', 'logs', '.copilot-tracking', 'CHANGELOG.md', 'scripts/tests')
     $allFiles = @()
 
     # Explicit paths bypass exclusion filtering (e.g., 'logs/specific.md')

--- a/scripts/tests/linting/Invoke-MsDateFreshnessCheck.Tests.ps1
+++ b/scripts/tests/linting/Invoke-MsDateFreshnessCheck.Tests.ps1
@@ -158,6 +158,18 @@ Describe 'Get-MarkdownFiles' -Tag 'Unit' {
             $files = @(Get-MarkdownFiles -SearchPaths @('.') -ChangedOnly -Base 'origin/main')
             $files | Should -BeNullOrEmpty
         }
+
+        It 'Excludes CHANGELOG.md when only changed file' {
+            New-Item -ItemType File -Path 'CHANGELOG.md' -Force | Out-Null
+
+            Mock git {
+                $global:LASTEXITCODE = 0
+                return @('CHANGELOG.md')
+            } -ModuleName 'LintingHelpers' -ParameterFilter { $args[0] -eq 'diff' }
+
+            $files = @(Get-MarkdownFiles -SearchPaths @('.') -ChangedOnly -Base 'origin/main')
+            $files | Should -BeNullOrEmpty
+        }
     }
 
     Context 'Multiple paths' {


### PR DESCRIPTION
## Description

`Invoke-MsDateFreshnessCheck.ps1` declared its `$excludePatterns` list (which already contained `CHANGELOG.md` and `scripts/tests`) **after** the `-ChangedOnly` early-return. As a result, the changed-files code path skipped the exclusion entirely and flagged `CHANGELOG.md` as stale whenever it was the only changed markdown file — which is exactly what release-please PRs produce.

This change lifts `$excludePatterns` above the early-return and applies the same name + normalized-path matching logic in the `-ChangedOnly` branch. The full-scan branch is unchanged.

Unblocks the release-please PR (#450) where the CI `lint:md` step was failing on the auto-generated `CHANGELOG.md` update.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test additions or improvements
- [ ] Build/CI configuration change

## Component(s) Affected

- [ ] Infrastructure (Terraform/Bicep)
- [ ] Data Pipeline
- [ ] Synthetic Data Generation
- [ ] Training (RL/IL)
- [ ] Evaluation (SiL/HiL)
- [ ] Fleet Deployment
- [ ] Fleet Intelligence
- [ ] Documentation
- [ ] CI/CD Workflows
- [x] Other: `scripts/linting/` (markdown freshness check)

## Testing Performed

- [x] Unit tests pass locally — added regression test; full Pester suite for `Invoke-MsDateFreshnessCheck.Tests.ps1` is 38/38 green.
- [ ] Integration tests pass locally
- [ ] Tested on actual hardware (specify):
- [ ] Tested in cloud environment
- [ ] Manual testing performed (describe below)

## Documentation Impact

- [x] No documentation changes needed

## Bug Fix Checklist (if applicable)

- [x] Root cause identified and addressed (not just symptoms)
- [x] Regression test added to prevent recurrence
- [ ] Related bugs identified and addressed (or filed separately)

## Checklist

- [x] My code follows the project's coding standards and conventions
- [x] I have performed a self-review of my own code
- [x] I have commented my code in hard-to-understand areas (n/a — single-purpose filter)
- [x] My changes generate no new warnings or errors
- [x] New and existing unit tests pass locally with my changes
- [ ] I have updated the CHANGELOG.md (if applicable) — handled by release-please
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format
- [x] I have considered the impact of my changes on documentation

## Related Issues

Unblocks #450 (release-please).
