### PR TITLE
chore(build): bump dependency-review-action v5.0.0, exclude gh-aw-actions from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -170,6 +170,12 @@ updates:
       github-actions:
         patterns:
           - "*"
+        exclude-patterns:
+          - "github/gh-aw-actions/*"
+    # gh-aw-actions SHAs are managed by the gh-aw compiler (lock files).
+    # Dependabot must not bump them independently.
+    ignore:
+      - dependency-name: "github/gh-aw-actions/*"
     labels:
       - "dependencies"
       - "github-actions"

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -22,7 +22,7 @@ jobs:
           persist-credentials: false
 
       - name: Dependency Review
-        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
         with:
           fail-on-severity: moderate
           comment-summary-in-pr: always


### PR DESCRIPTION
## Description

Bumped `actions/dependency-review-action` from v4.9.0 to v5.0.0 and excluded `github/gh-aw-actions/*` from Dependabot's github-actions group. This supersedes #662, which incorrectly bundled a compiler-managed action (`gh-aw-actions`) with a human-managed action (`dependency-review-action`) into a single PR.

> `gh-aw-actions` SHAs inside `aw-*.lock.yml` files are written by the `gh aw` compiler during workflow compilation. Dependabot bumping these SHAs independently is incorrect — the next `gh aw compile` overwrites whatever Dependabot set, and the lock file's internal dependency manifest must stay consistent with its `compiler_version`.

Closes #669

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change fixing an issue)
- [ ] ✨ New feature (non-breaking change adding functionality)
- [ ] 💥 Breaking change (fix or feature causing existing functionality to change)
- [ ] 📚 Documentation update
- [x] 🏗️ Infrastructure change (Terraform/IaC)
- [ ] ♻️ Refactoring (no functional changes)

## Component(s) Affected

- [ ] `infrastructure/terraform/prerequisites/` - Azure subscription setup
- [ ] `infrastructure/terraform/` - Terraform infrastructure
- [ ] `infrastructure/setup/` - OSMO control plane / Helm
- [ ] `workflows/` - Training and evaluation workflows
- [ ] `training/` - Training pipelines and scripts
- [ ] `docs/` - Documentation

## Testing Performed

- [ ] Terraform `plan` reviewed (no unexpected changes)
- [ ] Terraform `apply` tested in dev environment
- [ ] Training scripts tested locally with Isaac Sim
- [ ] OSMO workflow submitted successfully
- [ ] Smoke tests passed (`smoke_test_azure.py`)

## Documentation Impact

- [x] No documentation changes needed
- [ ] Documentation updated in this PR
- [ ] Documentation issue filed

## Bug Fix Checklist

*Complete this section for bug fix PRs. Skip for other contribution types.*

- [ ] Linked to issue being fixed
- [ ] Regression test included, OR
- [ ] Justification for no regression test:

## Checklist

- [x] My code follows the [project conventions](copilot-instructions.md)
- [x] Commit messages follow [conventional commit format](instructions/commit-message.instructions.md)
- [x] I have performed a self-review
- [x] Documentation impact assessed above
- [x] No new linting warnings introduced
