### PR TITLE
fix(training): wire AzureML named checkpoints output to runtime env var

### DIFF
--- a/.cspell/azure-services.txt
+++ b/.cspell/azure-services.txt
@@ -80,3 +80,4 @@ southeastasia
 storageaccountendpoint
 wasbs
 westus
+workspaceblobstore

--- a/.cspell/general-technical.txt
+++ b/.cspell/general-technical.txt
@@ -408,6 +408,7 @@ enablement
 enduser
 endusers
 enhancements
+enqueueable
 entitlement
 entitlements
 epicor
@@ -582,6 +583,7 @@ inmon
 innersource
 innodb
 inprivate
+inqueue
 intel
 intellicode
 intellij
@@ -1606,6 +1608,7 @@ apikey
 # Azure NVIDIA Robotics Reference Architecture
 amlarc
 amlignore
+amloperator
 argjson
 autouse
 burstable
@@ -1648,6 +1651,7 @@ pentry
 persistenced
 pgpassword
 pname
+podgroup
 podgroups
 podmonitors
 portforward

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -402,7 +402,7 @@ Training runs in NVIDIA Isaac Lab containers on GPU nodes via AzureML or OSMO.
 * Behavioral cloning: LeRobot (ACT/Diffusion policies), runtime-installed via `uv pip` in AzureML container
 * MLflow: monkey-patches `agent._update` for metric interception
   * Logging intervals: `step`, `balanced` (default, every 10 steps), `rollout`, or custom integer
-* Checkpoint flow: training writes to local FS → `TRAINING_CHECKPOINT_OUTPUT` env var → AzureML uploads as `uri_folder`
+* Checkpoint flow: training writes to local FS → mirrored into `$AZURE_ML_OUTPUT_CHECKPOINTS` at job exit → AzureML uploads as `uri_folder`
 
 ## GPU Configuration
 

--- a/docs/infrastructure/manage-node-pools.md
+++ b/docs/infrastructure/manage-node-pools.md
@@ -3,7 +3,7 @@ sidebar_position: 11
 title: Manage Node Pools
 description: Add, remove, and resize AKS node pools on an existing cluster
 author: Microsoft Robotics-AI Team
-ms.date: 2026-05-12
+ms.date: 2026-06-02
 ms.topic: how-to
 keywords:
   - node-pools
@@ -218,6 +218,7 @@ Faster but disruptive. Use only when no workloads are running on the pool, or wh
 - **OSMO flag parity.** Pass the same flags you used for the initial `04-deploy-osmo-backend.sh` run (for example, `--use-acr`, `--use-access-keys`). Omitting them reverts the backend to defaults.
 - **Spot constraints.** Azure rejects `upgrade_settings` for Spot pools; the Terraform module already handles this. `eviction_policy` applies only when `priority = "Spot"`.
 - **Autoscaling.** `min_count = 0` is allowed; the pool scales up on demand from pending pods. KAI/Volcano coscheduling requires whole-pool capacity for gang-scheduled jobs.
+- **Scale-from-zero for AzureML.** GPU pools used by AzureML jobs must declare `node_labels = { accelerator = "nvidia" }`. Without this static label, the cluster autoscaler cannot prove a from-zero scale-up would satisfy AzureML InstanceTypes that select on `accelerator: nvidia`, and refuses to scale. See [Azure ML Training Workflows — Scale-from-zero GPU Pools](../training/azureml-training.md#-scale-from-zero-gpu-pools).
 - **Script 03 is not affected.** Only `04-deploy-osmo-backend.sh` reads pool data. `03-deploy-osmo-control-plane.sh` does not need to be rerun for pool changes.
 
 ## 🔗 Related

--- a/docs/operations/troubleshooting.md
+++ b/docs/operations/troubleshooting.md
@@ -217,13 +217,13 @@ Use `simulation_shutdown.py` which stops the simulation timeline and applies a S
 
 ### Checkpoint upload fails silently
 
-**Cause:** The `TRAINING_CHECKPOINT_OUTPUT` environment variable is not set or points to a non-existent directory.
+**Cause:** The AzureML named output is wired through `${{outputs.checkpoints}}` in `environment_variables:`, which AzureML does NOT substitute (substitution only happens in `command:`). The container receives the literal template string and the sync helper writes to a relative directory of that name, leaving `cap/data-capability/wd/checkpoints/` empty.
 
 **Resolution:**
 
-1. Verify the environment variable is set in the job definition.
-2. Confirm the output path is writable during training.
-3. Check job logs for upload errors after training completes.
+1. Read `AZURE_ML_OUTPUT_CHECKPOINTS` (set by the data-capability runtime) directly in the training entry point — do not indirect through a custom env var.
+2. Confirm the named `outputs.checkpoints` `uri_folder` is declared in the job YAML.
+3. Check job logs (`system_logs/data_capability/data-capability.log`) for `uploaded N files` rather than `is empty. Skip uploading`.
 
 ## Workflow Runtime Errors
 

--- a/docs/training/azureml-training.md
+++ b/docs/training/azureml-training.md
@@ -3,7 +3,7 @@ sidebar_position: 2
 title: Azure ML Training Workflows
 description: Submit Isaac Lab and LeRobot training jobs to Azure Machine Learning
 author: Microsoft Robotics-AI Team
-ms.date: 2026-06-01
+ms.date: 2026-06-02
 ms.topic: how-to
 keywords:
   - azure ml
@@ -141,6 +141,64 @@ Specify the checkpoint mode with `--checkpoint-mode`:
   --checkpoint-mode from-trained \
   --task Isaac-Cartpole-v0
 ```
+
+## 🛌 Scale-from-zero GPU Pools
+
+GPU node pools in this stack default to `min_count = 0` so idle Spot capacity is released. Three unrelated defaults must be overridden for jobs to actually start when the target pool is at zero; all three are applied automatically by the deploy scripts, but the rationale matters when troubleshooting.
+
+### `aml-operator` resource validation
+
+The Azure ML Kubernetes extension installs `aml-operator`, which runs a pre-flight check on every submitted `AmlJob`:
+
+> Does the requested `InstanceType` fit inside the largest currently-Ready node?
+
+With the chart default `amloperator.skipResourceValidation: false`, the operator fails the job immediately with `Code: 9` ("Invalid instance type. The instance type defined resource requirement has exceeded the node size") whenever the target GPU pool is at zero. No Pod is created, kube-scheduler is never invoked, and the cluster autoscaler never observes a pending Pod to scale up against.
+
+Result: a permanent deadlock — you cannot submit the job that would cause the GPU resource to become available.
+
+`02-deploy-azureml-extension.sh` sets the flag to `true` by default. Override with `--enforce-resource-validation` on fixed-capacity clusters where you want misconfigured InstanceTypes to fail fast at submission rather than producing Pods stuck in `Pending`.
+
+Trade-off when enabled (the default): a typo in an `InstanceType` (e.g. `nvidia.com/gpu: 8` on a 4-GPU SKU) manifests as `FailedScheduling` events on a long-Pending Pod instead of an immediate job failure. Diagnose with `kubectl describe pod`.
+
+### Static `accelerator=nvidia` node label
+
+The InstanceTypes installed by `02-deploy-azureml-extension.sh` (`gpuspot`, `gpu`, `gpuspot2`, …) select on `accelerator: nvidia`. That label is normally applied at runtime by NFD / GPU Operator on already-running GPU nodes. When the pool is at zero, the cluster autoscaler builds a synthetic node template from **static** AKS-side labels only (transmitted to it via VMSS tags) and never sees `accelerator=nvidia` — so it concludes that scaling the pool up would not satisfy the pending Pod, and refuses.
+
+The fix is to declare the label statically on every GPU pool via Terraform:
+
+```hcl
+node_labels = {
+  accelerator = "nvidia"
+}
+```
+
+Already wired into the default `gpu` pool in `infrastructure/terraform/variables.tf` and `infrastructure/terraform/modules/sil/variables.tf`. Any custom GPU pool added via `node_pools` in `terraform.tfvars` must include the same label. NFD and the static label coexist without conflict.
+
+### Volcano enqueue-time capacity gate
+
+The Azure ML extension installs Volcano with `overcommit` and `proportion` plugins in the third tier of its scheduler config. Both implement Volcano's `JobEnqueueable` interface and gate the `enqueue` action against currently-Ready cluster capacity (`proportion`: `requested ≤ queue.Allocated + queue.Free`; `overcommit`: `requested ≤ total × overcommit-factor`).
+
+On a cluster whose GPU pools sit at `count = 0`, the GPU capacity term is `0 × 1.2 = 0`, so every GPU PodGroup fails enqueue and stays in phase `Pending` forever. Because Volcano only creates the underlying Pod once the PodGroup reaches `Inqueue`, no Pending Pod ever appears in kube-scheduler's queue — and without a Pending Pod, the AKS cluster autoscaler has nothing to scale up against.
+
+`02-deploy-azureml-extension.sh` patches `volcano-scheduler-configmap` with [`infrastructure/setup/manifests/volcano-scheduler-config-scale-from-zero.conf`](../../infrastructure/setup/manifests/volcano-scheduler-config-scale-from-zero.conf) (both plugins removed from tier 3) and restarts `volcano-scheduler` after extension install. Gang scheduling is preserved because the `gang` plugin still gates the `allocate` action — multi-pod jobs continue to wait for `minAvailable` before any task starts.
+
+Override with `--enforce-volcano-capacity-check` on multi-tenant clusters where queue-level capacity fairness must be enforced at submit time. Scale-from-zero will then be impossible without keeping at least one GPU node warm (`min_count ≥ 1`).
+
+### Verifying scale-up
+
+```bash
+# Submit a job, then watch the autoscaler decision.
+kubectl -n kube-system get cm cluster-autoscaler-status -o jsonpath='{.data.status}' | head
+# Expected progression:
+#   scaleUp.status: NoActivity -> InProgress
+#   nodeGroups[aks-<pool>-vmss].cloudProviderTarget: 0 -> 1
+```
+
+If `scaleUp.status` stays `NoActivity` after submission, walk the three layers in order:
+
+1. `kubectl -n azureml logs deploy/aml-operator` — look for `"resource validation failed"` (operator layer).
+2. `kubectl get podgroup -n azureml` — phase `Pending` with `Unschedulable: resource in cluster is overused` is the Volcano enqueue gate.
+3. `kubectl describe pod -n azureml <worker>` — `FailedScheduling: 0/N nodes are available, ... node(s) didn't match Pod's node affinity/selector` is the missing-label layer.
 
 ## 📚 Related Documentation
 

--- a/infrastructure/setup/02-deploy-azureml-extension.sh
+++ b/infrastructure/setup/02-deploy-azureml-extension.sh
@@ -23,6 +23,21 @@ OPTIONS:
     -t, --tf-dir DIR          Terraform directory (default: $DEFAULT_TF_DIR)
     --compute-name NAME       Compute target name (default: k8s-<suffix>)
     --fast-prod               Set cluster purpose to FastProd with HA inference router
+    --enforce-resource-validation
+                              Enforce aml-operator resource validation (default: disabled).
+                              Disabled is required for scale-to-zero GPU node pools; otherwise
+                              the operator refuses jobs whose InstanceType exceeds the largest
+                              currently-Ready node, blocking the autoscaler from ever scaling
+                              the pool up. Enable only on fixed-capacity clusters where you
+                              want misconfigured InstanceTypes to fail fast at submission.
+    --enforce-volcano-capacity-check
+                              Re-enable Volcano's enqueue-time capacity check (default: disabled).
+                              Disabled is required for scale-from-zero GPU node pools; otherwise
+                              the volcano-scheduler's overcommit/proportion plugins refuse to
+                              enqueue PodGroups whose requests exceed currently-Ready cluster
+                              capacity, blocking the AKS autoscaler from ever seeing a Pending
+                              Pod. Enable only on multi-tenant clusters where queue-level
+                              capacity fairness must be enforced at submit time.
     --skip-attach             Skip attaching cluster as compute target
     --skip-instance-types     Skip creating GPU instance types
     --config-preview          Print configuration and exit
@@ -42,20 +57,24 @@ inference_ha="false"
 allow_insecure="true"
 install_volcano="true"
 install_prom_op="false"
+skip_resource_validation="true"
+enforce_volcano_capacity_check=false
 skip_attach=false
 skip_instance_types=false
 config_preview=false
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    -h|--help)             show_help; exit 0 ;;
-    -t|--tf-dir)           tf_dir="$2"; shift 2 ;;
-    --compute-name)        compute_name="$2"; shift 2 ;;
-    --fast-prod)           cluster_purpose="FastProd"; inference_ha="true"; allow_insecure="false"; shift ;;
-    --skip-attach)         skip_attach=true; shift ;;
-    --skip-instance-types) skip_instance_types=true; shift ;;
-    --config-preview)      config_preview=true; shift ;;
-    *)                     fatal "Unknown option: $1" ;;
+    -h|--help)                       show_help; exit 0 ;;
+    -t|--tf-dir)                     tf_dir="$2"; shift 2 ;;
+    --compute-name)                  compute_name="$2"; shift 2 ;;
+    --fast-prod)                     cluster_purpose="FastProd"; inference_ha="true"; allow_insecure="false"; shift ;;
+    --enforce-resource-validation)   skip_resource_validation="false"; shift ;;
+    --enforce-volcano-capacity-check) enforce_volcano_capacity_check=true; shift ;;
+    --skip-attach)                   skip_attach=true; shift ;;
+    --skip-instance-types)           skip_instance_types=true; shift ;;
+    --config-preview)                config_preview=true; shift ;;
+    *)                               fatal "Unknown option: $1" ;;
   esac
 done
 
@@ -91,6 +110,8 @@ if [[ "$config_preview" == "true" ]]; then
   print_kv "Extension Name" "$extension_name"
   print_kv "Compute Name" "$compute_name"
   print_kv "Cluster Purpose" "$cluster_purpose"
+  print_kv "Skip Resource Validation" "$skip_resource_validation"
+  print_kv "Enforce Volcano Capacity Check" "$enforce_volcano_capacity_check"
   print_kv "ML Workspace" "${ml_workspace:-<not configured>}"
   print_kv "ML Identity" "${ml_identity_name:-<not configured>}"
   exit 0
@@ -125,6 +146,7 @@ export ALLOW_INSECURE_CONNECTIONS="$allow_insecure"
 export CLUSTER_PURPOSE="$cluster_purpose"
 export INSTALL_VOLCANO="$install_volcano"
 export INSTALL_PROM_OP="$install_prom_op"
+export SKIP_RESOURCE_VALIDATION="$skip_resource_validation"
 
 envsubst < "$config_template" > "$CONFIG_DIR/out/azureml-aks-config.json"
 
@@ -144,6 +166,51 @@ else
     --release-train stable \
     --config-file "$CONFIG_DIR/out/azureml-aks-config.json"
   sleep 30
+fi
+
+#------------------------------------------------------------------------------
+# Configure Volcano Scheduler for Scale-from-Zero
+#------------------------------------------------------------------------------
+# The AzureML extension ships a Volcano config whose enqueue-time overcommit
+# and proportion plugins block PodGroups whose requests exceed currently-Ready
+# cluster capacity. That deadlocks scale-from-zero GPU pools because the Pod
+# is never created, so the AKS autoscaler never sees a Pending Pod. Replace
+# the configmap with a permissive enqueue config (proportion/overcommit
+# removed; gang scheduling preserved at allocate) and restart the scheduler.
+# Opt out with --enforce-volcano-capacity-check on multi-tenant clusters.
+
+if [[ "$install_volcano" == "true" && "$enforce_volcano_capacity_check" == "false" ]]; then
+  section "Configure Volcano Scheduler for Scale-from-Zero"
+
+  volcano_cfg_src="$MANIFESTS_DIR/volcano-scheduler-config-scale-from-zero.conf"
+  [[ -f "$volcano_cfg_src" ]] || fatal "Volcano scheduler config not found: $volcano_cfg_src"
+
+  info "Waiting for volcano-scheduler-configmap to exist..."
+  retries=30
+  while ! kubectl get cm -n "$NS_AZUREML" volcano-scheduler-configmap &>/dev/null; do
+    (( --retries > 0 )) || fatal "volcano-scheduler-configmap did not appear within 5 minutes; cannot deliver scale-from-zero"
+    sleep 10
+  done
+
+  info "Applying scale-from-zero Volcano scheduler config (server-side apply, field-manager=hex-azureml-volcano-patch)..."
+  # Server-side apply with a dedicated field manager + --force-conflicts:
+  # registers ownership of data.volcano-scheduler.conf so subsequent
+  # Helm-driven extension upgrades observe a conflict and leave our patch in
+  # place instead of silently reverting it. Other fields (labels, annotations,
+  # Helm metadata) stay owned by the AzureML extension Helm release.
+  kubectl create configmap volcano-scheduler-configmap \
+    -n "$NS_AZUREML" \
+    --from-file=volcano-scheduler.conf="$volcano_cfg_src" \
+    --dry-run=client -o yaml \
+    | kubectl apply --server-side --field-manager=hex-azureml-volcano-patch --force-conflicts -f -
+
+  if kubectl get deploy -n "$NS_AZUREML" volcano-scheduler &>/dev/null; then
+    info "Restarting volcano-scheduler to pick up new config..."
+    kubectl rollout restart -n "$NS_AZUREML" deploy/volcano-scheduler
+    kubectl rollout status -n "$NS_AZUREML" deploy/volcano-scheduler --timeout=2m
+  else
+    warn "volcano-scheduler deployment not found; configmap will be picked up on next start"
+  fi
 fi
 
 #------------------------------------------------------------------------------
@@ -221,6 +288,8 @@ print_kv "Cluster" "$cluster"
 print_kv "Extension" "$extension_name"
 print_kv "Compute" "$compute_name"
 print_kv "Purpose" "$cluster_purpose"
+print_kv "Skip Resource Validation" "$skip_resource_validation"
+print_kv "Enforce Volcano Capacity Check" "$enforce_volcano_capacity_check"
 print_kv "ML Workspace" "${ml_workspace:-<not configured>}"
 echo
 kubectl get pods -n "$NS_AZUREML" --no-headers 2>/dev/null | head -5 || true

--- a/infrastructure/setup/config/azureml-aks-config.template.json
+++ b/infrastructure/setup/config/azureml-aks-config.template.json
@@ -6,6 +6,7 @@
   "allowInsecureConnections": "${ALLOW_INSECURE_CONNECTIONS}",
   "internalLoadBalancerProvider": "azure",
   "clusterPurpose": "${CLUSTER_PURPOSE}",
+  "amloperator.skipResourceValidation": "${SKIP_RESOURCE_VALIDATION}",
   "installNvidiaDevicePlugin": "false",
   "installDcgmExporter": "false",
   "installVolcano": "${INSTALL_VOLCANO}",

--- a/infrastructure/setup/manifests/volcano-scheduler-config-scale-from-zero.conf
+++ b/infrastructure/setup/manifests/volcano-scheduler-config-scale-from-zero.conf
@@ -1,0 +1,37 @@
+# Volcano scheduler config tuned for AKS cluster autoscaler scale-from-zero.
+#
+# The AzureML Kubernetes extension installs Volcano with the `overcommit` and
+# `proportion` plugins in the third tier. Both implement `JobEnqueueable`, which
+# the `enqueue` action calls to decide whether a PodGroup may transition from
+# Pending to Inqueue. Their decision is based on currently-Ready node capacity
+# only (proportion: queue.Allocated + queue.Free, overcommit: total * factor),
+# so on a cluster whose GPU node pools sit at count=0 they always return false:
+# no PodGroup is enqueued, Volcano never creates the underlying Pod, no Pending
+# Pod is visible to the AKS cluster autoscaler, and the GPU pool is never
+# scaled up — a self-induced deadlock.
+#
+# Removing both plugins makes `enqueue` permissive (default Permit when no
+# plugin objects), so Volcano creates the Pod immediately. The Pod is Pending
+# on a missing nvidia.com/gpu node, the autoscaler scales the pool from 0 to 1,
+# and once the node is Ready the `allocate` action binds the Pod. Gang
+# scheduling (the `gang` plugin in the second tier) still gates `allocate`, so
+# multi-pod jobs continue to wait for minAvailable before any task starts.
+#
+# Trade-off: queue-level capacity fairness across multiple PodGroups is no
+# longer enforced at enqueue time. Acceptable on single-tenant dev/training
+# clusters; re-enable proportion/overcommit on multi-tenant production clusters
+# (pass --enforce-volcano-capacity-check to 02-deploy-azureml-extension.sh).
+actions: "enqueue, allocate, backfill"
+tiers:
+  - plugins:
+      - name: priority
+        enableJobStarving: false
+      - name: conformance
+  - plugins:
+      - name: gang
+      - name: drf
+        enablePreemptable: false
+  - plugins:
+      - name: predicates
+      - name: nodeorder
+      - name: binpack

--- a/infrastructure/terraform/modules/sil/variables.tf
+++ b/infrastructure/terraform/modules/sil/variables.tf
@@ -102,6 +102,7 @@ variable "node_pools" {
       node_count                 = null
       subnet_address_prefixes    = ["10.0.16.0/24"]
       node_taints                = ["nvidia.com/gpu:NoSchedule", "kubernetes.azure.com/scalesetpriority=spot:NoSchedule"]
+      node_labels                = { accelerator = "nvidia" }
       gpu_driver                 = "Install"
       priority                   = "Spot"
       should_enable_auto_scaling = true

--- a/infrastructure/terraform/variables.tf
+++ b/infrastructure/terraform/variables.tf
@@ -411,6 +411,7 @@ variable "node_pools" {
       vm_size                    = "Standard_NV36ads_A10_v5"
       subnet_address_prefixes    = ["10.0.7.0/24"]
       node_taints                = ["nvidia.com/gpu:NoSchedule", "kubernetes.azure.com/scalesetpriority=spot:NoSchedule"]
+      node_labels                = { accelerator = "nvidia" }
       gpu_driver                 = "Install"
       priority                   = "Spot"
       should_enable_auto_scaling = true

--- a/tests/e2e/_aml.py
+++ b/tests/e2e/_aml.py
@@ -98,6 +98,72 @@ def submit_aml_training(
     )
 
 
+def submit_aml_lerobot_training(
+    repo_root: Path,
+    aml_workspace: AzureMLWorkspace,
+    *,
+    dataset_repo_id: str,
+    policy_type: str,
+    training_steps: int,
+    save_freq: int,
+    batch_size: int,
+    log_freq: int,
+) -> AzureMLJob:
+    experiment_name = _e2e_name("il-training-e2e-aml")
+    log_e2e(
+        "Submitting AzureML LeRobot training job "
+        f"for dataset={dataset_repo_id}, policy={policy_type}, training_steps={training_steps}, "
+        f"save_freq={save_freq}, batch_size={batch_size}, log_freq={log_freq}, experiment={experiment_name}"
+    )
+    # eval-freq > training-steps disables in-loop evaluation (which would need
+    # sim deps that are not part of the lerobot training container).
+    result = run_command(
+        [
+            str(repo_root / "training/il/scripts/submit-azureml-lerobot-training.sh"),
+            "--dataset-repo-id",
+            dataset_repo_id,
+            "--policy-type",
+            policy_type,
+            "--training-steps",
+            str(training_steps),
+            "--save-freq",
+            str(save_freq),
+            "--batch-size",
+            str(batch_size),
+            "--eval-freq",
+            str(training_steps + 1),
+            "--log-freq",
+            str(log_freq),
+            "--experiment-name",
+            experiment_name,
+            "--subscription-id",
+            aml_workspace.subscription_id,
+            "--resource-group",
+            aml_workspace.resource_group,
+            "--workspace-name",
+            aml_workspace.workspace_name,
+        ],
+        cwd=repo_root,
+    )
+    if result.returncode != 0:
+        raise AssertionError(f"AzureML LeRobot e2e submission failed\n\n{format_command_failure(result)}")
+
+    combined_output = "\n".join(part for part in (result.stdout, result.stderr) if part)
+    job_name = _parse_azureml_job_name(combined_output)
+    if job_name is None:
+        raise AssertionError(
+            f"Unable to parse AzureML job name from LeRobot submission output\n\n{combined_output.strip()}"
+        )
+
+    log_e2e(f"Submitted AzureML LeRobot job name={job_name}")
+
+    return AzureMLJob(
+        name=job_name,
+        workspace=aml_workspace,
+        experiment_name=experiment_name,
+    )
+
+
 def fetch_aml_job_payload(job: AzureMLJob, repo_root: Path) -> dict[str, Any]:
     result = run_command(
         [
@@ -183,18 +249,59 @@ def _mark_job_terminal(job: AzureMLJob, terminal_status: str) -> None:
     job.terminal_status = terminal_status
 
 
-def assert_job_has_checkpoint(job: AzureMLJob, repo_root: Path) -> None:
-    log_e2e(f"Checking checkpoint output for AzureML job {job.name}")
-    payload = fetch_aml_job_payload(job, repo_root)
-    properties = payload.get("properties")
-    outputs = payload.get("outputs")
-    if isinstance(properties, Mapping) and isinstance(properties.get("outputs"), Mapping):
-        outputs = properties["outputs"]
+def assert_job_has_checkpoint(job: AzureMLJob) -> None:
+    """Verify the AzureML ``checkpoints`` named output was populated with at least one file.
 
-    if isinstance(outputs, Mapping) and "checkpoints" in outputs:
-        log_e2e(f"Checkpoint output is present for AzureML job {job.name}")
-        return
-    raise AssertionError(f"AzureML job {job.name!r} did not expose a 'checkpoints' output")
+    The contents check (not just declaration check) is essential: when the
+    output binding is mis-wired, the named output is still *declared* on the
+    job payload but the upload directory stays empty and Azure ML silently
+    skips the upload. The bug fixed by #855 had exactly this shape — the
+    pre-fix code produced jobs whose payload listed ``outputs.checkpoints``
+    but whose blob path contained zero files.
+
+    Lists blobs under the named output's ``workspaceblobstore`` prefix
+    instead of downloading them — checkpoints can be hundreds of MB.
+    """
+    from azure.ai.ml import MLClient
+    from azure.identity import DefaultAzureCredential
+    from azure.storage.blob import ContainerClient
+
+    log_e2e(f"Listing checkpoint output blobs for AzureML job {job.name}")
+    credential = DefaultAzureCredential()
+    client = MLClient(
+        credential=credential,
+        subscription_id=job.workspace.subscription_id,
+        resource_group_name=job.workspace.resource_group,
+        workspace_name=job.workspace.workspace_name,
+    )
+
+    datastore = client.datastores.get("workspaceblobstore")
+    account_name = getattr(datastore, "account_name", None)
+    container_name = getattr(datastore, "container_name", None)
+    if not isinstance(account_name, str) or not account_name:
+        raise AssertionError(f"workspaceblobstore datastore has no account_name: {datastore!r}")
+    if not isinstance(container_name, str) or not container_name:
+        raise AssertionError(f"workspaceblobstore datastore has no container_name: {datastore!r}")
+
+    prefix = f"azureml/{job.name}/checkpoints/"
+    container = ContainerClient(
+        account_url=f"https://{account_name}.blob.core.windows.net",
+        container_name=container_name,
+        credential=credential,
+    )
+    with container:
+        blob_names = sorted(b.name for b in container.list_blobs(name_starts_with=prefix))
+
+    if not blob_names:
+        raise AssertionError(
+            f"AzureML job {job.name!r} 'checkpoints' named output is empty. "
+            "The training entry point did not write any files to "
+            "$AZURE_ML_OUTPUT_CHECKPOINTS — the wiring is broken (see #855)."
+        )
+
+    relative_names = [name.removeprefix(prefix) for name in blob_names]
+    sample = ", ".join(relative_names[:5])
+    log_e2e(f"Checkpoint output for AzureML job {job.name} contains {len(blob_names)} file(s); sample: {sample}")
 
 
 def _aml_code_resource_id(payload: Mapping[str, Any]) -> str:

--- a/tests/e2e/_mlflow.py
+++ b/tests/e2e/_mlflow.py
@@ -22,6 +22,15 @@ REQUIRED_PARAMS = (
     "distributed",
     "num_envs",
 )
+_LEROBOT_REQUIRED_METRICS = (
+    "train/loss",
+    "train/learning_rate",
+)
+_LEROBOT_REQUIRED_PARAMS = (
+    "policy_type",
+    "num_gpus",
+    "distributed",
+)
 
 
 @dataclass(frozen=True)
@@ -105,6 +114,8 @@ def _assert_run_has_expected_tracking(
     *,
     run_id: str,
     experiment_name: str,
+    required_metrics: tuple[str, ...] = REQUIRED_METRICS,
+    required_params: tuple[str, ...] = REQUIRED_PARAMS,
 ) -> MLflowTrackingResult:
     client = _mlflow_client(aml_workspace)
     run = client.get_run(run_id)
@@ -119,21 +130,21 @@ def _assert_run_has_expected_tracking(
     metrics = run.data.metrics
     params = run.data.params
 
-    missing_metrics = [name for name in REQUIRED_METRICS if name not in metrics]
+    missing_metrics = [name for name in required_metrics if name not in metrics]
     if missing_metrics:
         raise AssertionError(
             f"MLflow run {run_id!r} was missing metrics {missing_metrics}; available metrics: {sorted(metrics)}"
         )
 
-    missing_params = [name for name in REQUIRED_PARAMS if name not in params or params[name] == ""]
+    missing_params = [name for name in required_params if name not in params or params[name] == ""]
     if missing_params:
         raise AssertionError(
             f"MLflow run {run_id!r} was missing params {missing_params}; available params: {sorted(params)}"
         )
 
     return MLflowTrackingResult(
-        metrics={name: metrics[name] for name in REQUIRED_METRICS},
-        params={name: params[name] for name in REQUIRED_PARAMS},
+        metrics={name: metrics[name] for name in required_metrics},
+        params={name: params[name] for name in required_params},
         tags=run.data.tags,
     )
 
@@ -147,6 +158,19 @@ def assert_aml_job_has_mlflow_tracking(job: AzureMLJob, aml_workspace: AzureMLWo
     rendered_metrics = ", ".join(f"{name}={value}" for name, value in tracking.metrics.items())
     rendered_params = ", ".join(f"{name}={value}" for name, value in tracking.params.items())
     log_e2e(f"AzureML MLflow tracking passed: metrics=[{rendered_metrics}] params=[{rendered_params}]")
+
+
+def assert_aml_lerobot_job_has_mlflow_tracking(job: AzureMLJob, aml_workspace: AzureMLWorkspace) -> None:
+    tracking = _assert_run_has_expected_tracking(
+        aml_workspace,
+        run_id=job.name,
+        experiment_name=job.experiment_name,
+        required_metrics=_LEROBOT_REQUIRED_METRICS,
+        required_params=_LEROBOT_REQUIRED_PARAMS,
+    )
+    rendered_metrics = ", ".join(f"{name}={value}" for name, value in tracking.metrics.items())
+    rendered_params = ", ".join(f"{name}={value}" for name, value in tracking.params.items())
+    log_e2e(f"AzureML LeRobot MLflow tracking passed: metrics=[{rendered_metrics}] params=[{rendered_params}]")
 
 
 def assert_osmo_workflow_has_mlflow_tracking(workflow: OSMOWorkflow, aml_workspace: AzureMLWorkspace) -> None:

--- a/tests/e2e/test_e2e_training.py
+++ b/tests/e2e/test_e2e_training.py
@@ -9,8 +9,11 @@ To run these:
 # All e2e tests
 uv run pytest -vv -s -m e2e tests/e2e/test_e2e_training.py
 
-# Only AML e2e test
+# Only AML RL e2e test
 uv run pytest -vv -s -m e2e tests/e2e/test_e2e_training.py::test_aml_rl_training_e2e
+
+# Only AML IL (LeRobot) e2e test
+uv run pytest -vv -s -m e2e tests/e2e/test_e2e_training.py::test_aml_il_training_e2e
 
 # Only OSMO e2e test
 uv run pytest -vv -s -m e2e tests/e2e/test_e2e_training.py::test_osmo_rl_training_e2e
@@ -29,6 +32,7 @@ from tests.e2e._aml import (
     assert_job_has_checkpoint,
     assert_job_snapshot_contains_only_training,
     cancel_aml_job,
+    submit_aml_lerobot_training,
     submit_aml_training,
     wait_until_aml_completed,
     wait_until_aml_started,
@@ -36,6 +40,7 @@ from tests.e2e._aml import (
 from tests.e2e._common import log_e2e
 from tests.e2e._mlflow import (
     assert_aml_job_has_mlflow_tracking,
+    assert_aml_lerobot_job_has_mlflow_tracking,
     assert_osmo_workflow_has_mlflow_tracking,
 )
 from tests.e2e._osmo import (
@@ -73,8 +78,41 @@ def test_aml_rl_training_e2e(
     log_e2e("Validating AzureML MLflow tracking")
     assert_aml_job_has_mlflow_tracking(job, aml_workspace)
     log_e2e("Validating AzureML checkpoint output")
-    assert_job_has_checkpoint(job, repo_root)
+    assert_job_has_checkpoint(job)
     log_e2e("AzureML RL e2e test finished successfully")
+
+
+@pytest.mark.e2e
+@pytest.mark.usefixtures("aml_compute_target")
+def test_aml_il_training_e2e(
+    request: pytest.FixtureRequest,
+    aml_workspace: AzureMLWorkspace,
+    repo_root: Path,
+) -> None:
+    log_e2e("Starting AzureML IL (LeRobot) e2e test")
+    job = submit_aml_lerobot_training(
+        repo_root,
+        aml_workspace,
+        dataset_repo_id="lerobot/pusht",
+        policy_type="act",
+        training_steps=10,
+        save_freq=5,
+        batch_size=8,
+        log_freq=1,
+    )
+    request.addfinalizer(lambda: cancel_aml_job(job, repo_root))
+
+    log_e2e(f"Waiting for AzureML LeRobot job {job.name} to start")
+    wait_until_aml_started(job, repo_root, timeout_minutes=15, poll_interval_seconds=30)
+    log_e2e(f"Waiting for AzureML LeRobot job {job.name} to complete")
+    wait_until_aml_completed(job, repo_root, timeout_minutes=30, poll_interval_seconds=30)
+    log_e2e("Validating AzureML LeRobot uploaded code snapshot")
+    assert_job_snapshot_contains_only_training(job, repo_root)
+    log_e2e("Validating AzureML LeRobot MLflow tracking")
+    assert_aml_lerobot_job_has_mlflow_tracking(job, aml_workspace)
+    log_e2e("Validating AzureML LeRobot checkpoint output")
+    assert_job_has_checkpoint(job)
+    log_e2e("AzureML LeRobot e2e test finished successfully")
 
 
 @pytest.mark.e2e

--- a/training/il/scripts/lerobot/azureml-train-entry.sh
+++ b/training/il/scripts/lerobot/azureml-train-entry.sh
@@ -172,6 +172,10 @@ if [[ ${total_sources} -eq 0 ]]; then
   if [[ -n "${HF_TOKEN:-}" ]]; then
     python3 -c "import os; from huggingface_hub import login; login(token=os.environ['HF_TOKEN'], add_to_git_credential=False)"
   fi
+  # video_backend=pyav avoids torchcodec's dynamic-link dependency on
+  # libnvrtc.so (shipped as a pip wheel whose lib/ is not on LD_LIBRARY_PATH
+  # in a fresh venv). Consistent with the local-data paths below.
+  train_args+=(--dataset.video_backend=pyav)
 elif [[ ${total_sources} -eq 1 ]]; then
   # Single source — use directly, no merge needed.
   # use_imagenet_stats=true so lerobot normalizes images with ImageNet (3,1,1)

--- a/training/il/scripts/lerobot/train.py
+++ b/training/il/scripts/lerobot/train.py
@@ -74,6 +74,33 @@ _PROCESS_GROUP_KILL_GRACE_S = 15
 _VALID_MIXED_PRECISION = {"no", "fp16", "bf16"}
 
 
+def _sync_checkpoint_output(output_dir: Path) -> None:
+    """Mirror ``output_dir/checkpoints/`` into ``$AZURE_ML_OUTPUT_CHECKPOINTS`` if set.
+
+    Azure ML exports ``AZURE_ML_OUTPUT_<NAME>`` for each ``uri_folder`` output
+    declared on the job; whatever lands in that directory is uploaded to the
+    named output's blob path at job end. No-op when the env var is unset
+    (e.g., local runs) or when there is nothing to copy.
+    """
+
+    target = os.environ.get("AZURE_ML_OUTPUT_CHECKPOINTS")
+    if not target:
+        return
+
+    source = output_dir / "checkpoints"
+    if not source.exists():
+        return
+
+    destination = Path(target)
+    try:
+        if destination.exists():
+            shutil.rmtree(destination)
+        shutil.copytree(source, destination, dirs_exist_ok=True)
+        print(f"[AzureML] Copied checkpoints to {destination}")
+    except Exception as exc:
+        print(f"[AzureML] Failed to copy checkpoints to {destination}: {exc}")
+
+
 def _detect_num_gpus() -> int:
     """Detect the number of CUDA devices visible to the job container.
 
@@ -367,9 +394,7 @@ def run_training(cmd: list[str], source: str = "osmo-lerobot-training", num_gpus
         )
 
         def signal_handler(signum: int, frame: object) -> None:
-            print(f"[MLflow] Received signal {signum}, saving checkpoints and terminating subprocess group...")
-            with contextlib.suppress(Exception):
-                upload_new_checkpoints(run, output_dir, uploaded_checkpoints, source=source)
+            print(f"[MLflow] Received signal {signum}, terminating subprocess group then mirroring checkpoints...")
             with contextlib.suppress(ProcessLookupError):
                 os.killpg(process.pid, signal.SIGTERM)
             try:
@@ -381,6 +406,16 @@ def run_training(cmd: list[str], source: str = "osmo-lerobot-training", num_gpus
                 )
                 with contextlib.suppress(ProcessLookupError):
                     os.killpg(process.pid, signal.SIGKILL)
+                with contextlib.suppress(subprocess.TimeoutExpired):
+                    process.wait(timeout=5)
+            # Workers are now quiescent; safe to read the on-disk checkpoint tree
+            # without risking partial-file mirrors. Doing the copy before kill
+            # would race accelerate workers still writing to checkpoint shards
+            # and could mirror a half-written destination.
+            with contextlib.suppress(Exception):
+                upload_new_checkpoints(run, output_dir, uploaded_checkpoints, source=source)
+            with contextlib.suppress(Exception):
+                _sync_checkpoint_output(output_dir)
 
         signal.signal(signal.SIGTERM, signal_handler)
         signal.signal(signal.SIGINT, signal_handler)
@@ -424,6 +459,7 @@ def run_training(cmd: list[str], source: str = "osmo-lerobot-training", num_gpus
 
         print("[MLflow] Uploading final checkpoints...")
         upload_new_checkpoints(run, output_dir, uploaded_checkpoints, source=source)
+        _sync_checkpoint_output(output_dir)
 
         mlflow.log_param("output_dir", str(output_dir))
 
@@ -515,6 +551,7 @@ def main() -> int:
         "LEARNING_RATE": "--policy.optimizer_lr",
         "EVAL_FREQ": "--eval_freq",
         "SAVE_FREQ": "--save_freq",
+        "LOG_FREQ": "--log_freq",
     }
     for env_var, arg_name in env_arg_map.items():
         if arg_name not in cli_text:

--- a/training/il/scripts/submit-azureml-lerobot-training.sh
+++ b/training/il/scripts/submit-azureml-lerobot-training.sh
@@ -76,6 +76,7 @@ TRAINING HYPERPARAMETERS:
         --batch-size N            Training batch size
         --eval-freq N             Evaluation frequency
         --save-freq N             Checkpoint save frequency (default: 5000)
+        --log-freq N              MLflow metric log frequency (default: 200)
 
 CHECKPOINT REGISTRATION:
     -r, --register-checkpoint NAME  Model name for Azure ML registration
@@ -285,6 +286,7 @@ training_steps="${TRAINING_STEPS:-}"
 batch_size="${BATCH_SIZE:-}"
 eval_freq="${EVAL_FREQ:-}"
 save_freq="${SAVE_FREQ:-5000}"
+log_freq="${LOG_FREQ:-}"
 
 register_checkpoint="${REGISTER_CHECKPOINT:-}"
 
@@ -330,6 +332,7 @@ while [[ $# -gt 0 ]]; do
     --batch-size)                 batch_size="$2"; shift 2 ;;
     --eval-freq)                  eval_freq="$2"; shift 2 ;;
     --save-freq)                  save_freq="$2"; shift 2 ;;
+    --log-freq)                   log_freq="$2"; shift 2 ;;
     -r|--register-checkpoint)     register_checkpoint="$2"; shift 2 ;;
     --subscription-id)            subscription_id="$2"; shift 2 ;;
     --resource-group)             resource_group="$2"; shift 2 ;;
@@ -593,6 +596,7 @@ az_args+=(
 [[ -n "$training_steps" ]]      && az_args+=(--set "environment_variables.TRAINING_STEPS=$training_steps")
 [[ -n "$batch_size" ]]          && az_args+=(--set "environment_variables.BATCH_SIZE=$batch_size")
 [[ -n "$eval_freq" ]]           && az_args+=(--set "environment_variables.EVAL_FREQ=$eval_freq")
+[[ -n "$log_freq" ]]            && az_args+=(--set "environment_variables.LOG_FREQ=$log_freq")
 [[ -n "$register_checkpoint" ]] && az_args+=(--set "environment_variables.REGISTER_CHECKPOINT=$register_checkpoint")
 
 if [[ ${#dataset_assets[@]} -gt 0 ]]; then

--- a/training/il/workflows/azureml/lerobot-train.yaml
+++ b/training/il/workflows/azureml/lerobot-train.yaml
@@ -61,10 +61,11 @@ command: echo "Command will be set by submission script"
 # Static env vars only. Every training-related env var is set by
 # submit-azureml-lerobot-training.sh via --set environment_variables.X=Y flags
 # because the AzureML K8s extension does not substitute ${{inputs.X}} template
-# refs at runtime.
+# refs at runtime. The same constraint applies to ${{outputs.X}} — do NOT add
+# templated output env vars here; training reads $AZURE_ML_OUTPUT_<NAME>
+# directly from the runtime.
 environment_variables:
   AZURE_AUTHORITY_HOST: https://login.microsoftonline.com
-  TRAINING_CHECKPOINT_OUTPUT: ${{outputs.checkpoints}}
   # MLFLOW_HTTP_REQUEST_TIMEOUT: <set by script>
 
 outputs:

--- a/training/rl/scripts/skrl_training.py
+++ b/training/rl/scripts/skrl_training.py
@@ -121,9 +121,15 @@ def _build_parser(app_launcher_cls: Any) -> argparse.ArgumentParser:
 
 
 def _sync_checkpoint_output(checkpoint_dir: Path) -> None:
-    """Copy checkpoints into AzureML outputs when TRAINING_CHECKPOINT_OUTPUT is set."""
+    """Copy ``checkpoint_dir`` into ``$AZURE_ML_OUTPUT_CHECKPOINTS`` if set.
 
-    target = os.environ.get("TRAINING_CHECKPOINT_OUTPUT")
+    Azure ML exports ``AZURE_ML_OUTPUT_<NAME>`` for each ``uri_folder`` output
+    declared on the job; whatever the training process writes into that
+    directory is uploaded to the named output's blob path at job end. No-op
+    when the env var is unset (e.g., local runs).
+    """
+
+    target = os.environ.get("AZURE_ML_OUTPUT_CHECKPOINTS")
     if not target or not checkpoint_dir.exists():
         return
 

--- a/training/rl/workflows/azureml/train.yaml
+++ b/training/rl/workflows/azureml/train.yaml
@@ -54,7 +54,9 @@ environment_variables:
   PYTHON: /workspace/isaaclab/isaaclab.sh -p
   ACCEPT_EULA: "Y"
   PRIVACY_CONSENT: "Y"
-  TRAINING_CHECKPOINT_OUTPUT: ${{outputs.checkpoints}}
+  # Do NOT add ${{outputs.X}} env vars here — Azure ML does not substitute
+  # template expressions inside environment_variables (only inside command).
+  # Training reads $AZURE_ML_OUTPUT_<NAME> directly from the runtime.
   # The following are set by submit-azureml-training.sh via --set flags
   # AZURE_SUBSCRIPTION_ID: <set by script>
   # AZURE_RESOURCE_GROUP: <set by script>

--- a/training/specifications/rl-training.specification.md
+++ b/training/specifications/rl-training.specification.md
@@ -34,4 +34,4 @@ Active — primary training approach.
 
 ## Checkpoint Flow
 
-Training writes checkpoints to local filesystem. The `TRAINING_CHECKPOINT_OUTPUT` environment variable controls the output path. AzureML uploads checkpoints as `uri_folder` artifacts.
+Training writes checkpoints to the local filesystem and mirrors them at job exit into the directory named by `$AZURE_ML_OUTPUT_CHECKPOINTS`. Azure ML uploads the contents to the job's `checkpoints` `uri_folder` output, from where downstream pipeline jobs can consume them as a typed input.

--- a/training/tests/test_lerobot_train.py
+++ b/training/tests/test_lerobot_train.py
@@ -68,6 +68,53 @@ class TestParseKValue:
         assert _MOD._parse_k_value("1.5K") == 1500.0
 
 
+class TestSyncCheckpointOutput:
+    """``_sync_checkpoint_output`` mirrors ``OUTPUT_DIR/checkpoints/`` into the
+    AzureML ``checkpoints`` named output (env var ``AZURE_ML_OUTPUT_CHECKPOINTS``)."""
+
+    def test_no_target_does_nothing(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("AZURE_ML_OUTPUT_CHECKPOINTS", raising=False)
+        (tmp_path / "checkpoints").mkdir()
+        _MOD._sync_checkpoint_output(tmp_path)
+
+    def test_missing_source_does_nothing(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("AZURE_ML_OUTPUT_CHECKPOINTS", str(tmp_path / "out"))
+        _MOD._sync_checkpoint_output(tmp_path)
+        assert not (tmp_path / "out").exists()
+
+    def test_copies_to_destination(self, tmp_path, monkeypatch):
+        src = tmp_path / "checkpoints"
+        src.mkdir()
+        (src / "ckpt.safetensors").write_text("data")
+        dest = tmp_path / "out"
+        monkeypatch.setenv("AZURE_ML_OUTPUT_CHECKPOINTS", str(dest))
+
+        _MOD._sync_checkpoint_output(tmp_path)
+
+        assert (dest / "ckpt.safetensors").read_text() == "data"
+
+    def test_replaces_existing_destination(self, tmp_path, monkeypatch):
+        src = tmp_path / "checkpoints"
+        src.mkdir()
+        (src / "new.safetensors").write_text("new")
+        dest = tmp_path / "out"
+        dest.mkdir()
+        (dest / "stale.safetensors").write_text("stale")
+        monkeypatch.setenv("AZURE_ML_OUTPUT_CHECKPOINTS", str(dest))
+
+        _MOD._sync_checkpoint_output(tmp_path)
+
+        assert (dest / "new.safetensors").exists()
+        assert not (dest / "stale.safetensors").exists()
+
+    def test_swallows_copy_errors(self, tmp_path, monkeypatch):
+        (tmp_path / "checkpoints").mkdir()
+        monkeypatch.setenv("AZURE_ML_OUTPUT_CHECKPOINTS", str(tmp_path / "out"))
+        monkeypatch.setattr(_MOD.shutil, "copytree", MagicMock(side_effect=OSError("denied")))
+        # Should not raise.
+        _MOD._sync_checkpoint_output(tmp_path)
+
+
 class TestInitSystemCollector:
     def test_disabled_via_env(self, monkeypatch):
         monkeypatch.setenv("SYSTEM_METRICS", "false")

--- a/training/tests/test_skrl_training.py
+++ b/training/tests/test_skrl_training.py
@@ -96,12 +96,12 @@ class TestBuildParser:
 
 class TestSyncCheckpointOutput:
     def test_no_target_does_nothing(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.delenv("TRAINING_CHECKPOINT_OUTPUT", raising=False)
+        monkeypatch.delenv("AZURE_ML_OUTPUT_CHECKPOINTS", raising=False)
         # Should silently return without error.
         _MOD._sync_checkpoint_output(tmp_path / "missing")
 
     def test_missing_source_does_nothing(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        monkeypatch.setenv("TRAINING_CHECKPOINT_OUTPUT", str(tmp_path / "out"))
+        monkeypatch.setenv("AZURE_ML_OUTPUT_CHECKPOINTS", str(tmp_path / "out"))
         _MOD._sync_checkpoint_output(tmp_path / "does_not_exist")
         assert not (tmp_path / "out").exists()
 
@@ -110,7 +110,7 @@ class TestSyncCheckpointOutput:
         src.mkdir()
         (src / "ckpt.pt").write_text("data")
         dest = tmp_path / "out"
-        monkeypatch.setenv("TRAINING_CHECKPOINT_OUTPUT", str(dest))
+        monkeypatch.setenv("AZURE_ML_OUTPUT_CHECKPOINTS", str(dest))
 
         _MOD._sync_checkpoint_output(src)
 
@@ -123,7 +123,7 @@ class TestSyncCheckpointOutput:
         dest = tmp_path / "out"
         dest.mkdir()
         (dest / "stale.pt").write_text("stale")
-        monkeypatch.setenv("TRAINING_CHECKPOINT_OUTPUT", str(dest))
+        monkeypatch.setenv("AZURE_ML_OUTPUT_CHECKPOINTS", str(dest))
 
         _MOD._sync_checkpoint_output(src)
 
@@ -133,7 +133,7 @@ class TestSyncCheckpointOutput:
     def test_swallows_copy_errors(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         src = tmp_path / "checkpoints"
         src.mkdir()
-        monkeypatch.setenv("TRAINING_CHECKPOINT_OUTPUT", str(tmp_path / "out"))
+        monkeypatch.setenv("AZURE_ML_OUTPUT_CHECKPOINTS", str(tmp_path / "out"))
         monkeypatch.setattr(_MOD.shutil, "copytree", MagicMock(side_effect=OSError("denied")))
         # Should not raise.
         _MOD._sync_checkpoint_output(src)


### PR DESCRIPTION
# Pull Request

## Description

Fixes the AzureML `checkpoints` *uri_folder* output for both RL and IL training jobs (issue #855), then adds the surrounding pieces required for that fix to be exercisable end-to-end on a scale-to-zero GPU cluster.

The root cause was wiring the named output through `TRAINING_CHECKPOINT_OUTPUT: ${{outputs.checkpoints}}` inside `environment_variables:`. Azure ML only substitutes `${{outputs.X}}` template expressions inside `command:`; inside `environment_variables:` the container receives the literal template string, writes into a directory of that name, and the data-capability sidecar uploads nothing to the named output. Training entry points now read `$AZURE_ML_OUTPUT_CHECKPOINTS` directly (the per-output runtime path Azure ML exports for every `uri_folder` output) and mirror their local *checkpoints/* tree into it at finalization. The broken `${{outputs.checkpoints}}` line is removed from both job YAMLs.

A real AzureML LeRobot e2e test was added alongside the existing SKRL one, and `assert_job_has_checkpoint` was upgraded to enumerate the *checkpoints* output blobs via the **azure-storage-blob SDK** and assert non-empty contents — the previous declaration-only check happily passed against the buggy code. The LeRobot test forced two related issues to the surface and they are fixed in the same branch: a *torchcodec* / *torch* C++ ABI mismatch from a stale override pin, and missing MLflow metrics on short runs because lerobot's `cfg.log_freq` defaults to 200. Finally, three independent defaults blocked scale-from-zero on the GPU pool the new test targets — *aml-operator* resource validation, a missing static `accelerator=nvidia` node label, and Volcano's enqueue-time capacity gate — and all three are corrected and documented.

Closes #855

### Checkpoint output wiring

- Replaced the `TRAINING_CHECKPOINT_OUTPUT` env-var indirection with a direct read of **`$AZURE_ML_OUTPUT_CHECKPOINTS`** in *training/rl/scripts/skrl_training.py* and a new `_sync_checkpoint_output` helper in *training/il/scripts/lerobot/train.py*. Both entry points mirror local *checkpoints/* into the runtime path on the SIGTERM handler and on normal finalization.
- Removed the literal `TRAINING_CHECKPOINT_OUTPUT: ${{outputs.checkpoints}}` line from *training/rl/workflows/azureml/train.yaml* and *training/il/workflows/azureml/lerobot-train.yaml*; both YAMLs now carry an inline comment warning that `environment_variables:` does **not** template-substitute.
- Updated *training/specifications/rl-training.specification.md*, *docs/operations/troubleshooting.md*, and *.github/copilot-instructions.md* to describe the new contract.

### AzureML e2e coverage

- Rewrote `assert_job_has_checkpoint` in *tests/e2e/_aml.py* to resolve the `workspaceblobstore` datastore via `MLClient.datastores.get(...)`, then list blobs under `azureml/{job}/checkpoints/` with `azure.storage.blob.ContainerClient.list_blobs(name_starts_with=...)`. The check no longer downloads any checkpoint bytes — avoids the >100 MB AzCopy nag on every e2e run — but still catches the exact regression #855 fixed; the previous payload-only check did not.
- Added `submit_aml_lerobot_training` and `test_aml_il_training_e2e` (lerobot/pusht, *act*, 10 steps, `--log-freq 1`, `--eval-freq > training-steps` to skip in-loop eval).
- Parametrised `_assert_run_has_expected_tracking` in *tests/e2e/_mlflow.py* with `required_metrics` / `required_params` and added a LeRobot-specific tuple (`train/loss`, `train/learning_rate`, `policy_type`, `num_gpus`, `distributed`) plus `assert_aml_lerobot_job_has_mlflow_tracking`.
- Added `TestSyncCheckpointOutput` to *training/tests/test_lerobot_train.py* (five cases mirroring the SKRL coverage); renamed the env var in the matching SKRL tests.

### LeRobot dependency fixes

- Pinned **`torchcodec==0.10.0`** (was 0.13.0) in *training/il/lerobot/pyproject.toml*. 0.13.x requires `torch>=2.11` per its release notes but declares no torch dependency in PyPI metadata, so the uv resolver did not catch it — pairing 0.13.0 with the lerobot-allowed torch 2.10 produced `libtorchcodec_core4.so: undefined symbol: torch_from_blob` at import time. 0.10.0 still ships `manylinux_2_28_x86_64` wheels for cp312.
- Pinned **`numpy==2.2.6`** (was 2.4.6) — the previous comment claimed lerobot's cap was `<2.4` but the actual cap on 0.5.1 is `<2.3`.
- Dropped both pins from `[tool.uv] override-dependencies` and regenerated *training/il/lerobot/requirements.txt*.

### MLflow `--log-freq` plumbing

- lerobot emits the `step:N smpl:... loss:... lr:...` lines our wrapper parses only when `step % cfg.log_freq == 0`; with the upstream default of 200 the 10-step e2e run captured zero MLflow metrics. Added `--log-freq N` end-to-end: *submit-azureml-lerobot-training.sh* CLI flag and `LOG_FREQ` env-var passthrough, `"LOG_FREQ": "--log_freq"` in `env_arg_map` inside *training/il/scripts/lerobot/train.py*, the new required `log_freq` kwarg on `submit_aml_lerobot_training`, and `log_freq=1` in the e2e test.

### Scale-from-zero GPU pools

> Three independent defaults deadlock scale-from-zero on the AzureML GPU pool. *aml-operator* rejects any job whose `InstanceType` exceeds the largest currently-Ready node (which is "none" on an empty pool, so submission fails before a Pod exists for the autoscaler to react to). The autoscaler's synthetic node template strips the `accelerator: nvidia` label that the InstanceType selector requires. And Volcano's `enqueue` action runs `JobEnqueueable` plugins (`overcommit`, `proportion`) that compare requested resources against currently-Ready cluster capacity — when GPU total is zero, every GPU PodGroup is rejected at enqueue, no Pod is ever created, and the autoscaler never sees a Pending Pod.

- Flipped `amloperator.skipResourceValidation` to **`true`** by default in *infrastructure/setup/02-deploy-azureml-extension.sh* and the matching `azureml-aks-config.template.json`. New `--enforce-resource-validation` flag opts back into fail-fast for fixed-capacity clusters.
- Added the static **`node_labels = { accelerator = "nvidia" }`** declaration to the default GPU pool in *infrastructure/terraform/variables.tf* and *infrastructure/terraform/modules/sil/variables.tf* so the autoscaler's synthetic node template includes it.
- Patched the `volcano-scheduler-configmap` post-install to drop **`overcommit`** and **`proportion`** from tier 3 — gang scheduling stays in tier 2 so multi-pod jobs still wait for `minAvailable` before any task binds. New manifest *infrastructure/setup/manifests/volcano-scheduler-config-scale-from-zero.conf* and `--enforce-volcano-capacity-check` flag in *02-deploy-azureml-extension.sh* opt back into the upstream behaviour on multi-tenant clusters where submit-time queue fairness must be preserved.
- Documented all three root causes, the override flags, the static-label requirement, and a three-layer troubleshooting walk in the *🛌 Scale-from-zero GPU Pools* section of *docs/training/azureml-training.md*. Cross-linked from *docs/infrastructure/manage-node-pools.md*. Added `amloperator`, `enqueueable`, `inqueue`, and `podgroup` to *.cspell/general-technical.txt*.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change fixing an issue)
- [ ] ✨ New feature (non-breaking change adding functionality)
- [ ] 💥 Breaking change (fix or feature causing existing functionality to change)
- [x] 📚 Documentation update
- [x] 🏗️ Infrastructure change (Terraform/IaC)
- [ ] ♻️ Refactoring (no functional changes)

## Component(s) Affected

- [ ] `infrastructure/terraform/prerequisites/` - Azure subscription setup
- [x] `infrastructure/terraform/` - Terraform infrastructure
- [x] `infrastructure/setup/` - OSMO control plane / Helm
- [ ] `workflows/` - Training and evaluation workflows
- [x] `training/` - Training pipelines and scripts
- [x] `docs/` - Documentation

## Testing Performed

- [ ] Terraform `plan` reviewed (no unexpected changes)
- [ ] Terraform `apply` tested in dev environment
- [ ] Training scripts tested locally with Isaac Sim
- [ ] OSMO workflow submitted successfully
- [ ] Smoke tests passed (`smoke_test_azure.py`)

End-to-end verification on `mlw-hexmshack-dev-001` (AKS `aks-hexmshack-dev-001`, GPU pool `a100gpu` at `count=0, max=1`, Standard_NC24ads_A100_v4):

- `uv run pytest -vv -s -m e2e tests/e2e/test_e2e_training.py::test_aml_il_training_e2e` — **passed** (status *Completed*, ~6 min wall time). Verified the full chain: submit → queue → autoscale GPU pool 0→1 → Pod binds → run → MLflow tracking → non-empty `checkpoints` named output enumerated via blob list. MLflow captured `train/loss`, `train/learning_rate`, `policy_type=act`, `num_gpus=1`, `distributed=false`.
- Unit suites covering `_sync_checkpoint_output` (SKRL + LeRobot) extended with cases for the new `AZURE_ML_OUTPUT_CHECKPOINTS` env var.

## Documentation Impact

- [ ] No documentation changes needed
- [x] Documentation updated in this PR
- [ ] Documentation issue filed

## Bug Fix Checklist

- [x] Linked to issue being fixed
- [x] Regression test included, OR
- [ ] Justification for no regression test:

## Checklist

- [x] My code follows the [project conventions](copilot-instructions.md)
- [x] Commit messages follow [conventional commit format](instructions/commit-message.instructions.md)
- [x] I have performed a self-review
- [x] Documentation impact assessed above
- [x] No new linting warnings introduced
