### PR TITLE
test(data): fix InteractionRequiredAuthError constructor call for msal 5.15.0

### DIFF
--- a/data-management/viewer/frontend/src/lib/__tests__/auth-headers.test.ts
+++ b/data-management/viewer/frontend/src/lib/__tests__/auth-headers.test.ts
@@ -79,7 +79,9 @@ describe('auth-headers', () => {
       getActiveAccount: vi.fn().mockReturnValue(mockAccount),
       acquireTokenSilent: vi
         .fn()
-        .mockRejectedValue(new InteractionRequiredAuthError('interaction_required', 'test-correlation-id')),
+        .mockRejectedValue(
+          new InteractionRequiredAuthError('interaction_required', 'test-correlation-id'),
+        ),
       acquireTokenRedirect: vi.fn().mockResolvedValue(undefined),
     } as unknown as PublicClientApplication
     setMsalInstance(mockInstance)

--- a/data-management/viewer/frontend/src/lib/__tests__/auth-headers.test.ts
+++ b/data-management/viewer/frontend/src/lib/__tests__/auth-headers.test.ts
@@ -79,7 +79,7 @@ describe('auth-headers', () => {
       getActiveAccount: vi.fn().mockReturnValue(mockAccount),
       acquireTokenSilent: vi
         .fn()
-        .mockRejectedValue(new InteractionRequiredAuthError('interaction_required')),
+        .mockRejectedValue(new InteractionRequiredAuthError('interaction_required', 'test-correlation-id')),
       acquireTokenRedirect: vi.fn().mockResolvedValue(undefined),
     } as unknown as PublicClientApplication
     setMsalInstance(mockInstance)


### PR DESCRIPTION
Corrects a single *dataviewer frontend* test so it type-checks against the upcoming **@azure/msal-browser 5.15.0** bump. In 5.15.0 the `InteractionRequiredAuthError` constructor (from transitive *@azure/msal-common*) promoted `correlationId` to a **required second argument**, and the existing test in *auth-headers.test.ts* constructed the error with a single argument. That produced a `tsc` error (`TS2554: Expected 2-8 arguments, but got 1`), which failed the frontend *Lint, Type-check, Test and Build* and *Docker Compose Smoke* checks on the grouped Dependabot update.

The two-argument form is valid on both **5.14.0** (current `main`, where the argument maps to the optional `errorMessage` param) and **5.15.0**, so the change is forward-compatible and can merge to `main` on its own. Once merged, the pending frontend dependency bump goes green after it rebases.

Verified locally against `main`'s pinned *@azure/msal-browser 5.14.0*: `type-check` passes, the full **1666-test** vitest suite passes, and `build` succeeds.

## Description

Closes #1126

Supplied the required `correlationId` argument when constructing `InteractionRequiredAuthError` in *auth-headers.test.ts*, unblocking the frontend msal 5.15.0 update.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change fixing an issue)
- [ ] ✨ New feature (non-breaking change adding functionality)
- [ ] 💥 Breaking change (fix or feature causing existing functionality to change)
- [ ] 📚 Documentation update
- [ ] 🏗️ Infrastructure change (Terraform/IaC)
- [ ] ♻️ Refactoring (no functional changes)

## Component(s) Affected

- [ ] `infrastructure/terraform/prerequisites/` - Azure subscription setup
- [ ] `infrastructure/terraform/` - Terraform infrastructure
- [ ] `infrastructure/setup/` - OSMO control plane / Helm
- [ ] `workflows/` - Training and evaluation workflows
- [ ] `training/` - Training pipelines and scripts
- [ ] `docs/` - Documentation

<!-- Not listed above: data-management/viewer/frontend (dataviewer) -->

## Testing Performed

- [ ] Terraform `plan` reviewed (no unexpected changes)
- [ ] Terraform `apply` tested in dev environment
- [ ] Training scripts tested locally with Isaac Sim
- [ ] OSMO workflow submitted successfully
- [ ] Smoke tests passed (`smoke_test_azure.py`)

<!-- Frontend validation run against main's msal 5.14.0: npm run type-check (clean), npm run test (1666 passed), npm run build (succeeded). -->

## Documentation Impact

- [x] No documentation changes needed
- [ ] Documentation updated in this PR
- [ ] Documentation issue filed

## Bug Fix Checklist

- [x] Linked to issue being fixed
- [ ] Regression test included, OR
- [x] Justification for no regression test: the existing *auth-headers.test.ts* already covers the `InteractionRequiredAuthError` redirect path; this change corrects its constructor call so it compiles under msal 5.15.0.

## Checklist

- [x] My code follows the [project conventions](copilot-instructions.md)
- [x] Commit messages follow [conventional commit format](instructions/commit-message.instructions.md)
- [x] I have performed a self-review
- [x] Documentation impact assessed above
- [x] No new linting warnings introduced