### PR TITLE
fix(training): pin AzureML environment templates to explicit versions

### DIFF
--- a/evaluation/sil/workflows/azureml/isaaclab-evaluation.yaml
+++ b/evaluation/sil/workflows/azureml/isaaclab-evaluation.yaml
@@ -33,8 +33,10 @@ identity:
 
 # All values below are placeholders and will be overridden by submit-azureml-isaaclab-evaluation.sh
 # This file serves as a structural template for the job definition.
+# The environment version below is a direct-submit fallback; it must match the
+# version derived from DEFAULT_ISAAC_LAB_IMAGE in scripts/lib/common.sh.
 code: .
-environment: azureml:isaaclab-training-env:latest
+environment: azureml:isaaclab-training-env:2.3.2-sha256-388dbc806f48359a964cb9f807feb226da95d0a107f470fdcad9780ea10fe6f2
 compute: azureml:cpu-cluster
 
 # Inputs follow the same pattern as isaaclab-train.yaml

--- a/evaluation/sil/workflows/azureml/lerobot-eval.yaml
+++ b/evaluation/sil/workflows/azureml/lerobot-eval.yaml
@@ -27,8 +27,10 @@ identity:
 
 # Code root is the repository root so the entrypoint and helper scripts resolve
 # consistently when the template is submitted directly or via the wrapper script.
+# The environment version below is a direct-submit fallback; it must match the
+# version derived from DEFAULT_LEROBOT_EVAL_IMAGE in scripts/lib/common.sh.
 code: ../../../..
-environment: azureml:lerobot-inference-env:latest
+environment: azureml:lerobot-inference-env:2.4.1-cuda12.4-cudnn9-runtime-sha256-0a3b9fedefe1f61ac4d5a9de9015c0863db27ca0fde2d4e37e6268147980b726
 compute: azureml:cpu-inference
 
 command: >-

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -18,6 +18,13 @@ unset _common_sh_dir _env_local
 # OCI images are pinned by immutable @sha256 digest for reproducible, tamper-evident
 # pulls; the tag is retained for readability. Refresh digests with
 # scripts/update-image-digests.sh.
+#
+# derive_azureml_environment_version_from_image() below derives each image's AzureML
+# environment version. That derived version is duplicated as the direct-submit
+# fallback pin in training/il/workflows/azureml/lerobot-train.yaml,
+# training/rl/workflows/azureml/train.yaml, evaluation/sil/workflows/azureml/lerobot-eval.yaml,
+# and evaluation/sil/workflows/azureml/isaaclab-evaluation.yaml. update-image-digests.sh does
+# not rewrite those fallback pins; update them by hand whenever an image below changes.
 DEFAULT_ISAAC_LAB_IMAGE="${DEFAULT_ISAAC_LAB_IMAGE:-nvcr.io/nvidia/isaac-lab:2.3.2@sha256:388dbc806f48359a964cb9f807feb226da95d0a107f470fdcad9780ea10fe6f2}"
 DEFAULT_LEROBOT_TRAIN_IMAGE="${DEFAULT_LEROBOT_TRAIN_IMAGE:-pytorch/pytorch:2.11.0-cuda12.8-cudnn9-runtime@sha256:eee11b3b3872a8c838e35ef48f08b2d5def2080902c7f666831310ca1a0ef2be}"
 DEFAULT_LEROBOT_EVAL_IMAGE="${DEFAULT_LEROBOT_EVAL_IMAGE:-pytorch/pytorch:2.4.1-cuda12.4-cudnn9-runtime@sha256:0a3b9fedefe1f61ac4d5a9de9015c0863db27ca0fde2d4e37e6268147980b726}"

--- a/training/il/workflows/azureml/lerobot-train.yaml
+++ b/training/il/workflows/azureml/lerobot-train.yaml
@@ -26,8 +26,10 @@ identity:
   type: managed_identity
 
 # All values below are placeholders and will be overridden by submit-azureml-lerobot-training.sh
+# The environment version below is a direct-submit fallback; it must match the
+# version derived from DEFAULT_LEROBOT_TRAIN_IMAGE in scripts/lib/common.sh.
 code: .
-environment: azureml:lerobot-training-env:latest
+environment: azureml:lerobot-training-env:2.11.0-cuda12.8-cudnn9-runtime-sha256-eee11b3b3872a8c838e35ef48f08b2d5def2080902c7f666831310ca1a0ef2be
 compute: azureml:cpu-cluster
 
 inputs:

--- a/training/rl/workflows/azureml/train.yaml
+++ b/training/rl/workflows/azureml/train.yaml
@@ -28,8 +28,10 @@ identity:
 
 # All values below are placeholders and will be overridden by submit-azureml-training.sh
 # This file serves as a structural template for the job definition.
+# The environment version below is a direct-submit fallback; it must match the
+# version derived from DEFAULT_ISAAC_LAB_IMAGE in scripts/lib/common.sh.
 code: .
-environment: azureml:isaaclab-training-env:latest
+environment: azureml:isaaclab-training-env:2.3.2-sha256-388dbc806f48359a964cb9f807feb226da95d0a107f470fdcad9780ea10fe6f2
 compute: azureml:cpu-cluster
 
 inputs:


### PR DESCRIPTION
## Summary

AzureML workflow templates referenced their environment assets with the floating `azureml:<name>:latest` tag, which resolves to whichever version was most recently registered — not reproducible or auditable.

## Changes

- Pin the direct-submit fallback in `training/il/workflows/azureml/lerobot-train.yaml`, `training/rl/workflows/azureml/train.yaml`, `evaluation/sil/workflows/azureml/isaaclab-evaluation.yaml`, and `evaluation/sil/workflows/azureml/lerobot-eval.yaml` to the explicit version derived from each script's default image (`scripts/lib/common.sh`), matching what `derive_azureml_environment_version_from_image` produces at submit time.
- Document each pin as a direct-submit fallback in-place, and cross-reference the sync obligation from `scripts/lib/common.sh` back to the four templates, since `scripts/update-image-digests.sh` does not rewrite these derived version strings.
- Pipeline components (`components/train.yaml`, `components/preprocess.yaml`, `components/evaluate.yaml`, `components/register.yaml`) already bind via inline digest-pinned images rather than `azureml:<name>:latest`, so no further pinning is needed there.

## Testing

- `npm run lint:yaml`
- `npm run spell-check` (0 issues)
- `Invoke-Pester scripts/tests/security/Test-DependencyPinning.Tests.ps1` (248/248 passed)
- `shellcheck scripts/lib/common.sh`

Fixes #1079
