### PR TITLE
fix(build): pin ruff to 0.15.21 in python-lint and lint:py

### DIFF
--- a/.github/workflows/python-lint.yml
+++ b/.github/workflows/python-lint.yml
@@ -31,11 +31,13 @@ jobs:
       - name: Setup uv
         uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990  # v8.3.2
 
+      # Ruff version is pinned to match the `ruff` dev-dependency pin in the root
+      # pyproject.toml. Keep these in sync; bump both together (via Dependabot).
       - name: Ruff lint check
         id: ruff-check
         continue-on-error: true
         run: |
-          uvx ruff check . --output-format github 2>&1 | Tee-Object -FilePath ruff-check-results.txt
+          uvx --with ruff==0.15.21 ruff check . --output-format github 2>&1 | Tee-Object -FilePath ruff-check-results.txt
           $exitCode = $LASTEXITCODE
           if ($exitCode -ne 0) {
             'RUFF_CHECK_FAILED=true' >> $env:GITHUB_ENV
@@ -46,7 +48,7 @@ jobs:
         id: ruff-format
         continue-on-error: true
         run: |
-          uvx ruff format --check --diff . 2>&1 | Tee-Object -FilePath ruff-format-results.txt
+          uvx --with ruff==0.15.21 ruff format --check --diff . 2>&1 | Tee-Object -FilePath ruff-format-results.txt
           $exitCode = $LASTEXITCODE
           if ($exitCode -ne 0) {
             'RUFF_FORMAT_FAILED=true' >> $env:GITHUB_ENV
@@ -77,5 +79,5 @@ jobs:
       - name: Fail job if errors found
         if: (env.RUFF_CHECK_FAILED == 'true' || env.RUFF_FORMAT_FAILED == 'true' || env.HF_PINS_FAILED == 'true') && !inputs.soft-fail
         run: |
-          Write-Output "::error::Python lint violations detected. Run 'uvx ruff check --fix .', 'uvx ruff format .', and 'npm run lint:hfpins' locally."
+          Write-Output "::error::Python lint violations detected. Run 'uvx --with ruff==0.15.21 ruff check --fix .', 'uvx --with ruff==0.15.21 ruff format .', and 'npm run lint:hfpins' locally."
           exit 1

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lint:md": "markdownlint-cli2 \"**/*.md\"",
     "lint:md:fix": "markdownlint-cli2 \"**/*.md\" --fix",
     "lint:ps": "pwsh -File scripts/linting/Invoke-PSScriptAnalyzer.ps1",
-    "lint:py": "uvx ruff check .",
+    "lint:py": "uvx --with ruff==0.15.21 ruff check .",
     "lint:hfpins": "uv run --no-project python3 scripts/security/check_hf_pins.py",
     "lint:links": "pwsh -File scripts/linting/Invoke-LinkLanguageCheck.ps1",
     "lint:go": "pwsh -File scripts/linting/Invoke-GoLint.ps1",


### PR DESCRIPTION
## Description

<!-- Brief description of changes. Link related issues using Closes #123 -->

The reusable **Python lint** workflow and the root `lint:py` script invoked ruff without a version constraint (`uvx ruff ...`), so CI resolved whatever ruff version uv fetched and floated to *0.16.x*. That newer ruff widened file discovery and began formatting Python code blocks embedded in Markdown, which failed the format check on three untouched Markdown files and blocked unrelated pull requests.

This change pins both invocation sites to `ruff==0.15.21` — the version already tracked in the root *pyproject.toml* dev dependency group — using the `uvx --with ruff==0.15.21` form recognized by the dependency-pinning validator. Both **.github/workflows/python-lint.yml** and **package.json** now honor the single authoritative pin, restoring deterministic linting. No source or Markdown files were reformatted.

Closes #1254

## Type of Change
<!-- Mark relevant options with [x] -->

- [x] 🐛 Bug fix (non-breaking change fixing an issue)
- [ ] ✨ New feature (non-breaking change adding functionality)
- [ ] 💥 Breaking change (fix or feature causing existing functionality to change)
- [ ] 📚 Documentation update
- [ ] 🏗️ Infrastructure change (Terraform/IaC)
- [ ] ♻️ Refactoring (no functional changes)

## Component(s) Affected
<!-- Mark all that apply -->

- [ ] `infrastructure/terraform/prerequisites/` - Azure subscription setup
- [ ] `infrastructure/terraform/` - Terraform infrastructure
- [ ] `infrastructure/setup/` - OSMO control plane / Helm
- [ ] `workflows/` - Training and evaluation workflows
- [ ] `training/` - Training pipelines and scripts
- [ ] `docs/` - Documentation

<!-- This change touches `.github/workflows/python-lint.yml` (CI) and root `package.json`; none of the listed components apply. -->

## Testing Performed
<!-- Describe testing. Check applicable items -->

- [ ] Terraform `plan` reviewed (no unexpected changes)
- [ ] Terraform `apply` tested in dev environment
- [ ] Training scripts tested locally with Isaac Sim
- [ ] OSMO workflow submitted successfully
- [ ] Smoke tests passed (`smoke_test_azure.py`)

<!-- Validated locally: `uvx --with ruff==0.15.21 ruff --version` -> 0.15.21; `npm run lint:py` -> "All checks passed!"; `ruff format --check .` -> "259 files already formatted"; `npm run lint:yaml` (actionlint) -> 0 issues. -->

## Documentation Impact
<!-- Select one -->

- [x] No documentation changes needed
- [ ] Documentation updated in this PR
- [ ] Documentation issue filed

## Bug Fix Checklist

*Complete this section for bug fix PRs. Skip for other contribution types.*

- [x] Linked to issue being fixed
- [ ] Regression test included, OR
- [x] Justification for no regression test: This is a CI configuration change (tool version pin); it is self-validating because the workflow now runs the pinned ruff on every PR, and the existing lint steps act as the guard against regression.

## Checklist

- [x] My code follows the [project conventions](copilot-instructions.md)
- [x] Commit messages follow [conventional commit format](instructions/commit-message.instructions.md)
- [x] I have performed a self-review
- [x] Documentation impact assessed above
- [x] No new linting warnings introduced