### PR TITLE
ci(workflows): make OSV-Scanner advisory-only and non-blocking

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -159,7 +159,11 @@ jobs:
       upload-sarif: true
       exclude-paths: 'scripts/tests/Fixtures/**,shared/ci/tests/Fixtures/**'
 
-  # OSV-Scanner: vulnerability scan across manifests using osv-scanner.toml
+  # OSV-Scanner: advisory-only vulnerability scan across manifests using
+  # osv-scanner.toml. The scan step uses continue-on-error so the job always
+  # reports success (green) even when vulnerabilities are found; findings still
+  # surface in the Security tab via SARIF. This job is intentionally excluded
+  # from the pr-validation-summary gate.
   osv-scanner:
     name: OSV-Scanner
     runs-on: ubuntu-latest
@@ -173,6 +177,7 @@ jobs:
           persist-credentials: false
       - name: Run OSV-Scanner
         uses: google/osv-scanner-action/osv-scanner-action@9a498708959aeaef5ef730655706c5a1df1edbc2  # v2.3.8
+        continue-on-error: true
         with:
           # --no-resolve disables transitive resolution; pinned requirements files
           # contain version pins that conflict with transitive constraints, but

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "lint:tf": "pwsh -File scripts/linting/Invoke-TFLint.ps1",
     "lint:tf:validate": "pwsh -File scripts/linting/Invoke-TerraformValidation.ps1",
     "lint:vuln": "osv-scanner --config osv-scanner.toml .",
-    "lint:vuln:ci": "osv-scanner --config osv-scanner.toml .",
     "lint:all": "npm run lint:md && npm run lint:ps && npm run lint:links && npm run lint:yaml && npm run lint:tf && npm run lint:go && npm run lint:sh && npm run lint:py",
     "format:tables": "markdown-table-formatter \"**/*.md\"",
     "test:ps": "pwsh -File ./scripts/tests/Invoke-PesterTests.ps1",


### PR DESCRIPTION
## Description

Makes the OSV-Scanner CI check advisory-only so vulnerability findings no longer block PR merges. The scan still runs on every PR and uploads SARIF to the Security tab, but the job reports success (green) even when vulnerabilities are found, and it is intentionally excluded from the `pr-validation-summary` required gate.

Closes #914

## Type of Change

- [x] CI/CD or build configuration change

## Component(s) Affected

- [x] `workflows/` (CI/CD)

## Testing Performed

- `npm run lint:yaml` (actionlint) — 0 issues across all workflow files
- Verified `package.json` remains valid JSON after removing the unused `lint:vuln:ci` script

## Documentation Impact

- [x] No documentation changes required

## Checklist

- [x] My code follows the project's conventions
- [x] I have performed a self-review of my changes
- [x] My changes generate no new warnings or lint errors

### Changes

- Add `continue-on-error: true` to the **Run OSV-Scanner** step so findings do not fail the job
- Document the advisory-only behavior in a comment above the `osv-scanner` job
- Remove the now-redundant `lint:vuln:ci` npm script (the `lint:vuln` script is retained)

🔒 - Generated by Copilot