### PR TITLE
fix(ci): enforce go output contract checks

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -227,7 +227,7 @@ jobs:
     name: Go Tests
     uses: ./.github/workflows/go-tests.yml
     with:
-      soft-fail: true
+      soft-fail: false
       code-coverage: true
     permissions:
       contents: read

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -352,8 +352,8 @@ jobs:
     name: Go Tests
     uses: ./.github/workflows/go-tests.yml
     with:
-      soft-fail: true
-      changed-files-only: true
+      soft-fail: false
+      changed-files-only: false
       code-coverage: true
     permissions:
       contents: read

--- a/infrastructure/terraform/e2e/outputs.go
+++ b/infrastructure/terraform/e2e/outputs.go
@@ -32,7 +32,7 @@ type InfraOutputs struct {
 	ContainerRegistry          map[string]any `output:"container_registry"`
 	StorageAccount             map[string]any `output:"storage_account"`
 	DataLakeStorageAccount     any            `output:"data_lake_storage_account"`
-	AmlComputeCluster          any            `output:"aml_compute_cluster"`
+	AmlComputeClusters         map[string]any `output:"aml_compute_clusters"`
 	LogAnalyticsWorkspace      map[string]any `output:"log_analytics_workspace"`
 	ApplicationInsights        map[string]any `output:"application_insights"`
 	Grafana                    map[string]any `output:"grafana"`


### PR DESCRIPTION
## Summary
- update the Terraform output contract to use `aml_compute_clusters`
- stop skipping the Go test suite in PR validation when a change only touches Terraform/workflow files
- make Go test failures fail both PR validation and `main` instead of being soft-failed

## Why
`microsoft/physical-ai-toolchain#1034` describes two separate problems:
1. the contract struct still expects the old singular Terraform output name
2. the Go contract test can be skipped or silently green even when Terraform/output drift is introduced

This patch fixes the stale output tag and makes the existing Go test gate authoritative again.

## Testing
- `git diff --check`
- could not run the local Go test suite in this checkout because `go` is not installed in the current environment

Closes #1034
