### PR TITLE
build(docs): update docusaurus dependencies

### DIFF
--- a/docs/docusaurus/package-lock.json
+++ b/docs/docusaurus/package-lock.json
@@ -18458,9 +18458,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -21477,12 +21477,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/v8-to-istanbul": {

--- a/docs/docusaurus/package.json
+++ b/docs/docusaurus/package.json
@@ -44,9 +44,10 @@
     "follow-redirects": ">=1.16.0 <2.0.0",
     "lodash": "4.18.1",
     "path-to-regexp": "1.9.0",
-    "qs": "6.14.2",
+    "qs": "6.15.2",
     "serialize-javascript": "7.0.5",
-    "ws": "8.20.1"
+    "ws": "8.20.1",
+    "uuid": "11.1.1"
   },
   "engines": {
     "node": ">=24"

--- a/docs/docusaurus/tsconfig.json
+++ b/docs/docusaurus/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "@docusaurus/tsconfig",
   "compilerOptions": {
     "baseUrl": ".",
+    "ignoreDeprecations": "6.0",
     "jsx": "react-jsx",
     "strict": true,
     "types": ["@docusaurus/module-type-aliases"]


### PR DESCRIPTION
<!-- markdownlint-disable-file -->
## Summary

Small dependency maintenance pass on the Docusaurus site. Bumps `qs`, adds a `uuid` override, and unblocks the TypeScript build by allowing the 6.x deprecations.

## Changes

- `docs/docusaurus/package.json` + `package-lock.json`
  - `qs` 6.14.2 → 6.15.2
  - Adds `uuid` 11.1.1 as a resolution/override to dedupe the transitive tree on a single supported major.
- `docs/docusaurus/tsconfig.json`
  - Adds `"ignoreDeprecations": "6.0"` so the current TypeScript major builds without warnings-as-errors blocking the Docusaurus pipeline.

## Why

Routine dep hygiene — picks up a `qs` patch series, prevents `uuid` from fanning out across multiple majors in the lockfile, and keeps the site buildable under the current TS toolchain pending a larger upgrade.

## Validation

- Docusaurus build/typecheck succeeds locally with these versions.
- Site behavior unchanged.
