### PR TITLE
build(build): drop root gitpython constraint to decouple domain smoke resolves

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,6 @@ fuzz = ["atheris==3.1.0"]
 [tool.uv]
 package = false
 constraint-dependencies = [
-    "gitpython==3.1.50",
     "pygments==2.20.0",
 ]
 override-dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -3,10 +3,7 @@ revision = 3
 requires-python = ">=3.12"
 
 [manifest]
-constraints = [
-    { name = "gitpython", specifier = "==3.1.50" },
-    { name = "pygments", specifier = "==2.20.0" },
-]
+constraints = [{ name = "pygments", specifier = "==2.20.0" }]
 overrides = [{ name = "cryptography", specifier = "==48.0.1" }]
 
 [[package]]


### PR DESCRIPTION
## Problem

Dependabot PR #1205 (bump `gitpython` 3.1.50 → 3.1.51 in `training/rl`) fails the `Smoke / CPU Import Smoke (rl)` check with:

```
No solution found when resolving dependencies:
Because you require gitpython==3.1.51 and gitpython==3.1.50, we can conclude that your requirements are unsatisfiable.
```

## Root cause

The repo root `pyproject.toml` declares a global exact pin:

```toml
[tool.uv]
constraint-dependencies = [
    "gitpython==3.1.50",
    ...
]
```

`shared/ci/smoke-import.sh` runs `uv pip install` from the repo root, so this root constraint is applied to **every** domain's smoke install. Any per-domain gitpython bump (rl → 3.1.51) then collides with the root `==3.1.50` pin. Dependabot cannot see `[tool.uv] constraint-dependencies`, so it only bumps the subproject — making this break recur on every gitpython bump.

## Fix

Remove `gitpython` from the root `constraint-dependencies` and regenerate the root `uv.lock`. Each domain already pins its own gitpython (`training/rl`, `training/il/lerobot` directly; others transitively), so the global pin was redundant coupling. Removing it does not force any version — root still locks 3.1.50 for its own resolution — so this is safe to merge independently and unblocks #1205 (and future gitpython bumps).

## Validation

From the repo root, both resolve cleanly after the change:

- `uv pip install --no-deps --dry-run 'gitpython==3.1.51'` ✅
- `uv pip install --no-deps --dry-run 'gitpython==3.1.50'` ✅
- `uv lock --check` ✅

🔧 - Generated by Copilot