### PR TITLE
fix(training): replace base64 OSMO payload with object-storage url: delivery

### DIFF
--- a/.github/skills/osmo-lerobot-training/SKILL.md
+++ b/.github/skills/osmo-lerobot-training/SKILL.md
@@ -16,7 +16,7 @@ Read the skill file `.github/skills/osmo-lerobot-training/SKILL.md` for paramete
 | `osmo` CLI | Workflow submission and monitoring |
 | `az` CLI | Azure authentication and model registry |
 | `terraform` | Infrastructure output resolution |
-| `zip`, `base64` | Training payload packaging |
+| `zip` | Training payload packaging |
 | Python 3.12+ with `azure-ai-ml`, `mlflow` | Metric retrieval from Azure ML |
 
 Authentication must be configured before any OSMO or Azure ML operations:

--- a/docs/operations/troubleshooting.md
+++ b/docs/operations/troubleshooting.md
@@ -237,6 +237,19 @@ Use `simulation_shutdown.py` which stops the simulation timeline and applies a S
 2. Confirm access before submitting: `osmo data check azure://<account>/<container>` returns `{"status": "pass"}`.
 3. If the pod fails to fetch the code, verify the workflow pod's workload identity has read access to the same container.
 
+### OSMO code-upload objects accumulate under `osmo-code/`
+
+**Cause:** Each submission content-addresses the packaged code by a hash over its files and uploads it to `osmo-code/<hash>` only when that object is absent. Byte-identical code reuses the existing object, but every distinct code revision creates a new one, so the prefix grows as the code evolves and is not pruned automatically.
+
+**Resolution:**
+
+List the staged archives and delete stale ones, or apply an Azure Storage lifecycle management policy that expires blobs under the prefix:
+
+```bash
+osmo data list azure://<account>/<container>/osmo-code
+osmo data delete azure://<account>/<container>/osmo-code/<hash>
+```
+
 ### OSMO workflow YAML template rendering fails
 
 **Cause:** OSMO uses Jinja templates (`{{ }}`). Helm Go template syntax (`{{ .Values }}`) causes parse errors.

--- a/docs/operations/troubleshooting.md
+++ b/docs/operations/troubleshooting.md
@@ -227,13 +227,15 @@ Use `simulation_shutdown.py` which stops the simulation timeline and applies a S
 
 ## Workflow Runtime Errors
 
-### OSMO workflow submission fails with payload too large
+### OSMO workflow code upload or download fails
 
-**Cause:** Base64-encoded archive exceeds the ~1 MB payload limit.
+**Cause:** The submit host or the workflow pod cannot reach the OSMO object-storage container that carries the packaged code, which the submission uploads with `osmo data upload` and the pod retrieves through a `url:` task input.
 
 **Resolution:**
 
-Switch from inline payload to dataset folder injection. Upload files as an OSMO dataset and reference the dataset folder name in the workflow environment variables.
+1. Ensure the submit host is authenticated (`az login`) and holds `Storage Blob Data Contributor` on the OSMO storage account. Set `AZURE_STORAGE_ACCOUNT_NAME` (and `OSMO_WORKFLOW_BUCKET`, default `osmo`) if they are not resolved from Terraform outputs.
+2. Confirm access before submitting: `osmo data check azure://<account>/<container>` returns `{"status": "pass"}`.
+3. If the pod fails to fetch the code, verify the workflow pod's workload identity has read access to the same container.
 
 ### OSMO workflow YAML template rendering fails
 

--- a/docs/recipes/training/your-first-rl-training-job.md
+++ b/docs/recipes/training/your-first-rl-training-job.md
@@ -53,7 +53,7 @@ Submit a full training run with the SKRL backend (default):
   --max-iterations 1500
 ```
 
-The script packages `training/rl/` as a base64 payload, injects it into the OSMO workflow template, and submits the job. OSMO schedules the job on a GPU node via KAI Scheduler.
+The script packages `training/rl/`, uploads it to OSMO object storage with `osmo data upload`, and injects it into the workflow pod through a `url:` task input. OSMO schedules the job on a GPU node via KAI Scheduler.
 
 Override the backend to use RSL-RL instead of SKRL:
 

--- a/docs/reference/scripts-examples.md
+++ b/docs/reference/scripts-examples.md
@@ -22,7 +22,7 @@ Detailed submission examples for training, inference, and pipeline workflows on 
 
 ## OSMO Dataset Training
 
-The `submit-osmo-dataset-training.sh` script uploads `training/rl/` as a versioned OSMO dataset. This approach removes the ~1MB size limit of base64-encoded archives and enables dataset reuse across runs.
+The `submit-osmo-dataset-training.sh` script uploads `training/rl/` as a versioned OSMO dataset and enables dataset reuse across runs.
 
 ### Dataset Submission Example
 

--- a/docs/reference/scripts.md
+++ b/docs/reference/scripts.md
@@ -26,7 +26,7 @@ Inventory of submission scripts for training, evaluation, and inference workflow
 | `submit-azureml-training.sh`            | Package code and submit Azure ML training job       | Azure ML |
 | `submit-azureml-isaaclab-evaluation.sh` | Submit Isaac Lab policy evaluation job              | Azure ML |
 | `submit-azureml-lerobot-training.sh`    | Submit LeRobot training to Azure ML                 | Azure ML |
-| `submit-osmo-training.sh`               | Package code and submit OSMO workflow (base64)      | OSMO     |
+| `submit-osmo-training.sh`               | Package code and submit OSMO workflow               | OSMO     |
 | `submit-osmo-dataset-training.sh`       | Submit OSMO workflow using dataset folder injection | OSMO     |
 | `submit-osmo-lerobot-training.sh`       | Submit LeRobot behavioral cloning training          | OSMO     |
 | `submit-osmo-lerobot-inference.sh`      | Submit LeRobot inference/evaluation                 | OSMO     |
@@ -40,7 +40,7 @@ Scripts auto-detect Azure context from Terraform outputs in `infrastructure/terr
 # Azure ML training
 ./submit-azureml-training.sh --task Isaac-Velocity-Rough-Anymal-C-v0
 
-# OSMO training (base64 encoded)
+# OSMO training
 ./submit-osmo-training.sh --task Isaac-Velocity-Rough-Anymal-C-v0
 
 # OSMO training (dataset folder upload)
@@ -81,7 +81,7 @@ Script-specific tools:
 - Azure ML scripts: `az` CLI + `az extension add --name ml`
 - Validation: `jq`
 - OSMO scripts: `osmo`
-- Base64 payload submission: `zip`, `base64`
+- OSMO code upload: `zip`
 - Dataset injection submission: `rsync`
 
 ## CLI Arguments
@@ -168,7 +168,7 @@ Example:
   --stream
 ```
 
-### `submit-osmo-training.sh` (base64 payload)
+### `submit-osmo-training.sh`
 
 | Option                         | Default                                                      | Description                                      | Source                        |
 |--------------------------------|--------------------------------------------------------------|--------------------------------------------------|-------------------------------|

--- a/docs/reference/workflow-templates-osmo.md
+++ b/docs/reference/workflow-templates-osmo.md
@@ -20,7 +20,7 @@ legacy naming.
 
 | Template             | Purpose                                             | Source YAML path                                  | Typical submit path                                   |
 |----------------------|-----------------------------------------------------|---------------------------------------------------|-------------------------------------------------------|
-| `train.yaml`         | Isaac Lab RL training with inline payload archive   | `training/rl/workflows/osmo/train.yaml`           | `training/rl/scripts/submit-osmo-training.sh`         |
+| `train.yaml`         | Isaac Lab RL training with object-storage code delivery | `training/rl/workflows/osmo/train.yaml`       | `training/rl/scripts/submit-osmo-training.sh`         |
 | `train-dataset.yaml` | Isaac Lab RL training with dataset folder injection | `training/rl/workflows/osmo/train-dataset.yaml`   | `training/rl/scripts/submit-osmo-dataset-training.sh` |
 | `lerobot-train.yaml` | LeRobot ACT or Diffusion training workflow          | `training/il/workflows/osmo/lerobot-train.yaml`   | `training/il/scripts/submit-osmo-lerobot-training.sh` |
 | `eval.yaml`          | Isaac Lab checkpoint evaluation workflow            | `evaluation/sil/workflows/osmo/eval.yaml`         | `evaluation/sil/scripts/submit-osmo-eval.sh`          |
@@ -30,11 +30,11 @@ legacy naming.
 
 | Field                            | Details                                                                                                                                                                                                                                                                                                |
 |----------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Purpose                          | OSMO RL training using a base64-encoded runtime payload.                                                                                                                                                                                                                                               |
+| Purpose                          | OSMO RL training. Code is packaged, uploaded to object storage with `osmo data upload`, and injected into the pod through a `url:` task input.                                                                                                                                                          |
 | Source YAML path                 | `training/rl/workflows/osmo/train.yaml`                                                                                                                                                                                                                                                                |
 | Primary parameters and overrides | `default-values.task` (`Isaac-Velocity-Rough-Anymal-C-v0`), `default-values.num_envs` (`"2048"`), `default-values.max_iterations` (empty), `default-values.checkpoint_mode` (`from-scratch`), `default-values.training_backend` (`skrl`), `default-values.gpu` (`"1"`), `default-values.cpu` (`"30"`). |
 | Typical submit path              | `training/rl/scripts/submit-osmo-training.sh`                                                                                                                                                                                                                                                          |
-| Usage notes                      | Use for RL training when shipping the runtime payload inline. Script flags typically override task, resources, and checkpoint behavior.                                                                                                                                                                |
+| Usage notes                      | Use for RL training. The submission delivers code via object storage; script flags typically override task, resources, and checkpoint behavior.                                                                                                                                                                |
 
 ## train-dataset.yaml
 
@@ -82,5 +82,5 @@ legacy naming.
 |-------------------|------------------------------------------------------------------------------------------------------------------|
 | Source of truth   | Use YAML files under `training/` and `evaluation/` as the canonical inventory.                                   |
 | Submission flow   | Submit through the companion scripts listed above to resolve defaults from CLI, env vars, and Terraform outputs. |
-| Runtime packaging | RL workflows use inline payload or dataset injection; choose based on payload size and reuse needs.              |
+| Runtime packaging | RL workflows deliver code via object storage (`url:` input) or dataset injection; choose based on reuse needs.    |
 | Related reference | See [Reference index](README.md) for adjacent script and artifact guides.                                        |

--- a/docs/training/README.md
+++ b/docs/training/README.md
@@ -34,7 +34,7 @@ Training documentation for reinforcement learning with Isaac Lab and behavioral 
 | Submission          | `az ml job create`       | `osmo workflow submit`                  |
 | Orchestration       | Azure ML compute targets | OSMO workflow engine + KAI Scheduler    |
 | Experiment tracking | MLflow (managed)         | MLflow (Azure ML backend)               |
-| Dataset injection   | Azure ML datastores      | OSMO buckets (base64 or dataset upload) |
+| Dataset injection   | Azure ML datastores      | OSMO object storage or dataset upload   |
 | Model registration  | `az ml model create`     | Via MLflow or post-training script      |
 | Monitoring          | Azure ML Studio          | OSMO UI Dashboard                       |
 

--- a/docs/training/isaac-lab-training.md
+++ b/docs/training/isaac-lab-training.md
@@ -39,7 +39,7 @@ Isaac Lab reinforcement learning training with SKRL and RSL-RL backends. Both Az
   --stream
 ```
 
-### OSMO (Base64 Payload)
+### OSMO (Object Storage)
 
 ```bash
 ./scripts/submit-osmo-training.sh \
@@ -55,7 +55,7 @@ Isaac Lab reinforcement learning training with SKRL and RSL-RL backends. Both Az
   --dataset-name my-training-v1
 ```
 
-Dataset injection removes the ~1 MB payload size limit of base64-encoded archives and enables dataset reuse across runs.
+Dataset injection provides named, reusable dataset versions across runs.
 
 ## ⚖️ Platform Selection
 
@@ -64,9 +64,9 @@ Dataset injection removes the ~1 MB payload size limit of base64-encoded archive
 | Submission          | `az ml job create` via YAML templates | `osmo workflow submit`               |
 | Orchestration       | AKS compute targets                   | KAI Scheduler / Volcano integration  |
 | Experiment tracking | MLflow (managed)                      | MLflow (Azure ML backend)            |
-| Dataset delivery    | Azure ML datastores                   | Base64 payload or OSMO bucket upload |
+| Dataset delivery    | Azure ML datastores                   | Object storage (`url:`) or OSMO bucket upload |
 | Monitoring          | Azure ML Studio                       | OSMO UI Dashboard                    |
-| Payload modes       | Single (YAML template)                | Base64 or dataset folder injection   |
+| Payload modes       | Single (YAML template)                | Object storage (`url:`) or dataset injection |
 
 Azure ML provides managed compute and experiment tracking through Azure ML Studio. OSMO adds distributed training coordination, KAI Scheduler integration, and a dataset versioning system.
 
@@ -137,10 +137,10 @@ Training scripts register checkpoints to Azure ML automatically. Override the mo
 
 OSMO supports two payload delivery modes for training code:
 
-| Mode              | Script                            | Size Limit | Versioning |
-|-------------------|-----------------------------------|------------|------------|
-| Base64 payload    | `submit-osmo-training.sh`         | ~1 MB      | None       |
-| Dataset injection | `submit-osmo-dataset-training.sh` | Unlimited  | Automatic  |
+| Mode                  | Script                            | Size Limit | Versioning |
+|-----------------------|-----------------------------------|------------|------------|
+| Object storage (`url:`) | `submit-osmo-training.sh`         | Unlimited  | Per submit |
+| Dataset injection     | `submit-osmo-dataset-training.sh` | Unlimited  | Automatic  |
 
 Dataset injection uploads `training/rl/` as a versioned OSMO dataset, mounted at `/data/<dataset_name>/training` in the container:
 

--- a/docs/training/osmo-training.md
+++ b/docs/training/osmo-training.md
@@ -27,7 +27,7 @@ Submit distributed Isaac Lab training jobs through NVIDIA OSMO workflow orchestr
 
 | Template             | Purpose                             | Submission Script                                                     |
 |----------------------|-------------------------------------|-----------------------------------------------------------------------|
-| `train.yaml`         | Isaac Lab training (base64 inline)  | `training/rl/scripts/submit-osmo-training.sh`                         |
+| `train.yaml`         | Isaac Lab RL training               | `training/rl/scripts/submit-osmo-training.sh`                         |
 | `train-dataset.yaml` | Isaac Lab training (dataset upload) | `training/rl/scripts/submit-osmo-dataset-training.sh`                 |
 | `lerobot-train.yaml` | LeRobot behavioral cloning          | `training/il/scripts/submit-osmo-lerobot-training.sh`                 |
 | `groot-train.yaml`   | GR00T-N1.5 / N1.7 fine-tuning (VLA) | `vla/scripts/submit-osmo-lerobot-vla-fine-tuning.sh` |
@@ -35,13 +35,13 @@ Submit distributed Isaac Lab training jobs through NVIDIA OSMO workflow orchestr
 
 ## ⚙️ Workflow Comparison
 
-| Aspect      | train.yaml             | train-dataset.yaml    |
-|-------------|------------------------|-----------------------|
-| Payload     | Base64-encoded archive | Dataset folder upload |
-| Size limit  | ~1MB                   | Unlimited             |
-| Versioning  | None                   | Automatic             |
-| Reusability | Per-run                | Across runs           |
-| Setup       | None                   | Bucket configured     |
+| Aspect      | train.yaml                 | train-dataset.yaml    |
+|-------------|----------------------------|-----------------------|
+| Payload     | Object-storage archive     | Dataset folder upload |
+| Size limit  | Unlimited                  | Unlimited             |
+| Versioning  | Content-hash per submit     | Automatic             |
+| Reusability | Per-run                    | Across runs           |
+| Setup       | Storage account            | Bucket configured     |
 
 ## 🏋️ Isaac Lab Training
 
@@ -72,7 +72,7 @@ Multi-GPU distributed training with KAI Scheduler / Volcano integration, automat
 
 ## 📂 Isaac Lab Dataset Training
 
-Dataset folder injection via OSMO bucket system instead of base64-encoded archives. Training folder mounts at `/data/<dataset_name>/training`.
+Dataset folder injection via OSMO bucket system. Training folder mounts at `/data/<dataset_name>/training`.
 
 ### Dataset Parameters
 

--- a/evaluation/sil/scripts/submit-osmo-eval.sh
+++ b/evaluation/sil/scripts/submit-osmo-eval.sh
@@ -78,18 +78,10 @@ if ! command -v zip >/dev/null 2>&1; then
   exit 1
 fi
 
-if ! command -v base64 >/dev/null 2>&1; then
-  echo "base64 utility is required on PATH" >&2
-  exit 1
-fi
-
 use_local_osmo=false
 config_preview=false
 
-WORKFLOW_TEMPLATE=${WORKFLOW_TEMPLATE:-"$REPO_ROOT/workflows/osmo/infer.yaml"}
-TMP_DIR=${TMP_DIR:-"$SCRIPT_DIR/.tmp"}
-ARCHIVE_PATH=${ARCHIVE_PATH:-"$TMP_DIR/osmo-inference.zip"}
-B64_PATH=${B64_PATH:-"$TMP_DIR/osmo-inference.b64"}
+WORKFLOW_TEMPLATE=${WORKFLOW_TEMPLATE:-"$REPO_ROOT/evaluation/sil/workflows/osmo/eval.yaml"}
 TASK_VALUE=${TASK:-Isaac-Ant-v0}
 NUM_ENVS_VALUE=${NUM_ENVS:-4}
 MAX_STEPS_VALUE=${MAX_STEPS:-500}
@@ -103,6 +95,7 @@ AZURE_SUBSCRIPTION_ID_VALUE="${AZURE_SUBSCRIPTION_ID:-$(get_subscription_id)}"
 AZURE_RESOURCE_GROUP_VALUE="${AZURE_RESOURCE_GROUP:-$(get_resource_group)}"
 AZURE_WORKSPACE_NAME_VALUE="${AZUREML_WORKSPACE_NAME:-$(get_azureml_workspace)}"
 AZURE_STORAGE_ACCOUNT_VALUE="${AZURE_STORAGE_ACCOUNT_NAME:-$(get_storage_account)}"
+OSMO_CONTAINER_VALUE="${OSMO_WORKFLOW_BUCKET:-osmo}"
 
 forward_args=()
 while [[ $# -gt 0 ]]; do
@@ -220,39 +213,17 @@ if [[ "$config_preview" == "true" ]]; then
   exit 0
 fi
 
-mkdir -p "$TMP_DIR"
-rm -f "$ARCHIVE_PATH" "$B64_PATH"
+[[ -z "$AZURE_STORAGE_ACCOUNT_VALUE" ]] && fatal "Azure storage account required for code upload (set AZURE_STORAGE_ACCOUNT_NAME or deploy infra)"
 
-pushd "$REPO_ROOT" >/dev/null
-if ! zip -qr "$ARCHIVE_PATH" training/rl evaluation/sil; then
-  echo "Failed to create evaluation archive" >&2
-  popd >/dev/null
-  exit 1
-fi
-popd >/dev/null
-
-if [[ ! -f "$ARCHIVE_PATH" ]]; then
-  echo "Archive not created: $ARCHIVE_PATH" >&2
-  exit 1
-fi
-
-if base64 --help 2>&1 | grep -q '\-\-input'; then
-  base64 --input "$ARCHIVE_PATH" | tr -d '\n' > "$B64_PATH"
-else
-  base64 -i "$ARCHIVE_PATH" | tr -d '\n' > "$B64_PATH"
-fi
-
-if [[ ! -s "$B64_PATH" ]]; then
-  echo "Failed to encode archive to base64" >&2
-  exit 1
-fi
-
-ENCODED_PAYLOAD=$(cat "$B64_PATH")
+CODE_URL=$(stage_and_upload_code "$REPO_ROOT" \
+  "azure://${AZURE_STORAGE_ACCOUNT_VALUE}/${OSMO_CONTAINER_VALUE}/osmo-code" \
+  training/rl evaluation/sil) \
+  || fatal "Failed to stage and upload evaluation payload"
 
 submit_args=(
   workflow submit "$WORKFLOW_TEMPLATE"
   --set-string "image=$IMAGE_VALUE"
-  "encoded_archive=$ENCODED_PAYLOAD"
+  "code_url=$CODE_URL"
   "task=$TASK_VALUE"
   "num_envs=$NUM_ENVS_VALUE"
   "max_steps=$MAX_STEPS_VALUE"

--- a/evaluation/sil/scripts/submit-osmo-lerobot-eval.sh
+++ b/evaluation/sil/scripts/submit-osmo-lerobot-eval.sh
@@ -77,7 +77,7 @@ EOF
 # Defaults
 #------------------------------------------------------------------------------
 
-workflow="$REPO_ROOT/workflows/osmo/lerobot-infer.yaml"
+workflow="$REPO_ROOT/evaluation/sil/workflows/osmo/lerobot-eval.yaml"
 policy_repo_id="${POLICY_REPO_ID:-}"
 policy_type="${POLICY_TYPE:-act}"
 dataset_repo_id="${DATASET_REPO_ID:-}"
@@ -153,8 +153,7 @@ done
 
 [[ "$use_local_osmo" == "true" ]] && activate_local_osmo
 
-require_tools osmo
-require_tools osmo zip base64
+require_tools osmo zip
 
 # Policy source validation
 if [[ "$from_aml_model" == "true" ]]; then
@@ -216,36 +215,20 @@ if [[ "$config_preview" == "true" ]]; then
 fi
 
 #------------------------------------------------------------------------------
-# Package Runtime Payload
+# Package and Upload Runtime Payload
 #------------------------------------------------------------------------------
 
-TMP_DIR="$SCRIPT_DIR/.tmp"
-ARCHIVE_PATH="$TMP_DIR/osmo-lerobot-inference.zip"
-B64_PATH="$TMP_DIR/osmo-lerobot-inference.b64"
 payload_root="${PAYLOAD_ROOT:-/workspace/lerobot_payload}"
+code_storage_account="${AZURE_STORAGE_ACCOUNT_NAME:-$(get_storage_account)}"
+osmo_container="${OSMO_WORKFLOW_BUCKET:-osmo}"
+[[ -z "$code_storage_account" ]] && fatal "Azure storage account required for code upload (set AZURE_STORAGE_ACCOUNT_NAME or deploy infra)"
 
-info "Packaging LeRobot runtime payload..."
-mkdir -p "$TMP_DIR"
-rm -f "$ARCHIVE_PATH" "$B64_PATH"
-
-(cd "$REPO_ROOT" && zip -qr "$ARCHIVE_PATH" training/il evaluation/sil \
-  -x "**/__pycache__/*" \
-  -x "*.pyc" \
-  -x "*.pyo" \
-  -x "**/.pytest_cache/*" \
-  -x "**/.mypy_cache/*" \
-  -x "**/*.egg-info/*") || fatal "Failed to create runtime archive"
-
-[[ -f "$ARCHIVE_PATH" ]] || fatal "Archive not created: $ARCHIVE_PATH"
-
-if base64 --help 2>&1 | grep -q '\-\-input'; then
-  base64 --input "$ARCHIVE_PATH" | tr -d '\n' > "$B64_PATH"
-else
-  base64 -i "$ARCHIVE_PATH" | tr -d '\n' > "$B64_PATH"
-fi
-
-[[ -s "$B64_PATH" ]] || fatal "Failed to encode archive"
-encoded_payload=$(<"$B64_PATH")
+info "Packaging and uploading LeRobot runtime payload..."
+code_url=$(stage_and_upload_code "$REPO_ROOT" \
+  "azure://${code_storage_account}/${osmo_container}/osmo-code" \
+  training/il evaluation/sil) \
+  || fatal "Failed to stage and upload runtime payload"
+info "Runtime payload uploaded: $code_url"
 
 #------------------------------------------------------------------------------
 # Build Submission Command
@@ -254,7 +237,7 @@ encoded_payload=$(<"$B64_PATH")
 submit_args=(
   workflow submit "$workflow"
   --set-string "image=$image"
-  "encoded_archive=$encoded_payload"
+  "code_url=$code_url"
   "payload_root=$payload_root"
   "policy_repo_id=$policy_repo_id"
   "policy_type=$policy_type"

--- a/evaluation/sil/scripts/submit-osmo-lerobot-eval.sh
+++ b/evaluation/sil/scripts/submit-osmo-lerobot-eval.sh
@@ -107,6 +107,9 @@ subscription_id="${AZURE_SUBSCRIPTION_ID:-$(get_subscription_id)}"
 resource_group="${AZURE_RESOURCE_GROUP:-$(get_resource_group)}"
 workspace_name="${AZUREML_WORKSPACE_NAME:-$(get_azureml_workspace)}"
 
+code_storage_account="${AZURE_STORAGE_ACCOUNT_NAME:-$(get_storage_account)}"
+osmo_container="${OSMO_WORKFLOW_BUCKET:-osmo}"
+
 forward_args=()
 
 #------------------------------------------------------------------------------
@@ -210,6 +213,8 @@ if [[ "$config_preview" == "true" ]]; then
   print_kv "Subscription" "${subscription_id:-<not set>}"
   print_kv "Resource Group" "${resource_group:-<not set>}"
   print_kv "Workspace" "${workspace_name:-<not set>}"
+  print_kv "Storage Account" "${code_storage_account:-<not set>}"
+  print_kv "Code Storage" "azure://${code_storage_account}/${osmo_container}/osmo-code"
   print_kv "Workflow" "$workflow"
   exit 0
 fi
@@ -219,8 +224,6 @@ fi
 #------------------------------------------------------------------------------
 
 payload_root="${PAYLOAD_ROOT:-/workspace/lerobot_payload}"
-code_storage_account="${AZURE_STORAGE_ACCOUNT_NAME:-$(get_storage_account)}"
-osmo_container="${OSMO_WORKFLOW_BUCKET:-osmo}"
 [[ -z "$code_storage_account" ]] && fatal "Azure storage account required for code upload (set AZURE_STORAGE_ACCOUNT_NAME or deploy infra)"
 
 info "Packaging and uploading LeRobot runtime payload..."

--- a/evaluation/sil/workflows/osmo/eval.yaml
+++ b/evaluation/sil/workflows/osmo/eval.yaml
@@ -8,6 +8,7 @@ workflow:
       cpu: 120
       memory: 480Gi
       storage: 200Gi
+      platform: gpu_platform
   tasks:
     - name: isaac-inference
       image: "{{ image }}"

--- a/evaluation/sil/workflows/osmo/eval.yaml
+++ b/evaluation/sil/workflows/osmo/eval.yaml
@@ -14,6 +14,9 @@ workflow:
       command:
         - /bin/bash
         - /tmp/entry.sh
+      inputs:
+        - url: "{{ code_url }}"
+          regex: ".*"
       environment:
         NVIDIA_DRIVER_CAPABILITIES: "all"
         TASK: "{{ task }}"
@@ -22,7 +25,6 @@ workflow:
         VIDEO_LENGTH: "{{ video_length }}"
         ACCEPT_EULA: "Y"
         PRIVACY_CONSENT: "Y"
-        ENCODED_ARCHIVE: "{{ encoded_archive }}"
         PAYLOAD_ROOT: "{{ payload_root }}"
         CHECKPOINT_URI: "{{ checkpoint_uri }}"
         INFERENCE_FORMAT: "{{ inference_format }}"
@@ -39,22 +41,24 @@ workflow:
             #!/bin/bash
             set -euo pipefail
 
-            if [[ -z "${ENCODED_ARCHIVE:-}" ]]; then
-              echo "encoded_archive is required" >&2
-              exit 1
-            fi
-
             if [[ -z "${CHECKPOINT_URI:-}" ]]; then
               echo "checkpoint_uri is required" >&2
               exit 1
             fi
 
-            ARCHIVE_PATH="${TEMP_ARCHIVE:-/tmp/isaac_payload.zip}"
             PAYLOAD_ROOT="${PAYLOAD_ROOT:-/workspace/isaac_payload}"
             INFERENCE_ROOT="${INFERENCE_ROOT:-${PAYLOAD_ROOT}/evaluation/sil}"
 
             mkdir -p "${PAYLOAD_ROOT}"
-            printf '%s' "${ENCODED_ARCHIVE}" | base64 -d > "${ARCHIVE_PATH}"
+            # Code is delivered via the OSMO url: input (object storage), not an
+            # env var: a single env string is capped at 128 KiB (MAX_ARG_STRLEN)
+            # and the archive exceeds that, failing the container execve E2BIG.
+            ARCHIVE_PATH="$(find {{input:0}} -maxdepth 2 -name '*.zip' | head -n1)"
+            if [[ -z "${ARCHIVE_PATH}" || ! -s "${ARCHIVE_PATH}" ]]; then
+              echo "ERROR: no code archive found under the input mount; runtime payload is required." >&2
+              ls -laR {{input:0}} || true
+              exit 1
+            fi
             unzip -oq "${ARCHIVE_PATH}" -d "${PAYLOAD_ROOT}"
 
             infer_args=(
@@ -77,7 +81,7 @@ default-values:
   num_envs: "4"
   max_steps: "500"
   video_length: "200"
-  encoded_archive: ""
+  code_url: ""
   payload_root: /workspace/isaac_payload
   checkpoint_uri: ""
   inference_format: "both"

--- a/evaluation/sil/workflows/osmo/eval.yaml
+++ b/evaluation/sil/workflows/osmo/eval.yaml
@@ -72,7 +72,7 @@ workflow:
               --headless
             )
 
-            bash "${INFERENCE_ROOT}/scripts/infer.sh" "${infer_args[@]}"
+            bash "${INFERENCE_ROOT}/infer.sh" "${infer_args[@]}"
 
 default-values:
   # Submission scripts set image from scripts/lib/common.sh via --set-string.

--- a/evaluation/sil/workflows/osmo/eval.yaml
+++ b/evaluation/sil/workflows/osmo/eval.yaml
@@ -54,10 +54,10 @@ workflow:
             # Code is delivered via the OSMO url: input (object storage), not an
             # env var: a single env string is capped at 128 KiB (MAX_ARG_STRLEN)
             # and the archive exceeds that, failing the container execve E2BIG.
-            ARCHIVE_PATH="$(find {{input:0}} -maxdepth 2 -name '*.zip' | head -n1)"
+            ARCHIVE_PATH="$(find "{{input:0}}" -maxdepth 2 -name '*.zip' | head -n1)"
             if [[ -z "${ARCHIVE_PATH}" || ! -s "${ARCHIVE_PATH}" ]]; then
               echo "ERROR: no code archive found under the input mount; runtime payload is required." >&2
-              ls -laR {{input:0}} || true
+              ls -laR "{{input:0}}" || true
               exit 1
             fi
             unzip -oq "${ARCHIVE_PATH}" -d "${PAYLOAD_ROOT}"

--- a/evaluation/sil/workflows/osmo/lerobot-eval.yaml
+++ b/evaluation/sil/workflows/osmo/lerobot-eval.yaml
@@ -79,6 +79,15 @@ workflow:
             echo "Installing UV package manager..."
             pip install --quiet uv==0.7.12
 
+            # LeRobot requires Python >= 3.12; the base image ships 3.11. Create a
+            # dedicated 3.12 venv (uv downloads the interpreter) so `uv export` of
+            # the lerobot lock resolves, matching the training workflow.
+            echo "Creating Python 3.12 environment..."
+            uv python install 3.12
+            uv venv --python 3.12 /opt/lerobot-venv
+            # shellcheck disable=SC1091
+            source /opt/lerobot-venv/bin/activate
+
             # Unpack runtime payload and install dependencies from workflow manifest.
             # Code is delivered via the OSMO url: input (object storage), not an
             # env var: a single env string is capped at 128 KiB (MAX_ARG_STRLEN)
@@ -101,12 +110,14 @@ workflow:
               exit 1
             fi
             uv export --frozen --no-hashes --no-emit-project --project "${LEROBOT_PROJECT}" \
-              | uv pip install --no-cache-dir --no-deps --system -r -
+              | uv pip install --no-cache-dir --no-deps -r -
 
-            # Install MLflow and matplotlib when MLflow tracking is enabled
+            # matplotlib (trajectory plots) is the only MLflow-logging dependency
+            # not already provided by the lerobot lock; azureml-mlflow and
+            # mlflow-skinny come from the lock install above.
             if [[ "${MLFLOW_ENABLE:-false}" == "true" ]]; then
-              echo "Installing MLflow and plotting dependencies..."
-              uv pip install azureml-mlflow "mlflow>=2.8.0,<3.0.0" matplotlib --system
+              echo "Installing plotting dependencies..."
+              uv pip install matplotlib
             fi
 
             # Download model from AzureML registry if specified
@@ -184,11 +195,9 @@ workflow:
               fi
             fi
 
-            # Download dataset from Azure Blob Storage if configured
+            # Download dataset from Azure Blob Storage if configured. The azure
+            # storage SDKs are already installed from the lerobot lock above.
             if [[ -n "${BLOB_STORAGE_ACCOUNT:-}" && -n "${BLOB_PREFIX:-}" ]]; then
-              echo "Installing Azure storage dependencies..."
-              uv pip install azure-storage-blob azure-identity --system
-
               echo "Downloading dataset from Azure Blob: ${BLOB_STORAGE_ACCOUNT}/${BLOB_STORAGE_CONTAINER}/${BLOB_PREFIX}..."
 
               python3 << 'BLOB_DOWNLOAD_SCRIPT'

--- a/evaluation/sil/workflows/osmo/lerobot-eval.yaml
+++ b/evaluation/sil/workflows/osmo/lerobot-eval.yaml
@@ -195,8 +195,7 @@ workflow:
               fi
             fi
 
-            # Download dataset from Azure Blob Storage if configured. The azure
-            # storage SDKs are already installed from the lerobot lock above.
+            # Download dataset from Azure Blob Storage if configured
             if [[ -n "${BLOB_STORAGE_ACCOUNT:-}" && -n "${BLOB_PREFIX:-}" ]]; then
               echo "Downloading dataset from Azure Blob: ${BLOB_STORAGE_ACCOUNT}/${BLOB_STORAGE_CONTAINER}/${BLOB_PREFIX}..."
 

--- a/evaluation/sil/workflows/osmo/lerobot-eval.yaml
+++ b/evaluation/sil/workflows/osmo/lerobot-eval.yaml
@@ -14,6 +14,9 @@ workflow:
       command:
         - /bin/bash
         - /tmp/entry.sh
+      inputs:
+        - url: "{{ code_url }}"
+          regex: ".*"
       credentials:
         huggingface:
           HF_TOKEN: hf_token
@@ -42,7 +45,6 @@ workflow:
         BLOB_STORAGE_ACCOUNT: "{{ blob_storage_account }}"
         BLOB_STORAGE_CONTAINER: "{{ blob_storage_container }}"
         BLOB_PREFIX: "{{ blob_prefix }}"
-        ENCODED_ARCHIVE: "{{ encoded_archive }}"
         PAYLOAD_ROOT: "{{ payload_root }}"
       files:
         - path: /tmp/entry.sh
@@ -76,15 +78,19 @@ workflow:
             echo "Installing UV package manager..."
             pip install --quiet uv==0.7.12
 
-            # Unpack runtime payload and install dependencies from workflow manifest
-            ARCHIVE_PATH="/tmp/lerobot_payload.zip"
+            # Unpack runtime payload and install dependencies from workflow manifest.
+            # Code is delivered via the OSMO url: input (object storage), not an
+            # env var: a single env string is capped at 128 KiB (MAX_ARG_STRLEN)
+            # and the archive (which ships the lerobot uv.lock for `uv export`)
+            # exceeds that, failing the container execve E2BIG.
             PAYLOAD_ROOT="${PAYLOAD_ROOT:-/workspace/lerobot_payload}"
             mkdir -p "${PAYLOAD_ROOT}"
-            if [[ -z "${ENCODED_ARCHIVE:-}" ]]; then
-              echo "ERROR: ENCODED_ARCHIVE is not set or empty; runtime payload is required." >&2
+            ARCHIVE_PATH="$(find {{input:0}} -maxdepth 2 -name '*.zip' | head -n1)"
+            if [[ -z "${ARCHIVE_PATH}" || ! -s "${ARCHIVE_PATH}" ]]; then
+              echo "ERROR: no code archive found under the input mount; runtime payload is required." >&2
+              ls -laR {{input:0}} || true
               exit 1
             fi
-            printf '%s' "${ENCODED_ARCHIVE}" | base64 -d > "${ARCHIVE_PATH}"
             unzip -oq "${ARCHIVE_PATH}" -d "${PAYLOAD_ROOT}"
             export PYTHONPATH="${PAYLOAD_ROOT}:${PYTHONPATH:-}"
 
@@ -857,5 +863,5 @@ default-values:
   blob_storage_account: ""
   blob_storage_container: datasets
   blob_prefix: ""
-  encoded_archive: ""
+  code_url: ""
   payload_root: /workspace/lerobot_payload

--- a/evaluation/sil/workflows/osmo/lerobot-eval.yaml
+++ b/evaluation/sil/workflows/osmo/lerobot-eval.yaml
@@ -8,6 +8,7 @@ workflow:
       cpu: 4
       memory: 32Gi
       storage: 40Gi
+      platform: gpu_platform
   tasks:
     - name: lerobot-eval
       image: "{{ image }}"

--- a/evaluation/sil/workflows/osmo/lerobot-eval.yaml
+++ b/evaluation/sil/workflows/osmo/lerobot-eval.yaml
@@ -95,10 +95,10 @@ workflow:
             # exceeds that, failing the container execve E2BIG.
             PAYLOAD_ROOT="${PAYLOAD_ROOT:-/workspace/lerobot_payload}"
             mkdir -p "${PAYLOAD_ROOT}"
-            ARCHIVE_PATH="$(find {{input:0}} -maxdepth 2 -name '*.zip' | head -n1)"
+            ARCHIVE_PATH="$(find "{{input:0}}" -maxdepth 2 -name '*.zip' | head -n1)"
             if [[ -z "${ARCHIVE_PATH}" || ! -s "${ARCHIVE_PATH}" ]]; then
               echo "ERROR: no code archive found under the input mount; runtime payload is required." >&2
-              ls -laR {{input:0}} || true
+              ls -laR "{{input:0}}" || true
               exit 1
             fi
             unzip -oq "${ARCHIVE_PATH}" -d "${PAYLOAD_ROOT}"

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -82,6 +82,63 @@ activate_local_osmo() {
   export -f osmo
 }
 
+# Package repo-relative paths into a zip, upload it to a unique OSMO data URI,
+# and echo that URI for a workflow `url:` input to consume.
+#
+# The payload is delivered to the workflow pod as a downloaded object (via the
+# pod's workload identity) rather than an inline base64 env var: a single env
+# string is capped at 128 KiB (Linux MAX_ARG_STRLEN) and the payload exceeds
+# that, which fails the container execve with E2BIG.
+#
+# All progress logs go to stderr; only the URI is printed to stdout.
+# Usage: code_url=$(stage_and_upload_code <repo_root> <uri_base> <path>...)
+stage_and_upload_code() {
+  local repo_root="${1:?repo_root required}"
+  local uri_base="${2:?uri_base required}"
+  shift 2
+  [[ $# -gt 0 ]] || { error "stage_and_upload_code: no paths to package"; return 1; }
+
+  local tmp archive hash uri size
+  tmp="$(mktemp -d)"
+  archive="$tmp/osmo-code.zip"
+
+  if ! (cd "$repo_root" && zip -qr "$archive" "$@" \
+    -x '**/__pycache__/*' \
+    -x '*.pyc' \
+    -x '*.pyo' \
+    -x '**/.pytest_cache/*' \
+    -x '**/.mypy_cache/*' \
+    -x '**/*.egg-info/*' \
+    -x '**/.git/*' \
+    -x '**/node_modules/*' \
+    -x '**/.venv/*' \
+    -x '**/.tmp/*') >&2; then
+    rm -rf "$tmp"
+    error "Failed to build code archive"
+    return 1
+  fi
+
+  if [[ ! -s "$archive" ]]; then
+    rm -rf "$tmp"
+    error "Code archive is empty"
+    return 1
+  fi
+
+  size="$(wc -c < "$archive" | tr -d ' ')"
+  hash="$(calculate_sha256 "$archive" | cut -c1-16)"
+  uri="${uri_base}/${hash}"
+
+  info "Uploading code archive (${size} bytes) to ${uri}" >&2
+  if ! osmo data upload "$uri" "$archive" >&2; then
+    rm -rf "$tmp"
+    error "osmo data upload failed for ${uri}"
+    return 1
+  fi
+
+  rm -rf "$tmp"
+  echo "$uri"
+}
+
 # Ensure Azure CLI extension is installed
 require_az_extension() {
   local ext="${1:?extension name required}"

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -98,7 +98,7 @@ stage_and_upload_code() {
   shift 2
   [[ $# -gt 0 ]] || { error "stage_and_upload_code: no paths to package"; return 1; }
 
-  local tmp archive hash uri size
+  local tmp archive hash uri size extract manifest
   tmp="$(mktemp -d)"
   archive="$tmp/osmo-code.zip"
 
@@ -125,8 +125,49 @@ stage_and_upload_code() {
   fi
 
   size="$(wc -c < "$archive" | tr -d ' ')"
-  hash="$(calculate_sha256 "$archive" | cut -c1-16)"
+
+  # Content-addressed key over the archive *contents* (per-file sha + sorted
+  # relative path), not the .zip itself: Info-ZIP records each entry's mtime, so
+  # hashing the archive file would yield a new key for byte-identical code on
+  # every submit. Re-reading the just-built archive hashes exactly what is
+  # uploaded and reuses the exclude set applied above.
+  extract="$tmp/extract"
+  manifest="$tmp/manifest"
+  mkdir -p "$extract"
+  if ! unzip -qq "$archive" -d "$extract" >&2; then
+    rm -rf "$tmp"
+    error "Failed to extract code archive for content hashing"
+    return 1
+  fi
+  ( cd "$extract" && find . -type f -print0 | LC_ALL=C sort -z \
+    | while IFS= read -r -d '' f; do
+        printf '%s  %s\n' "$(calculate_sha256 "$f")" "$f"
+      done ) > "$manifest"
+  if [[ ! -s "$manifest" ]]; then
+    rm -rf "$tmp"
+    error "Code archive contains no files to hash"
+    return 1
+  fi
+  hash="$(calculate_sha256 "$manifest" | cut -c1-16)"
   uri="${uri_base}/${hash}"
+
+  # Upload only when the content-addressed object is absent. The key is a pure
+  # function of the code, so an existing object is byte-identical: skipping the
+  # upload avoids overwriting an object a concurrent job may be downloading
+  # (osmo data upload always overwrites) and saves re-uploading unchanged code.
+  #
+  # The list (check) and upload (use) are not atomic, so there is a TOCTOU
+  # window. It is benign by construction: because the key is content-addressed,
+  # two submitters that both observe "absent" upload byte-identical bytes to the
+  # same key, and no workflow pod reads the object until *after* its submitter
+  # has finished uploading and submitted the workflow. The worst case is a
+  # redundant overwrite with identical content, never a corrupt or partial read.
+  if osmo data list "$uri" "$tmp/listing" >&2 && grep -q "$hash" "$tmp/listing" 2>/dev/null; then
+    info "Code archive already present at ${uri}; skipping upload" >&2
+    rm -rf "$tmp"
+    echo "$uri"
+    return 0
+  fi
 
   info "Uploading code archive (${size} bytes) to ${uri}" >&2
   if ! osmo data upload "$uri" "$archive" >&2; then

--- a/training/README.md
+++ b/training/README.md
@@ -58,7 +58,7 @@ Trained policies export to ONNX and TensorRT formats via `packaging/scripts/expo
 | Document                                                     | Description                                       |
 |--------------------------------------------------------------|---------------------------------------------------|
 | [RL Training](specifications/rl-training.specification.md)   | SKRL, RSL-RL, Isaac Lab runtime configuration     |
-| [IL Training](specifications/il-training.specification.md)   | LeRobot ACT/Diffusion policies, dataset injection |
+| [IL Training](specifications/il-training.specification.md)   | LeRobot ACT/Diffusion policies, blob datasets     |
 | [VLA Training](specifications/vla-training.specification.md) | Multi-modal transformer training (planned)        |
 | [Packaging](specifications/packaging.specification.md)       | ONNX/TensorRT model export                        |
 

--- a/training/il/scripts/submit-osmo-lerobot-training.sh
+++ b/training/il/scripts/submit-osmo-lerobot-training.sh
@@ -148,13 +148,12 @@ register_checkpoint="${REGISTER_CHECKPOINT:-}"
 subscription_id="${AZURE_SUBSCRIPTION_ID:-$(get_subscription_id)}"
 resource_group="${AZURE_RESOURCE_GROUP:-$(get_resource_group)}"
 workspace_name="${AZUREML_WORKSPACE_NAME:-$(get_azureml_workspace)}"
+storage_account="${AZURE_STORAGE_ACCOUNT_NAME:-$(get_storage_account)}"
+osmo_container="${OSMO_WORKFLOW_BUCKET:-osmo}"
 azure_authority_host="${AZURE_AUTHORITY_HOST:-https://login.microsoftonline.com}"
 mlflow_retries="${MLFLOW_TRACKING_TOKEN_REFRESH_RETRIES:-3}"
 mlflow_timeout="${MLFLOW_HTTP_REQUEST_TIMEOUT:-60}"
 
-TMP_DIR="$SCRIPT_DIR/.tmp"
-ARCHIVE_PATH="$TMP_DIR/osmo-lerobot-training.zip"
-B64_PATH="$TMP_DIR/osmo-lerobot-training.b64"
 payload_root="${PAYLOAD_ROOT:-/workspace/lerobot_payload}"
 
 use_local_osmo=false
@@ -204,7 +203,7 @@ done
 
 [[ "$use_local_osmo" == "true" ]] && activate_local_osmo
 
-require_tools osmo zip base64 python3
+require_tools osmo zip python3
 
 [[ -d "$REPO_ROOT/training/il" ]] || fatal "Directory training/il not found"
 
@@ -235,6 +234,7 @@ esac
 [[ -z "$subscription_id" ]] && fatal "Azure subscription ID required (set AZURE_SUBSCRIPTION_ID or deploy infra)"
 [[ -z "$resource_group" ]] && fatal "Azure resource group required (set AZURE_RESOURCE_GROUP or deploy infra)"
 [[ -z "$workspace_name" ]] && fatal "Azure ML workspace name required (set AZUREML_WORKSPACE_NAME or deploy infra)"
+[[ -z "$storage_account" ]] && fatal "Azure storage account required (set AZURE_STORAGE_ACCOUNT_NAME or deploy infra)"
 
 [[ "$val_split_enabled" == "false" ]] && val_split="0"
 
@@ -258,41 +258,22 @@ if [[ "$config_preview" == "true" ]]; then
   print_kv "Subscription" "$subscription_id"
   print_kv "Resource Group" "$resource_group"
   print_kv "Workspace" "$workspace_name"
+  print_kv "Storage Account" "$storage_account"
+  print_kv "Code Storage" "azure://${storage_account}/${osmo_container}/osmo-code"
   print_kv "Workflow" "$workflow"
   exit 0
 fi
 
 #------------------------------------------------------------------------------
-# Package Training Payload
+# Package and Upload Training Payload
 #------------------------------------------------------------------------------
 
-info "Packaging training payload..."
-mkdir -p "$TMP_DIR"
-rm -f "$ARCHIVE_PATH" "$B64_PATH"
-
-(cd "$REPO_ROOT" && zip -qr "$ARCHIVE_PATH" training/il training/__init__.py training/stream.py training/utils \
-  -x "**/__pycache__/*" \
-  -x "*.pyc" \
-  -x "*.pyo" \
-  -x "**/.pytest_cache/*" \
-  -x "**/.mypy_cache/*" \
-  -x "**/*.egg-info/*") || fatal "Failed to create training archive"
-
-[[ -f "$ARCHIVE_PATH" ]] || fatal "Archive not created: $ARCHIVE_PATH"
-
-if base64 --help 2>&1 | grep -q '\-\-input'; then
-  base64 --input "$ARCHIVE_PATH" | tr -d '\n' > "$B64_PATH"
-else
-  base64 -i "$ARCHIVE_PATH" | tr -d '\n' > "$B64_PATH"
-fi
-
-[[ -s "$B64_PATH" ]] || fatal "Failed to encode archive"
-
-archive_size=$(wc -c < "$ARCHIVE_PATH" | tr -d ' ')
-b64_size=$(wc -c < "$B64_PATH" | tr -d ' ')
-info "Payload: ${archive_size} bytes (${b64_size} bytes base64)"
-
-encoded_payload=$(<"$B64_PATH")
+info "Packaging and uploading training payload..."
+code_url=$(stage_and_upload_code "$REPO_ROOT" \
+  "azure://${storage_account}/${osmo_container}/osmo-code" \
+  training/il training/__init__.py training/stream.py training/utils) \
+  || fatal "Failed to stage and upload training payload"
+info "Training payload uploaded: $code_url"
 
 #------------------------------------------------------------------------------
 # Build Submission Command
@@ -301,7 +282,7 @@ encoded_payload=$(<"$B64_PATH")
 submit_args=(
   workflow submit "$workflow"
   --set-string "image=$image"
-  "encoded_archive=$encoded_payload"
+  "code_url=$code_url"
   "payload_root=$payload_root"
   "dataset_repo_id=$dataset_repo_id"
   "dataset_root=$dataset_root"
@@ -348,7 +329,7 @@ info "  Batch Size: $batch_size"
 info "  Learning Rate: $learning_rate"
 info "  Val Split: $val_split"
 info "  System Metrics: $system_metrics"
-info "  Payload: ${archive_size} bytes"
+info "  Code URL: $code_url"
 [[ $blob_source_count -gt 0 ]] && info "  Data Source: Azure Blob URLs ($blob_source_count)"
 [[ -n "$policy_repo_id" ]] && info "  Fine-tune from: $policy_repo_id"
 [[ -n "$register_checkpoint" ]] && info "  Register model: $register_checkpoint"

--- a/training/il/workflows/osmo/lerobot-train.yaml
+++ b/training/il/workflows/osmo/lerobot-train.yaml
@@ -106,10 +106,10 @@ workflow:
             # for `uv export`) exceeds that, failing the container execve E2BIG.
             PAYLOAD_ROOT="${PAYLOAD_ROOT:-/workspace/lerobot_payload}"
             mkdir -p "${PAYLOAD_ROOT}"
-            ARCHIVE_PATH="$(find {{input:0}} -maxdepth 2 -name '*.zip' | head -n1)"
+            ARCHIVE_PATH="$(find "{{input:0}}" -maxdepth 2 -name '*.zip' | head -n1)"
             if [[ -z "${ARCHIVE_PATH}" || ! -s "${ARCHIVE_PATH}" ]]; then
               echo "ERROR: no code archive found under the input mount; training payload is required." >&2
-              ls -laR {{input:0}} || true
+              ls -laR "{{input:0}}" || true
               exit 1
             fi
             unzip -oq "${ARCHIVE_PATH}" -d "${PAYLOAD_ROOT}"

--- a/training/il/workflows/osmo/lerobot-train.yaml
+++ b/training/il/workflows/osmo/lerobot-train.yaml
@@ -15,6 +15,9 @@ workflow:
       command:
         - /bin/bash
         - /tmp/entry.sh
+      inputs:
+        - url: "{{ code_url }}"
+          regex: ".*"
       credentials:
         huggingface:
           HF_TOKEN: hf_token
@@ -44,7 +47,6 @@ workflow:
         AZURE_SUBSCRIPTION_ID: "{{ azure_subscription_id }}"
         AZURE_RESOURCE_GROUP: "{{ azure_resource_group }}"
         AZUREML_WORKSPACE_NAME: "{{ azure_workspace_name }}"
-        ENCODED_ARCHIVE: "{{ encoded_archive }}"
         PAYLOAD_ROOT: "{{ payload_root }}"
         AZURE_AUTHORITY_HOST: "{{ azure_authority_host }}"
         MLFLOW_TRACKING_TOKEN_REFRESH_RETRIES: "{{ mlflow_token_refresh_retries }}"
@@ -97,18 +99,22 @@ workflow:
             # shellcheck disable=SC1091
             source /opt/lerobot-venv/bin/activate
 
-            # Unpack training scripts from base64-encoded payload
-            ARCHIVE_PATH="/tmp/lerobot_payload.zip"
+            # Unpack training scripts delivered via the OSMO url: input. The code
+            # archive arrives as a downloaded object under the input mount rather
+            # than an env var: a single env string is capped at 128 KiB
+            # (MAX_ARG_STRLEN) and the archive (which ships the lerobot uv.lock
+            # for `uv export`) exceeds that, failing the container execve E2BIG.
             PAYLOAD_ROOT="${PAYLOAD_ROOT:-/workspace/lerobot_payload}"
             mkdir -p "${PAYLOAD_ROOT}"
-            if [[ -z "${ENCODED_ARCHIVE:-}" ]]; then
-              echo "ERROR: ENCODED_ARCHIVE is not set or empty; training payload is required." >&2
+            ARCHIVE_PATH="$(find {{input:0}} -maxdepth 2 -name '*.zip' | head -n1)"
+            if [[ -z "${ARCHIVE_PATH}" || ! -s "${ARCHIVE_PATH}" ]]; then
+              echo "ERROR: no code archive found under the input mount; training payload is required." >&2
+              ls -laR {{input:0}} || true
               exit 1
             fi
-            printf '%s' "${ENCODED_ARCHIVE}" | base64 -d > "${ARCHIVE_PATH}"
             unzip -oq "${ARCHIVE_PATH}" -d "${PAYLOAD_ROOT}"
             export PYTHONPATH="${PAYLOAD_ROOT}:${PYTHONPATH:-}"
-            echo "Training scripts unpacked to ${PAYLOAD_ROOT}"
+            echo "Training scripts unpacked to ${PAYLOAD_ROOT} from ${ARCHIVE_PATH}"
 
             # Decide blob-vs-HuggingFace via the canonical Python helper so
             # whitespace, pretty-printed JSON, and [""] / [null] payloads agree
@@ -160,7 +166,7 @@ workflow:
 
 default-values:
   image: pytorch/pytorch:2.11.0-cuda12.8-cudnn9-runtime
-  encoded_archive: ""
+  code_url: ""
   payload_root: /workspace/lerobot_payload
   dataset_repo_id: ""
   dataset_root: /workspace/data

--- a/training/rl/scripts/submit-osmo-training.sh
+++ b/training/rl/scripts/submit-osmo-training.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Submit OSMO training workflow with training/rl/ packaged as base64 payload
+# Submit OSMO training workflow with training/rl/ delivered via object storage
 # Excludes __pycache__ and build artifacts to reduce payload size
 set -o errexit -o nounset
 
@@ -19,7 +19,7 @@ show_help() {
   cat << EOF
 Usage: submit-osmo-training.sh [OPTIONS] [-- osmo-submit-flags]
 
-Package training/rl/, encode as base64, and submit an OSMO workflow.
+Package training/rl/, upload it to OSMO object storage, and submit an OSMO workflow.
 
 WORKFLOW OPTIONS:
     -w, --workflow PATH           Workflow template (default: training/rl/workflows/osmo/train.yaml)
@@ -83,10 +83,6 @@ normalize_checkpoint_mode() {
 # Defaults
 #------------------------------------------------------------------------------
 
-TMP_DIR="$SCRIPT_DIR/.tmp"
-ARCHIVE_PATH="$TMP_DIR/osmo-training.zip"
-B64_PATH="$TMP_DIR/osmo-training.b64"
-
 workflow="$REPO_ROOT/training/rl/workflows/osmo/train.yaml"
 task="${TASK:-Isaac-Velocity-Rough-Anymal-C-v0}"
 num_envs="${NUM_ENVS:-2048}"
@@ -108,6 +104,8 @@ skip_register=false
 subscription_id="${AZURE_SUBSCRIPTION_ID:-$(get_subscription_id)}"
 resource_group="${AZURE_RESOURCE_GROUP:-$(get_resource_group)}"
 workspace_name="${AZUREML_WORKSPACE_NAME:-$(get_azureml_workspace)}"
+storage_account="${AZURE_STORAGE_ACCOUNT_NAME:-$(get_storage_account)}"
+osmo_container="${OSMO_WORKFLOW_BUCKET:-osmo}"
 correlation_id="${MLFLOW_CORRELATION_ID:-}"
 
 sleep_after_unpack="${SLEEP_AFTER_UNPACK:-}"
@@ -157,10 +155,11 @@ done
 
 [[ "$use_local_osmo" == "true" ]] && activate_local_osmo
 
-require_tools osmo zip base64
+require_tools osmo zip
 
 [[ -f "$workflow" ]] || fatal "Workflow template not found: $workflow"
 [[ -d "$REPO_ROOT/training/rl" ]] || fatal "Directory training/rl not found"
+[[ -z "$storage_account" ]] && fatal "Azure storage account required for code upload (set AZURE_STORAGE_ACCOUNT_NAME or deploy infra)"
 
 checkpoint_mode="$(normalize_checkpoint_mode "$checkpoint_mode")"
 
@@ -189,44 +188,21 @@ if [[ "$config_preview" == "true" ]]; then
   print_kv "Subscription" "${subscription_id:-<not set>}"
   print_kv "Resource Group" "${resource_group:-<not set>}"
   print_kv "Workspace" "${workspace_name:-<not set>}"
+  print_kv "Storage Account" "${storage_account:-<not set>}"
   print_kv "Correlation ID" "${correlation_id:-<not set>}"
   exit 0
 fi
 
 #------------------------------------------------------------------------------
-# Package Training Payload
+# Package and Upload Training Payload
 #------------------------------------------------------------------------------
 
-info "Packaging training payload..."
-mkdir -p "$TMP_DIR"
-rm -f "$ARCHIVE_PATH" "$B64_PATH"
-
-# Exclude __pycache__, .pyc, and build artifacts to reduce payload size
-(cd "$REPO_ROOT" && zip -qr "$ARCHIVE_PATH" training/rl training/__init__.py training/stream.py training/utils \
-  -x "**/__pycache__/*" \
-  -x "*.pyc" \
-  -x "*.pyo" \
-  -x "**/.venv/*" \
-  -x "**/.pytest_cache/*" \
-  -x "**/.mypy_cache/*" \
-  -x "**/*.egg-info/*") || fatal "Failed to create training archive"
-
-[[ -f "$ARCHIVE_PATH" ]] || fatal "Archive not created: $ARCHIVE_PATH"
-
-# Base64 encode (macOS vs Linux compatible)
-if base64 --help 2>&1 | grep -q '\-\-input'; then
-  base64 --input "$ARCHIVE_PATH" | tr -d '\n' > "$B64_PATH"
-else
-  base64 -i "$ARCHIVE_PATH" | tr -d '\n' > "$B64_PATH"
-fi
-
-[[ -s "$B64_PATH" ]] || fatal "Failed to encode archive"
-
-archive_size=$(wc -c < "$ARCHIVE_PATH" | tr -d ' ')
-b64_size=$(wc -c < "$B64_PATH" | tr -d ' ')
-info "Payload: ${archive_size} bytes (${b64_size} bytes base64)"
-
-encoded_payload=$(<"$B64_PATH")
+info "Packaging and uploading training payload..."
+code_url=$(stage_and_upload_code "$REPO_ROOT" \
+  "azure://${storage_account}/${osmo_container}/osmo-code" \
+  training/rl training/__init__.py training/stream.py training/utils) \
+  || fatal "Failed to stage and upload training payload"
+info "Training payload uploaded: $code_url"
 
 #------------------------------------------------------------------------------
 # Build Submission Command
@@ -235,7 +211,7 @@ encoded_payload=$(<"$B64_PATH")
 submit_args=(
   workflow submit "$workflow"
   --set-string "image=$image"
-  "encoded_archive=$encoded_payload"
+  "code_url=$code_url"
   "task=$task"
   "num_envs=$num_envs"
   "payload_root=$payload_root"

--- a/training/rl/workflows/osmo/train.yaml
+++ b/training/rl/workflows/osmo/train.yaml
@@ -53,10 +53,10 @@ workflow:
             # Code is delivered via the OSMO url: input (object storage), not an
             # env var: a single env string is capped at 128 KiB (MAX_ARG_STRLEN)
             # and the archive exceeds that, failing the container execve E2BIG.
-            ARCHIVE_PATH="$(find {{input:0}} -maxdepth 2 -name '*.zip' | head -n1)"
+            ARCHIVE_PATH="$(find "{{input:0}}" -maxdepth 2 -name '*.zip' | head -n1)"
             if [[ -z "${ARCHIVE_PATH}" || ! -s "${ARCHIVE_PATH}" ]]; then
               echo "ERROR: no code archive found under the input mount; training payload is required." >&2
-              ls -laR {{input:0}} || true
+              ls -laR "{{input:0}}" || true
               exit 1
             fi
             unzip -oq "${ARCHIVE_PATH}" -d "${PAYLOAD_ROOT}"

--- a/training/rl/workflows/osmo/train.yaml
+++ b/training/rl/workflows/osmo/train.yaml
@@ -14,6 +14,9 @@ workflow:
       command:
         - /bin/bash
         - /tmp/entry.sh
+      inputs:
+        - url: "{{ code_url }}"
+          regex: ".*"
       environment:
         NVIDIA_DRIVER_CAPABILITIES: "all"
         TASK: "{{ task }}"
@@ -21,7 +24,6 @@ workflow:
         MAX_ITERATIONS: "{{ max_iterations }}"
         ACCEPT_EULA: "Y"
         PRIVACY_CONSENT: "Y"
-        ENCODED_ARCHIVE: "{{ encoded_archive }}"
         PAYLOAD_ROOT: "{{ payload_root }}"
         SLEEP_AFTER_UNPACK: "{{ sleep_after_unpack }}"
         AZURE_SUBSCRIPTION_ID: "{{ azure_subscription_id }}"
@@ -43,17 +45,19 @@ workflow:
             #!/bin/bash
             set -euo pipefail
 
-            if [[ -z "${ENCODED_ARCHIVE:-}" ]]; then
-              echo "encoded_archive is required" >&2
-              exit 1
-            fi
-
-            ARCHIVE_PATH="${TEMP_ARCHIVE:-/tmp/isaac_payload.zip}"
             PAYLOAD_ROOT="${PAYLOAD_ROOT:-/workspace/isaac_payload}"
             TRAINING_ROOT="${TRAINING_ROOT:-${PAYLOAD_ROOT}/training/rl}"
 
             mkdir -p "${PAYLOAD_ROOT}"
-            printf '%s' "${ENCODED_ARCHIVE}" | base64 -d > "${ARCHIVE_PATH}"
+            # Code is delivered via the OSMO url: input (object storage), not an
+            # env var: a single env string is capped at 128 KiB (MAX_ARG_STRLEN)
+            # and the archive exceeds that, failing the container execve E2BIG.
+            ARCHIVE_PATH="$(find {{input:0}} -maxdepth 2 -name '*.zip' | head -n1)"
+            if [[ -z "${ARCHIVE_PATH}" || ! -s "${ARCHIVE_PATH}" ]]; then
+              echo "ERROR: no code archive found under the input mount; training payload is required." >&2
+              ls -laR {{input:0}} || true
+              exit 1
+            fi
             unzip -oq "${ARCHIVE_PATH}" -d "${PAYLOAD_ROOT}"
 
             if [[ -n "${SLEEP_AFTER_UNPACK:-}" ]]; then
@@ -88,7 +92,7 @@ default-values:
   task: Isaac-Velocity-Rough-Anymal-C-v0
   num_envs: "2048"
   max_iterations: ""
-  encoded_archive: ""
+  code_url: ""
   payload_root: /workspace/isaac_payload
   sleep_after_unpack: ""
   azure_subscription_id: ""

--- a/training/rl/workflows/osmo/train.yaml
+++ b/training/rl/workflows/osmo/train.yaml
@@ -8,6 +8,7 @@ workflow:
       cpu: {{ cpu }}
       memory: {{ memory }}
       storage: {{ storage }}
+      platform: gpu_platform
   tasks:
     - name: isaac-training
       image: "{{ image }}"

--- a/training/specifications/il-training.specification.md
+++ b/training/specifications/il-training.specification.md
@@ -32,11 +32,6 @@ LeRobot is runtime-installed via `uv pip` inside the Isaac Lab container. Traini
 | AzureML  | `training/il/scripts/submit-azureml-lerobot-training.sh` | `training/il/workflows/azureml/lerobot-train.yaml` |
 | OSMO     | `training/il/scripts/submit-osmo-lerobot-training.sh`    | `training/il/workflows/osmo/lerobot-train.yaml`    |
 
-## Dataset Injection
+## Code Delivery
 
-OSMO supports two payload strategies for dataset delivery:
-
-| Strategy                 | Size Limit | Mechanism                                   |
-|--------------------------|------------|---------------------------------------------|
-| Base64-encoded archive   | ~1 MB      | Embedded in workflow YAML                   |
-| Dataset folder injection | Unlimited  | Versioned folder, name in workflow env vars |
+The OSMO submission packages the code, uploads it to object storage with `osmo data upload`, and injects it into the workflow pod through a `url:` task input. The pod downloads the archive via its workload identity and unpacks it at runtime. This delivery path has no payload size limit.


### PR DESCRIPTION
## Description

OSMO workflows shipped their packaged code as a base64-encoded `ENCODED_ARCHIVE` **Kubernetes env var**. On Linux a single env/arg string is capped at `MAX_ARG_STRLEN` = 128 KiB, and once the LeRobot `uv.lock` is part of the archive the value exceeds that, so the workflow container fails to start (`execve` → `argument list too long`). This surfaced after the `uv.lock` grew (it more than doubled the payload to ~256 KiB).

This PR replaces inline base64 delivery with **object-storage injection**:

- The submission packages the code, uploads it with `osmo data upload azure://<account>/<container>/osmo-code/<hash>`, and submits the workflow with a `code_url` parameter.
- The workflow declares an `inputs: - url: "{{ code_url }}"` task input; the pod downloads the archive via its **workload identity** to `{{input:0}}` and unpacks it. No payload size limit, no base64 env var, no oversized argv.
- A shared `stage_and_upload_code()` helper is added to `scripts/lib/common.sh`; the IL training, RL training, and SIL eval (×2) submit scripts and workflows are migrated.

Two adjacent issues found while validating are also fixed:

- GPU workflows lacked an explicit `platform: gpu_platform`, so they failed OSMO resource validation against the CPU-only default platform.
- The LeRobot eval workflow installed dependencies into the image's Python 3.11 (`--system`); LeRobot requires `>=3.12`. It now creates a 3.12 venv (mirroring training) and drops redundant dependency installs already provided by the LeRobot lock.

Closes #1036

## Type of Change

- [x] 🐛 Bug fix (non-breaking change fixing an issue)
- [x] 📚 Documentation update

## Component(s) Affected

- [x] `workflows/` - Training and evaluation workflows
- [x] `training/` - Training pipelines and scripts
- [x] `docs/` - Documentation
- [x] `evaluation/` - SIL evaluation workflows and scripts
- [x] `scripts/lib/` - Shared submission library

## Testing Performed

- [x] OSMO workflow submitted successfully

Validated on a live OSMO cluster (OSMO 6.3):

- **IL training** ran end-to-end: code delivered via `url:`, pod started (env var dropped from 256 KB to <0.5 KB), trained, and registered the model to Azure ML.
- **RL training** passed resource validation and scheduled onto the GPU node (the prior failure was at submit-time validation).
- **`url:` input download** verified in-pod via a minimal probe workflow (download via workload identity to `/osmo/data/input/0`).
- `shellcheck`, `markdownlint-cli2`, and `cspell` clean on changed files.

## Documentation Impact

- [x] Documentation updated in this PR

## Bug Fix Checklist

- [x] Linked to issue being fixed
- [x] Justification for no regression test: the failure modes are GPU/runtime/interpreter-specific (container `execve` env-size limit, OSMO server-side resource validation, container Python 3.12) and pass green on CPU-only PR CI; they are exercised by live OSMO submissions rather than unit tests.

## Checklist

- [x] My code follows the project conventions
- [x] Commit messages follow conventional commit format (two web-editor "Update …" commits aside)
- [x] I have performed a self-review
- [x] Documentation impact assessed above
- [x] No new linting warnings introduced
