### PR TITLE
Configure devcontainer Dockerfile with dynamic build args for proxy package indexes

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,11 @@
+ARG BASE_IMAGE=
+FROM ${BASE_IMAGE:-mcr.microsoft.com/devcontainers/python:3.12-bookworm}
+
+ARG NPM_CONFIG_REGISTRY=
+ENV NPM_CONFIG_REGISTRY=${NPM_CONFIG_REGISTRY:-https://registry.npmjs.org/}
+
+ARG PIP_INDEX_URL=
+ENV PIP_INDEX_URL=${PIP_INDEX_URL:-https://pypi.org/simple/}
+
+ARG UV_DEFAULT_INDEX=
+ENV UV_DEFAULT_INDEX=${UV_DEFAULT_INDEX:-https://pypi.org/simple/}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,7 +3,15 @@
 {
 	"name": "physical-ai-toolchain-devcontainer",
 	// Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-	"image": "mcr.microsoft.com/devcontainers/python:3.12-bookworm",
+	"build": {
+		"dockerfile": "Dockerfile",
+		"args": {
+			"BASE_IMAGE": "${localEnv:PHYSICAL_AI_DEVCONTAINER_IMAGE}",
+			"NPM_CONFIG_REGISTRY": "${localEnv:NPM_CONFIG_REGISTRY}",
+			"PIP_INDEX_URL": "${localEnv:PIP_INDEX_URL}",
+			"UV_DEFAULT_INDEX": "${localEnv:UV_DEFAULT_INDEX}"
+		}
+	},
 	// Features to add to the dev container. More info: https://containers.dev/features.
 	"features": {
 		"ghcr.io/devcontainers/features/common-utils:2": {},


### PR DESCRIPTION
## Summary

Adds a `.devcontainer/Dockerfile` and updates `devcontainer.json` to support dynamic build arguments, allowing the dev container base image and package index URLs (npm, pip, uv) to be overridden from the local environment. This enables building the dev container behind a corporate proxy or against internal package mirrors without editing tracked files.

## Changes

- **`.devcontainer/Dockerfile`** (new): Accepts `BASE_IMAGE`, `NPM_CONFIG_REGISTRY`, `PIP_INDEX_URL`, and `UV_DEFAULT_INDEX` build args, each falling back to public defaults when unset.
- **`.devcontainer/devcontainer.json`**: Switches from a static `image` reference to a `build` block that forwards the corresponding `${localEnv:*}` values into the Dockerfile build args.

## Why

Contributors on networks that require proxied or mirrored package registries can now set the relevant environment variables locally and have the dev container build against them, while the defaults preserve the existing public behavior for everyone else.