### PR TITLE
feat(build): auto-merge low-risk patch dependency updates

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -25,6 +25,12 @@ jobs:
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
+      - name: Checkout trusted base scripts
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.base.sha }}
+
       - name: Enable auto-merge for eligible patch bumps
         # All values below are dependabot/fetch-metadata outputs, not dependabot.yml strings:
         #  - update-type 'version-update:semver-patch' = patch bumps only
@@ -43,12 +49,4 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_URL: ${{ github.event.pull_request.html_url }}
-        run: |
-          if out=$(gh pr merge --auto --squash "${PR_URL}" 2>&1); then
-            echo "Auto-merge armed: ${PR_URL}"
-          elif grep -qi "auto.merge is not allowed" <<<"${out}"; then
-            echo "::notice::'Allow auto-merge' is off; no-op until an admin enables it."
-          else
-            echo "${out}" >&2
-            exit 1
-          fi
+        run: scripts/dependabot-auto-merge.sh --pr-url "$PR_URL"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,55 @@
+name: Dependabot Auto-merge
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+
+permissions:
+  contents: read
+
+jobs:
+  auto-merge:
+    name: Auto-merge patch bumps
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Enable auto-merge for eligible patch bumps
+        # All values below are dependabot/fetch-metadata outputs, not dependabot.yml strings:
+        #  - update-type 'version-update:semver-patch' = patch bumps only
+        #  - ghsa-id '' = not a security advisory (security PRs never auto-merge)
+        #  - package-ecosystem is normalized: npm/yarn -> 'npm_and_yarn', github-actions -> 'github_actions'
+        # uv excluded (CPU CI blind to GPU/ABI); gomod manual until Go patches have a CI gate.
+        if: >-
+          steps.metadata.outputs.update-type == 'version-update:semver-patch'
+          && steps.metadata.outputs.ghsa-id == ''
+          && (
+            steps.metadata.outputs.package-ecosystem == 'github_actions'
+            || steps.metadata.outputs.package-ecosystem == 'terraform'
+            || steps.metadata.outputs.package-ecosystem == 'npm_and_yarn'
+            || steps.metadata.outputs.package-ecosystem == 'docker'
+          )
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          if out=$(gh pr merge --auto --squash "${PR_URL}" 2>&1); then
+            echo "Auto-merge armed: ${PR_URL}"
+          elif grep -qi "auto.merge is not allowed" <<<"${out}"; then
+            echo "::notice::'Allow auto-merge' is off; no-op until an admin enables it."
+          else
+            echo "${out}" >&2
+            exit 1
+          fi

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -16,7 +16,6 @@ jobs:
     runs-on: ubuntu-latest
     if: github.actor == 'dependabot[bot]'
     permissions:
-      contents: write
       pull-requests: write
 
     steps:

--- a/docs/contributing/component-updates.md
+++ b/docs/contributing/component-updates.md
@@ -76,6 +76,15 @@ The review body prepends a `⚠️ Maintainer review recommended` banner when an
 
 Maintainers remain the source of truth — the reviewer is advisory context, not automated policy.
 
+### Patch Auto-merge
+
+[.github/workflows/dependabot-auto-merge.yml](pathname://../../.github/workflows/dependabot-auto-merge.yml) enables auto-merge for patch-only, non-security bumps in github-actions, terraform, npm, and docker. Major and minor bumps, uv (GPU/ABI risk), and any security update always stay in manual review. Merge is never forced — auto-merge waits for the required `pr-validation-summary` check, then merges by squash.
+
+Auto-merge requires the repo's **Allow auto-merge** setting (Settings → General → Pull Requests); until it is on the workflow is a green no-op. Each dependabot patch PR still needs its one approval and green checks before it merges — auto-merge only drops the final click.
+
+> [!WARNING]
+> Revert playbook: if an auto-merged patch breaks `main`, `gh pr revert <num>` (or `git revert <sha>`) and merge the revert. Then add an `ignore` pin in `.github/dependabot.yml` for the bad version.
+
 ### Python Lockfiles
 
 Every Python subproject carries a committed `uv.lock` beside its `pyproject.toml`. The lock is the single resolution source of truth — runtime-flat `requirements.txt` files are not committed.

--- a/scripts/dependabot-auto-merge.sh
+++ b/scripts/dependabot-auto-merge.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Enable GitHub auto-merge for an eligible Dependabot pull request.
+set -o errexit -o nounset -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || (cd "$SCRIPT_DIR/.." && pwd))"
+# shellcheck source=scripts/lib/common.sh
+source "$REPO_ROOT/scripts/lib/common.sh"
+
+show_help() {
+  cat << EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Enable GitHub auto-merge with squash for an eligible Dependabot pull request.
+
+OPTIONS:
+    -h, --help               Show this help message
+        --pr-url URL         Pull request URL (default: PR_URL environment variable)
+        --config-preview     Print configuration and exit
+
+EXAMPLES:
+    $(basename "$0") --pr-url https://github.com/org/repo/pull/123
+EOF
+}
+
+pr_url="${PR_URL:-}"
+config_preview=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h|--help)         show_help; exit 0 ;;
+    --pr-url)          pr_url="$2"; shift 2 ;;
+    --config-preview)  config_preview=true; shift ;;
+    *)                 fatal "Unknown option: $1" ;;
+  esac
+done
+
+#------------------------------------------------------------------------------
+# Gather Configuration
+#------------------------------------------------------------------------------
+
+if [[ "$config_preview" == "true" ]]; then
+  section "Configuration Preview"
+  print_kv "PR URL" "${pr_url:-<unset>}"
+  exit 0
+fi
+
+[[ -n "$pr_url" ]] || fatal "Pull request URL required via --pr-url or PR_URL"
+
+require_tools gh grep
+
+#------------------------------------------------------------------------------
+# Main Logic
+#------------------------------------------------------------------------------
+
+section "Enable Auto-merge"
+
+status="armed"
+if out=$(gh pr merge --auto --squash "$pr_url" 2>&1); then
+  info "Auto-merge armed: $pr_url"
+elif grep -qi "auto.merge is not allowed" <<<"$out"; then
+  status="skipped"
+  echo "::notice::'Allow auto-merge' is off; no-op until an admin enables it."
+else
+  error "$out"
+  exit 1
+fi
+
+#------------------------------------------------------------------------------
+# Summary
+#------------------------------------------------------------------------------
+
+section "Deployment Summary"
+print_kv "PR URL" "$pr_url"
+print_kv "Status" "$status"


### PR DESCRIPTION
Closes #1067.

Dependabot's patch tail is low-risk but still waits on a manual click after review; this auto-merges the safe slice while leaving anything riskier to maintainers.

## What it does

[.github/workflows/dependabot-auto-merge.yml](.github/workflows/dependabot-auto-merge.yml) runs on dependabot PRs, reads `dependabot/fetch-metadata` (no PR code executed), and arms `gh pr merge --auto --squash` only when **all** hold:

- update-type is patch (`version-update:semver-patch`)
- not a security advisory (`ghsa-id` empty)
- ecosystem in `github_actions`, `terraform`, `npm_and_yarn`, `docker`

Major/minor, uv (GPU/ABI risk CI can't see), and security stay manual. The allowlist is fail-closed: a new ecosystem isn't auto-merged until explicitly added.

## Safety

- Merge is never forced — auto-merge waits for the `pr-validation-summary` required check and the existing approval, then squash-merges. It only removes the post-approval click.
- Pre-enable: if "Allow auto-merge" is off, the step traps the error and exits 0 — a green no-op, nothing merges.
- Magic values are commented as fetch-metadata outputs (e.g. `npm` → `npm_and_yarn`) to prevent future "corrections".

## Docs

`docs/contributing/component-updates.md` gains a Patch Auto-merge section: scope, the one admin setting required ("Allow auto-merge"), and a revert playbook.

Config-only; no application code changes.
