### PR TITLE
fix(infrastructure): bump Azure Managed Grafana to major version 12

### DIFF
--- a/infrastructure/terraform/modules/platform/observability.tf
+++ b/infrastructure/terraform/modules/platform/observability.tf
@@ -67,7 +67,7 @@ resource "azurerm_dashboard_grafana" "main" {
   api_key_enabled                   = true
   deterministic_outbound_ip_enabled = false
   public_network_access_enabled     = var.should_enable_public_network_access
-  grafana_major_version             = 11
+  grafana_major_version             = 12
   sku                               = "Standard"
   zone_redundancy_enabled           = false
 


### PR DESCRIPTION
## Summary

Bumps the platform observability module's Azure Managed Grafana workspace from major version 11 to 12. Version 11 is approaching end of support; this tracks the current supported major version.

Closes #1039

## Changes

- `infrastructure/terraform/modules/platform/observability.tf`: set `grafana_major_version = 12` on `azurerm_dashboard_grafana.main`.

## Impact

- New deployments provision Grafana 12.
- Existing workspaces upgrade in place on `terraform apply` (Azure Managed Grafana supports in-place major version upgrade).

## Validation

- [ ] `npm run lint:tf` (tflint)
- [ ] `npm run lint:tf:validate` (fmt + validate)

## Notes

Single-line, low-risk change scoped to the observability module.