### PR TITLE
fix(scripts): extend hve-core linter freshness

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -338,9 +338,9 @@ The `Physical-AI RPI` umbrella (`.github/agents/physical-ai-rpi.agent.md`) and i
 
 See [docs/reference/copilot-artifacts.md](../docs/reference/copilot-artifacts.md) for the full umbrella/worker rationale.
 
-### hve-core Derived Files
+## hve-core Derived Files
 
-Files tracked with a source-header baseline must contain `Adapted from microsoft/hve-core <upstream-path> as of commit <40-hex SHA>`. Keep the upstream path equal to the local vendored path and update the SHA after reviewing and porting upstream changes. `scripts/security/Test-HveCoreFreshness.ps1` compares these entries with a resolved upstream `main` commit; release-baseline modules use the RPI `UPSTREAM_REF` and latest non-draft release.
+Follow the baseline conventions in [`scripts/README.md`](../scripts/README.md). `scripts/security/Test-HveCoreFreshness.ps1` compares source-header entries with a resolved upstream `main` commit and release entries with the RPI `UPSTREAM_REF` and a resolved latest non-draft release commit.
 
 ## Git Workflow
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -338,6 +338,10 @@ The `Physical-AI RPI` umbrella (`.github/agents/physical-ai-rpi.agent.md`) and i
 
 See [docs/reference/copilot-artifacts.md](../docs/reference/copilot-artifacts.md) for the full umbrella/worker rationale.
 
+### hve-core Derived Files
+
+Files tracked with a source-header baseline must contain `Adapted from microsoft/hve-core <upstream-path> as of commit <40-hex SHA>`. Keep the upstream path equal to the local vendored path and update the SHA after reviewing and porting upstream changes. `scripts/security/Test-HveCoreFreshness.ps1` compares these entries with a resolved upstream `main` commit; release-baseline modules use the RPI `UPSTREAM_REF` and latest non-draft release.
+
 ## Git Workflow
 
 Full specification in `.github/instructions/commit-message.instructions.md`.

--- a/.github/workflows/check-hve-core-freshness.yml
+++ b/.github/workflows/check-hve-core-freshness.yml
@@ -49,9 +49,13 @@ jobs:
           $runUrl = "$env:GITHUB_SERVER_URL/$env:GITHUB_REPOSITORY/actions/runs/$env:GITHUB_RUN_ID"
           $checkDate = Get-Date -Format 'yyyy-MM-dd' -AsUTC
           $body = Format-HveCoreIssueBody -Result $data -RunUrl $runUrl -CheckDate $checkDate
-          $title = "security: hve-core freshness needs attention ($env:DRIFT_COUNT drift, $env:ERROR_COUNT errors)"
+          $title = "security: hve-core freshness needs attention ($env:DRIFT_COUNT drifted, $env:ERROR_COUNT check errors)"
           $existing = Get-HveCoreTrackingIssue
-          if ($existing) { gh issue edit $existing --title $title --body $body; gh issue comment $existing --body "🔄 Weekly scan: $env:DRIFT_COUNT drifted, $env:ERROR_COUNT check errors as of $checkDate. [Workflow run]($runUrl)." }
+          if ($existing) {
+            gh issue edit $existing --title $title --body $body
+            if ($LASTEXITCODE -ne 0) { throw "Could not update hve-core freshness issue #$existing" }
+            gh issue comment $existing --body "🔄 Weekly scan: $env:DRIFT_COUNT drifted, $env:ERROR_COUNT check errors as of $checkDate. [Workflow run]($runUrl)."
+          }
           else { gh issue create --title $title --body $body --label "dependencies,automated,needs-triage" }
 
       - name: Close resolved tracking issue

--- a/.github/workflows/check-hve-core-freshness.yml
+++ b/.github/workflows/check-hve-core-freshness.yml
@@ -31,30 +31,31 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Check hve-core-derived files against latest release
+      - name: Check hve-core-derived files against reviewed upstream baselines
         id: check
         env:
           GH_TOKEN: ${{ github.token }}
         run: ./scripts/security/Test-HveCoreFreshness.ps1
 
       - name: Create or update tracking issue
-        if: steps.check.outputs.stale-count != '0'
+        if: steps.check.outputs.attention-count != '0'
         env:
           GH_TOKEN: ${{ github.token }}
-          STALE_COUNT: ${{ steps.check.outputs.stale-count }}
+          DRIFT_COUNT: ${{ steps.check.outputs.drift-count }}
+          ERROR_COUNT: ${{ steps.check.outputs.error-count }}
         run: |
           . ./scripts/security/Test-HveCoreFreshness.ps1
           $data = Get-Content 'hve-core-freshness-results.json' -Raw | ConvertFrom-Json
           $runUrl = "$env:GITHUB_SERVER_URL/$env:GITHUB_REPOSITORY/actions/runs/$env:GITHUB_RUN_ID"
           $checkDate = Get-Date -Format 'yyyy-MM-dd' -AsUTC
           $body = Format-HveCoreIssueBody -Result $data -RunUrl $runUrl -CheckDate $checkDate
-          $title = "security: hve-core upstream updates available ($env:STALE_COUNT stale)"
+          $title = "security: hve-core freshness needs attention ($env:DRIFT_COUNT drift, $env:ERROR_COUNT errors)"
           $existing = Get-HveCoreTrackingIssue
-          if ($existing) { gh issue edit $existing --title $title --body $body; gh issue comment $existing --body "🔄 Weekly scan: $env:STALE_COUNT item(s) stale as of $checkDate. [Workflow run]($runUrl)." }
+          if ($existing) { gh issue edit $existing --title $title --body $body; gh issue comment $existing --body "🔄 Weekly scan: $env:DRIFT_COUNT drifted, $env:ERROR_COUNT check errors as of $checkDate. [Workflow run]($runUrl)." }
           else { gh issue create --title $title --body $body --label "dependencies,automated,needs-triage" }
 
       - name: Close resolved tracking issue
-        if: steps.check.outputs.stale-count == '0'
+        if: steps.check.outputs.attention-count == '0'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -71,7 +71,7 @@ Security scanning and dependency management scripts.
 | `security/Test-DependencyPinning.ps1` | Validate dependency pinning compliance                                                        |
 | `security/Test-SHAStaleness.ps1`      | Check for outdated SHA pins                                                                   |
 | `security/Test-BinaryFreshness.ps1`   | Validate pinned binary hashes and Helm chart versions; emits SARIF for GitHub Security tab    |
-| `security/Test-HveCoreFreshness.ps1`  | Check hve-core-derived files against their reviewed release or source-header baselines         |
+| `security/Test-HveCoreFreshness.ps1`  | Check hve-core-derived files against their reviewed release or source-header baselines        |
 | `security/zap-to-sarif.py`            | Convert ZAP results to SARIF format                                                           |
 | `update-chart-hashes.sh`              | Refresh pinned Helm chart versions and SHA-256 hashes in `infrastructure/setup/defaults.conf` |
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -77,7 +77,7 @@ Security scanning and dependency management scripts.
 
 The `Test-BinaryFreshness.ps1` script is invoked by the `check-binary-integrity.yml` workflow on a weekly schedule. It downloads each pinned GPG key, installer, and CLI archive, compares SHA-256 hashes against the values pinned in `.devcontainer/install-dev-deps.sh` and `.devcontainer/devcontainer.json`, and queries upstream Helm repositories for chart version drift. Findings are written to `binary-freshness-results.sarif` with per-rule `helpUri` values pointing at the appropriate remediation script.
 
-The `Test-HveCoreFreshness.ps1` script is invoked by the `check-hve-core-freshness.yml` workflow on a weekly schedule. Modules compare the **upstream** blob SHA at the pinned `UPSTREAM_REF` against the newest non-draft `microsoft/hve-core` release. Security linters absent from releases compare the source revision recorded in their header against one resolved, immutable upstream `main` revision. This intentionally reports relevant upstream changes before they appear in a release.
+The `Test-HveCoreFreshness.ps1` script is invoked by the `check-hve-core-freshness.yml` workflow on a weekly schedule. Each derived file declares a baseline. `release` files compare the **upstream** blob SHA at the pinned `UPSTREAM_REF` against one resolved, immutable newest non-draft release revision. `source-header` files compare the revision recorded in their header against one resolved, immutable upstream `main` revision. This reports relevant upstream changes before they appear in a release.
 
 Source-header files must include `Adapted from microsoft/hve-core <upstream-path> as of commit <40-hex SHA>`. Comparing upstream blobs avoids false drift from intentional local adaptations.
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -77,7 +77,7 @@ Security scanning and dependency management scripts.
 
 The `Test-BinaryFreshness.ps1` script is invoked by the `check-binary-integrity.yml` workflow on a weekly schedule. It downloads each pinned GPG key, installer, and CLI archive, compares SHA-256 hashes against the values pinned in `.devcontainer/install-dev-deps.sh` and `.devcontainer/devcontainer.json`, and queries upstream Helm repositories for chart version drift. Findings are written to `binary-freshness-results.sarif` with per-rule `helpUri` values pointing at the appropriate remediation script.
 
-The `Test-HveCoreFreshness.ps1` script is invoked by the `check-hve-core-freshness.yml` workflow on a weekly schedule. Modules compare the **upstream** blob SHA at the pinned `UPSTREAM_REF` against the newest non-draft `microsoft/hve-core` release. Security linters absent from releases compare the source revision recorded in their header against one resolved, immutable upstream `main` revision.
+The `Test-HveCoreFreshness.ps1` script is invoked by the `check-hve-core-freshness.yml` workflow on a weekly schedule. Modules compare the **upstream** blob SHA at the pinned `UPSTREAM_REF` against the newest non-draft `microsoft/hve-core` release. Security linters absent from releases compare the source revision recorded in their header against one resolved, immutable upstream `main` revision. This intentionally reports relevant upstream changes before they appear in a release.
 
 Source-header files must include `Adapted from microsoft/hve-core <upstream-path> as of commit <40-hex SHA>`. Comparing upstream blobs avoids false drift from intentional local adaptations.
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -71,13 +71,15 @@ Security scanning and dependency management scripts.
 | `security/Test-DependencyPinning.ps1` | Validate dependency pinning compliance                                                        |
 | `security/Test-SHAStaleness.ps1`      | Check for outdated SHA pins                                                                   |
 | `security/Test-BinaryFreshness.ps1`   | Validate pinned binary hashes and Helm chart versions; emits SARIF for GitHub Security tab    |
-| `security/Test-HveCoreFreshness.ps1`  | Check hve-core-derived modules against the latest upstream release                            |
+| `security/Test-HveCoreFreshness.ps1`  | Check hve-core-derived files against their reviewed release or source-header baselines         |
 | `security/zap-to-sarif.py`            | Convert ZAP results to SARIF format                                                           |
 | `update-chart-hashes.sh`              | Refresh pinned Helm chart versions and SHA-256 hashes in `infrastructure/setup/defaults.conf` |
 
 The `Test-BinaryFreshness.ps1` script is invoked by the `check-binary-integrity.yml` workflow on a weekly schedule. It downloads each pinned GPG key, installer, and CLI archive, compares SHA-256 hashes against the values pinned in `.devcontainer/install-dev-deps.sh` and `.devcontainer/devcontainer.json`, and queries upstream Helm repositories for chart version drift. Findings are written to `binary-freshness-results.sarif` with per-rule `helpUri` values pointing at the appropriate remediation script.
 
-The `Test-HveCoreFreshness.ps1` script is invoked by the `check-hve-core-freshness.yml` workflow on a weekly schedule. For every hve-core-derived module, it compares the **upstream** blob SHA at the pinned `UPSTREAM_REF` (the last reviewed upstream ref) against the newest non-draft `microsoft/hve-core` release. Comparing blobs, not release tags, means a stale signal is a real upstream change rather than an unrelated prerelease.
+The `Test-HveCoreFreshness.ps1` script is invoked by the `check-hve-core-freshness.yml` workflow on a weekly schedule. Modules compare the **upstream** blob SHA at the pinned `UPSTREAM_REF` against the newest non-draft `microsoft/hve-core` release. Security linters absent from releases compare the source revision recorded in their header against one resolved, immutable upstream `main` revision.
+
+Source-header files must include `Adapted from microsoft/hve-core <upstream-path> as of commit <40-hex SHA>`. Comparing upstream blobs avoids false drift from intentional local adaptations.
 
 ### 🔗 Where Pins Live
 

--- a/scripts/security/Test-DangerousWorkflow.ps1
+++ b/scripts/security/Test-DangerousWorkflow.ps1
@@ -18,7 +18,7 @@
       the pull-request head ref, executing untrusted code in a privileged context.
 
     Adapted from microsoft/hve-core scripts/security/Test-DangerousWorkflow.ps1
-    as of commit b70237d08d5caf6918b9de9952a243a8588b92dc (2026-07-02).
+    as of commit b70237d08d5caf6918b9de9952a243a8588b92dc.
 
     Local divergences from upstream (each marked inline with a '# LOCAL' comment):
 

--- a/scripts/security/Test-HveCoreFreshness.ps1
+++ b/scripts/security/Test-HveCoreFreshness.ps1
@@ -13,7 +13,8 @@
     pinned UPSTREAM_REF and the latest release. Security linters use the source
     revision recorded in their headers and upstream main, which also covers files
     not present in a release. Writes a JSON results file consumed by the tracking-
-    issue steps and, under GitHub Actions, emits the stale item count to GITHUB_OUTPUT.
+    issue steps and, under GitHub Actions, emits attention-count, drift-count, and
+    error-count to GITHUB_OUTPUT.
 
 .PARAMETER ResultsFile
     Output JSON results path. Default: hve-core-freshness-results.json.
@@ -97,7 +98,12 @@ function Get-PinnedHveCoreRef {
     }
 
     $content = Get-Content -Path $Path -Raw
-    $sha = if ($content -match 'UPSTREAM_REF:\s*([0-9a-fA-F]{7,40})') { $Matches[1] } else { $null }
+    $sha = if ($content -match '(?m)^\s*UPSTREAM_REF:\s*[''"]?([0-9a-fA-F]{40})[''"]?\s*(?:#.*)?$') {
+        $Matches[1]
+    }
+    else {
+        $null
+    }
     $tag = if ($content -match 'hve-core release:\s*(\S+)') { $Matches[1] } else { 'unknown' }
 
     return [ordered]@{ Tag = $tag; Sha = $sha }
@@ -165,7 +171,7 @@ function Get-DriftState {
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)][AllowEmptyString()][string]$BaselineUpstreamSha,
-        [Parameter(Mandatory = $false)][AllowEmptyString()][string]$TargetUpstreamSha
+        [Parameter(Mandatory)][AllowEmptyString()][string]$TargetUpstreamSha
     )
 
     $baseline = $BaselineUpstreamSha.ToLowerInvariant()
@@ -190,12 +196,18 @@ function Get-HveCoreBlobSha {
     )
 
     $out = gh api --method GET "repos/$Repo/contents/$Path" -f "ref=$Ref" --jq '.sha' 2>&1
-    if ($LASTEXITCODE -eq 0) { return ("$out").Trim() }
+    if ($LASTEXITCODE -eq 0) {
+        $sha = ("$out").Trim()
+        if ($sha -notmatch $script:FullShaPattern) {
+            throw "gh api returned an invalid blob SHA for ${Path}@${Ref}: $out"
+        }
+        return $sha
+    }
 
     # A genuine 404 means the file is absent at that ref.
     # Any other failure (transient, auth, rate limit) must fail loudly rather than
     # masquerade as drift and file a false tracking issue.
-    if ("$out" -match 'HTTP 404|Not Found') { return '' }
+    if ("$out" -match 'HTTP 404') { return '' }
     throw "gh api failed for ${Path}@${Ref}: $out"
 }
 
@@ -217,6 +229,11 @@ function Get-HveCoreFileDrift {
     $baselineUpstreamSha = Get-HveCoreBlobSha -Repo $Repo -Path $Path -Ref $BaselineRef
     $targetUpstreamSha = Get-HveCoreBlobSha -Repo $Repo -Path $Path -Ref $TargetRef
     $state = Get-DriftState -BaselineUpstreamSha $baselineUpstreamSha -TargetUpstreamSha $targetUpstreamSha
+    if ($state -eq 'missing-both') {
+        throw [HveCoreFileValidationException]::new(
+            "Upstream path '$Path' is absent at both baseline ref '$BaselineRef' and target ref '$TargetRef'"
+        )
+    }
     $baselineRefUrl = [uri]::EscapeDataString($BaselineRef)
     $targetRefUrl = [uri]::EscapeDataString($TargetRef)
 
@@ -271,6 +288,19 @@ function ConvertTo-HveCoreMarkdownText {
             -replace '`', '&#96;')
 }
 
+function Get-HveCoreShortSha {
+    <#
+    .SYNOPSIS
+        Shortens a SHA for display while preserving empty and short values.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][AllowEmptyString()][string]$Value
+    )
+
+    return $Value.Substring(0, [Math]::Min($script:ShortShaLength, $Value.Length))
+}
+
 function Format-HveCoreDriftCells {
     <#
     .SYNOPSIS
@@ -281,10 +311,20 @@ function Format-HveCoreDriftCells {
         [Parameter(Mandatory)][object]$File
     )
 
-    $baselineSha = if ($File.BaselineUpstreamSha) { $File.BaselineUpstreamSha.Substring(0, [Math]::Min($script:ShortShaLength, $File.BaselineUpstreamSha.Length)) } else { '' }
-    $targetSha = if ($File.TargetUpstreamSha) { $File.TargetUpstreamSha.Substring(0, [Math]::Min($script:ShortShaLength, $File.TargetUpstreamSha.Length)) } else { '' }
-    $baselineRef = if ($File.BaselineRef -match $script:FullShaPattern) { $File.BaselineRef.Substring(0, $script:ShortShaLength) } else { $File.BaselineRef }
-    $targetRef = if ($File.TargetRef -match $script:FullShaPattern) { $File.TargetRef.Substring(0, $script:ShortShaLength) } else { $File.TargetRef }
+    $baselineSha = Get-HveCoreShortSha -Value $File.BaselineUpstreamSha
+    $targetSha = Get-HveCoreShortSha -Value $File.TargetUpstreamSha
+    $baselineRef = if ($File.BaselineRef -match $script:FullShaPattern) {
+        Get-HveCoreShortSha -Value $File.BaselineRef
+    }
+    else {
+        $File.BaselineRef
+    }
+    $targetRef = if ($File.TargetRef -match $script:FullShaPattern) {
+        Get-HveCoreShortSha -Value $File.TargetRef
+    }
+    else {
+        $File.TargetRef
+    }
     $baselineRef = ConvertTo-HveCoreMarkdownText -Value $baselineRef
     $targetRef = ConvertTo-HveCoreMarkdownText -Value $targetRef
 
@@ -305,11 +345,11 @@ function Format-HveCoreDriftCells {
     }
 
     return [ordered]@{
-        Baseline   = $baseline
-        Status     = $status
+        Baseline    = $baseline
+        Status      = $status
         BaselineSha = $baselineSha
         TargetSha   = $targetSha
-        Comparison = if ($File.ComparisonUrl) { "[$baselineRef → $targetRef]($($File.ComparisonUrl))" } else { '' }
+        Comparison  = if ($File.ComparisonUrl) { "[$baselineRef → $targetRef]($($File.ComparisonUrl))" } else { '' }
     }
 }
 
@@ -329,6 +369,10 @@ function Format-HveCoreDriftRow {
 }
 
 function Get-HveCoreTrustedReleaseUrl {
+    <#
+    .SYNOPSIS
+        Validates that a release URL is an absolute HTTPS URL on github.com.
+    #>
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)][string]$Value
@@ -360,6 +404,8 @@ function Format-HveCoreIssueBody {
     $latestTagText = ConvertTo-HveCoreMarkdownText -Value $Result.LatestTag
     $latestUrl = Get-HveCoreTrustedReleaseUrl -Value $Result.LatestUrl
     $latestLink = "[$latestTagText]($latestUrl)"
+    $pinnedTagText = ConvertTo-HveCoreMarkdownText -Value $pin.PinnedTag
+    $latestMainShaText = ConvertTo-HveCoreMarkdownText -Value $Result.LatestMainSha
 
     $fileRows = ($files | ForEach-Object { Format-HveCoreDriftRow -File $_ }) -join "`n"
 
@@ -371,8 +417,8 @@ function Format-HveCoreIssueBody {
 ## hve-core Upstream Freshness Report
 
 Latest reviewed hve-core release: $latestLink
-Release-file baseline: ``$($pin.PinnedTag)`` (``UPSTREAM_REF`` in ``$($pin.File)``)
-Source-header target: ``$($Result.LatestMainSha)``
+Release-file baseline: ``$pinnedTagText`` (``UPSTREAM_REF`` in ``$($pin.File)``)
+Source-header target: ``$latestMainShaText``
 Action required: $($Result.DriftCount) drifted, $($Result.ErrorCount) check errors
 
 ### Derived Files
@@ -408,10 +454,7 @@ function Format-HveCoreJobSummary {
     $pin = $Result.Pin
     $files = @($Result.Files)
 
-    $fileRows = foreach ($f in $files) {
-        $cells = Format-HveCoreDriftCells -File $f
-        "| $($f.Path) | $($cells.Baseline) | $($cells.Comparison) | $($cells.BaselineSha) | $($cells.TargetSha) | $($cells.Status) |"
-    }
+    $fileRows = $files | ForEach-Object { Format-HveCoreDriftRow -File $_ }
 
     return @"
 ## hve-core Upstream Freshness
@@ -421,8 +464,8 @@ Release-file baseline: $($pin.PinnedTag)
 Source-header target: $($Result.LatestMainSha)
 Action required: $($Result.DriftCount) drifted, $($Result.ErrorCount) check errors
 
-| Derived File | Baseline | Upstream comparison | Baseline blob | Target blob | Status |
-|--------------|----------|---------------------|---------------|-------------|--------|
+| File | Baseline | Upstream comparison | Baseline upstream blob | Target upstream blob | Status |
+|------|----------|---------------------|------------------------|----------------------|--------|
 $($fileRows -join "`n")
 "@
 }
@@ -435,8 +478,10 @@ function Get-HveCoreTrackingIssue {
     [CmdletBinding()]
     param()
 
-    $n = gh issue list --search $script:IssueSearch --limit 1 --json number --jq '.[0].number // empty'
-    if ($LASTEXITCODE -ne 0) { return $null }
+    $n = gh issue list --search $script:IssueSearch --limit 1 --json number --jq '.[0].number // empty' 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        throw "Could not query existing hve-core freshness issue: $n"
+    }
     return $(if ($n) { $n.Trim() } else { $null })
 }
 
@@ -473,7 +518,11 @@ function Resolve-HveCoreCommitSha {
     if ($LASTEXITCODE -ne 0 -or -not $sha) {
         throw "Could not resolve ref '$Ref' in ${Repo}: $sha"
     }
-    return ("$sha").Trim()
+    $sha = ("$sha").Trim()
+    if ($sha -notmatch $script:FullShaPattern) {
+        throw "Could not resolve ref '$Ref' in ${Repo}: invalid commit SHA '$sha'"
+    }
+    return $sha
 }
 
 function Assert-HveCoreCommitOnMain {
@@ -493,14 +542,18 @@ function Assert-HveCoreCommitOnMain {
 
     $mergeBase = gh api "repos/$Repo/compare/$CommitSha...$MainSha" --jq '.merge_base_commit.sha' 2>&1
     if ($LASTEXITCODE -ne 0 -or -not $mergeBase) {
-        if ("$mergeBase" -match 'HTTP 404|Not Found|No common ancestor') {
+        if ("$mergeBase" -match 'HTTP 404|No common ancestor') {
             throw [HveCoreFileValidationException]::new(
                 "Recorded source commit '$CommitSha' could not be compared with upstream main '$MainSha'"
             )
         }
         throw "Could not verify source commit '$CommitSha' against upstream main in ${Repo}: $mergeBase"
     }
-    if (("$mergeBase").Trim() -ne $CommitSha) {
+    $mergeBase = ("$mergeBase").Trim()
+    if ($mergeBase -notmatch $script:FullShaPattern) {
+        throw "Could not verify source commit '$CommitSha' against upstream main in ${Repo}: invalid merge-base SHA '$mergeBase'"
+    }
+    if ($mergeBase -cne $CommitSha) {
         throw [HveCoreFileValidationException]::new(
             "Recorded source commit '$CommitSha' is not an ancestor of upstream main '$MainSha'"
         )
@@ -528,7 +581,7 @@ function Get-HveCoreFileDriftForBaseline {
     switch ($File.Baseline) {
         'source-header' {
             $source = Get-HveCoreFileSource -Path $path
-            if ($source.Path -ne $path) {
+            if ($source.Path -cne $path) {
                 throw [HveCoreFileValidationException]::new(
                     "Vendored path '$path' must match its recorded hve-core source path, but the header records '$($source.Path)'"
                 )
@@ -606,8 +659,8 @@ function Invoke-HveCoreFreshnessCheck {
                 }
             }
 
-            $icon = if ($r.Drift) { 'DRIFT' } else { 'OK' }
-            Write-Host "$icon $path : $($r.State)"
+            $status = if ($r.State -eq 'error') { 'ERROR' } elseif ($r.Drift) { 'DRIFT' } else { 'OK' }
+            Write-Host "$status $path : $($r.State)"
             $r
         }
         $fileResults = @($fileResults)
@@ -637,6 +690,22 @@ function Invoke-HveCoreFreshnessCheck {
     finally {
         Pop-Location
     }
+}
+
+function Write-HveCoreGitHubOutputs {
+    <#
+    .SYNOPSIS
+        Appends freshness counters to a GitHub Actions output file.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][object]$Outcome,
+        [Parameter(Mandatory)][string]$Path
+    )
+
+    "attention-count=$($Outcome.AttentionCount)" >> $Path
+    "drift-count=$($Outcome.DriftCount)" >> $Path
+    "error-count=$($Outcome.ErrorCount)" >> $Path
 }
 
 function Resolve-RepoRoot {
@@ -682,9 +751,7 @@ if ($MyInvocation.InvocationName -ne '.') {
     try {
         $outcome = Invoke-HveCoreFreshnessCheck -RepoRoot $resolvedRoot -ResultsFile $ResultsFile
         if ($env:GITHUB_OUTPUT) {
-            "attention-count=$($outcome.AttentionCount)" >> $env:GITHUB_OUTPUT
-            "drift-count=$($outcome.DriftCount)" >> $env:GITHUB_OUTPUT
-            "error-count=$($outcome.ErrorCount)" >> $env:GITHUB_OUTPUT
+            Write-HveCoreGitHubOutputs -Outcome $outcome -Path $env:GITHUB_OUTPUT
         }
         exit 0
     }

--- a/scripts/security/Test-HveCoreFreshness.ps1
+++ b/scripts/security/Test-HveCoreFreshness.ps1
@@ -104,7 +104,7 @@ function Get-PinnedHveCoreRef {
     else {
         $null
     }
-    $tag = if ($content -match 'hve-core release:\s*(\S+)') { $Matches[1] } else { 'unknown' }
+    $tag = if ($content -match 'hve-core release:\s*([A-Za-z0-9._/+.-]{1,128})(?:\s|$)') { $Matches[1] } else { 'unknown' }
 
     return [ordered]@{ Tag = $tag; Sha = $sha }
 }
@@ -124,6 +124,9 @@ function Get-HveCoreFileSource {
     }
 
     $content = Get-Content -Path $Path -Raw
+    if ([string]::IsNullOrWhiteSpace($content)) {
+        throw [HveCoreFileValidationException]::new("Derived file is empty: $Path")
+    }
     $headerEnd = $content.IndexOf('#>')
     if ($headerEnd -lt 0) {
         throw [HveCoreFileValidationException]::new("Could not find a comment-based help header in $Path")
@@ -239,8 +242,8 @@ function Get-HveCoreFileDrift {
 
     return [ordered]@{
         Path                = $Path
-        BaselineUpstreamSha = if ($baselineUpstreamSha) { $baselineUpstreamSha } else { '' }
-        TargetUpstreamSha   = if ($targetUpstreamSha) { $targetUpstreamSha } else { '' }
+        BaselineUpstreamSha = $baselineUpstreamSha
+        TargetUpstreamSha   = $targetUpstreamSha
         BaselineRef         = $BaselineRef
         TargetRef           = $TargetRef
         ComparisonUrl       = "https://github.com/$Repo/compare/$baselineRefUrl...$targetRefUrl"
@@ -261,11 +264,14 @@ function Get-HveCoreStateLabel {
 
     switch ($State) {
         'drift'            { return '⚠️ Upstream advanced' }
-        'missing-both'     { return '❓ Not found at either ref' }
         'missing-baseline' { return '❓ Not found at baseline ref' }
         'missing-target'   { return '❓ Not found at target ref' }
         'error'            { return '❌ Check failed' }
-        default            { return '✅ Current' }
+        'current'          { return '✅ Current' }
+        default {
+            $stateText = ConvertTo-HveCoreMarkdownText -Value $State
+            return "❓ Unknown state: $stateText"
+        }
     }
 }
 
@@ -375,7 +381,7 @@ function Get-HveCoreTrustedReleaseUrl {
     #>
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory)][string]$Value
+        [Parameter(Mandatory)][AllowNull()][AllowEmptyString()][string]$Value
     )
 
     $uri = $null
@@ -416,7 +422,7 @@ function Format-HveCoreIssueBody {
     return @"
 ## hve-core Upstream Freshness Report
 
-Latest reviewed hve-core release: $latestLink
+Latest hve-core release: $latestLink
 Release-file baseline: ``$pinnedTagText`` (``UPSTREAM_REF`` in ``$($pin.File)``)
 Source-header target: ``$latestMainShaText``
 Action required: $($Result.DriftCount) drifted, $($Result.ErrorCount) check errors
@@ -454,14 +460,17 @@ function Format-HveCoreJobSummary {
     $pin = $Result.Pin
     $files = @($Result.Files)
 
+    $latestTagText = ConvertTo-HveCoreMarkdownText -Value $Result.LatestTag
+    $pinnedTagText = ConvertTo-HveCoreMarkdownText -Value $pin.PinnedTag
+    $latestMainShaText = ConvertTo-HveCoreMarkdownText -Value $Result.LatestMainSha
     $fileRows = $files | ForEach-Object { Format-HveCoreDriftRow -File $_ }
 
     return @"
 ## hve-core Upstream Freshness
 
-Latest release: $($Result.LatestTag)
-Release-file baseline: $($pin.PinnedTag)
-Source-header target: $($Result.LatestMainSha)
+Latest release: $latestTagText
+Release-file baseline: $pinnedTagText
+Source-header target: $latestMainShaText
 Action required: $($Result.DriftCount) drifted, $($Result.ErrorCount) check errors
 
 | File | Baseline | Upstream comparison | Baseline upstream blob | Target upstream blob | Status |
@@ -553,7 +562,7 @@ function Assert-HveCoreCommitOnMain {
     if ($mergeBase -notmatch $script:FullShaPattern) {
         throw "Could not verify source commit '$CommitSha' against upstream main in ${Repo}: invalid merge-base SHA '$mergeBase'"
     }
-    if ($mergeBase -cne $CommitSha) {
+    if ($mergeBase -ne $CommitSha) {
         throw [HveCoreFileValidationException]::new(
             "Recorded source commit '$CommitSha' is not an ancestor of upstream main '$MainSha'"
         )
@@ -569,7 +578,7 @@ function Get-HveCoreFileDriftForBaseline {
     param(
         [Parameter(Mandatory)][object]$File,
         [Parameter(Mandatory)][string]$PinnedReleaseSha,
-        [Parameter(Mandatory)][string]$LatestReleaseTag,
+        [Parameter(Mandatory)][string]$LatestReleaseSha,
         [Parameter(Mandatory)][string]$LatestMainSha
     )
 
@@ -587,10 +596,16 @@ function Get-HveCoreFileDriftForBaseline {
                 )
             }
             Assert-HveCoreCommitOnMain -Repo $script:UpstreamRepo -CommitSha $source.Sha -MainSha $LatestMainSha
-            return Get-HveCoreFileDrift -Repo $script:UpstreamRepo -Path $source.Path -BaselineRef $source.Sha -TargetRef $LatestMainSha
+            $result = Get-HveCoreFileDrift -Repo $script:UpstreamRepo -Path $source.Path -BaselineRef $source.Sha -TargetRef $LatestMainSha
+            if ($result.State -eq 'missing-baseline') {
+                throw [HveCoreFileValidationException]::new(
+                    "Recorded source path '$($source.Path)' is absent at its recorded commit '$($source.Sha)'"
+                )
+            }
+            return $result
         }
         'release' {
-            return Get-HveCoreFileDrift -Repo $script:UpstreamRepo -Path $path -BaselineRef $PinnedReleaseSha -TargetRef $LatestReleaseTag
+            return Get-HveCoreFileDrift -Repo $script:UpstreamRepo -Path $path -BaselineRef $PinnedReleaseSha -TargetRef $LatestReleaseSha
         }
         default {
             throw [HveCoreFileValidationException]::new("Unsupported hve-core baseline '$($File.Baseline)' for $path")
@@ -641,7 +656,7 @@ function Invoke-HveCoreFreshnessCheck {
         $fileResults = foreach ($file in $script:DerivedFiles) {
             $path = $file.Path
             try {
-                $r = Get-HveCoreFileDriftForBaseline -File $file -PinnedReleaseSha $pinRef.Sha -LatestReleaseTag $latestTag -LatestMainSha $latestMainSha
+                $r = Get-HveCoreFileDriftForBaseline -File $file -PinnedReleaseSha $pinRef.Sha -LatestReleaseSha $latestSha -LatestMainSha $latestMainSha
                 $r['Baseline'] = $file.Baseline
             }
             catch [HveCoreFileValidationException] {
@@ -672,6 +687,7 @@ function Invoke-HveCoreFreshnessCheck {
 
         [ordered]@{
             LatestTag     = $latestTag
+            LatestReleaseSha = $latestSha
             LatestUrl     = $latestUrl
             LatestMainSha = $latestMainSha
             DriftCount    = $driftCount

--- a/scripts/security/Test-HveCoreFreshness.ps1
+++ b/scripts/security/Test-HveCoreFreshness.ps1
@@ -8,12 +8,12 @@
     Checks hve-core-derived files against the latest upstream release.
 
 .DESCRIPTION
-    Resolves the newest non-draft microsoft/hve-core release and compares each
-    hve-core-derived file's upstream blob SHA at the pinned UPSTREAM_REF (the last
-    reviewed upstream ref, read from the RPI bootstrap workflow) against the same
-    upstream path at the latest release. Writes a JSON results file consumed by the
-    tracking-issue steps and, when running under GitHub Actions, emits the stale item
-    count to GITHUB_OUTPUT.
+    Compares each hve-core-derived file's upstream blob SHA at its reviewed source
+    revision against its current upstream target. Modules use the RPI bootstrap's
+    pinned UPSTREAM_REF and the latest release. Security linters use the source
+    revision recorded in their headers and upstream main, which also covers files
+    not present in a release. Writes a JSON results file consumed by the tracking-
+    issue steps and, under GitHub Actions, emits the stale item count to GITHUB_OUTPUT.
 
 .PARAMETER ResultsFile
     Output JSON results path. Default: hve-core-freshness-results.json.
@@ -55,17 +55,16 @@ $script:SetupWorkflow = '.github/workflows/copilot-setup-steps.yml'
 $script:IssueMarker = 'automation:hve-core-freshness'
 $script:IssueSearch = "in:body $script:IssueMarker is:open"
 
-# These are hve-core-derived modules; the check compares each file's UPSTREAM blob SHA
-# at the pinned ref vs the latest release, so local adaptations never cause false drift.
-# "drift" means upstream changed the file since the pinned ref and the change should
-# be reviewed and ported.
+# Blob-to-blob comparisons avoid false drift from intentional local adaptations.
 $script:DerivedFiles = @(
-    'scripts/security/Modules/SecurityHelpers.psm1'
-    'scripts/security/Modules/SecurityClasses.psm1'
-    'scripts/linting/Modules/LintingHelpers.psm1'
-    'scripts/tests/Mocks/GitMocks.psm1'
-    'scripts/lib/Modules/CIHelpers.psm1'
-    'scripts/linting/Modules/FrontmatterValidation.psm1'
+    [ordered]@{ Path = 'scripts/security/Modules/SecurityHelpers.psm1'; Baseline = 'release' }
+    [ordered]@{ Path = 'scripts/security/Modules/SecurityClasses.psm1'; Baseline = 'release' }
+    [ordered]@{ Path = 'scripts/linting/Modules/LintingHelpers.psm1'; Baseline = 'release' }
+    [ordered]@{ Path = 'scripts/tests/Mocks/GitMocks.psm1'; Baseline = 'release' }
+    [ordered]@{ Path = 'scripts/lib/Modules/CIHelpers.psm1'; Baseline = 'release' }
+    [ordered]@{ Path = 'scripts/linting/Modules/FrontmatterValidation.psm1'; Baseline = 'release' }
+    [ordered]@{ Path = 'scripts/security/Test-WorkflowPermissions.ps1'; Baseline = 'source-header' }
+    [ordered]@{ Path = 'scripts/security/Test-DangerousWorkflow.ps1'; Baseline = 'source-header' }
 )
 
 # ============================================================
@@ -94,6 +93,32 @@ function Get-PinnedHveCoreRef {
     $tag = if ($content -match 'hve-core release:\s*(\S+)') { $Matches[1] } else { 'unknown' }
 
     return [ordered]@{ Tag = $tag; Sha = $sha }
+}
+
+function Get-HveCoreFileSource {
+    <#
+    .SYNOPSIS
+        Reads an hve-core source path and commit from a vendored file's header.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$Path
+    )
+
+    if (-not (Test-Path $Path)) {
+        throw "Derived file not found locally: $Path"
+    }
+
+    $content = Get-Content -Path $Path -Raw
+    $pattern = 'Adapted from\s+microsoft/hve-core\s+(scripts/security/\S+\.ps1)\s+as of commit\s+([0-9a-fA-F]{40})'
+    if ($content -notmatch $pattern) {
+        throw "Could not extract hve-core source revision from $Path"
+    }
+
+    return [ordered]@{
+        Path = $Matches[1]
+        Sha  = $Matches[2].ToLowerInvariant()
+    }
 }
 
 function Select-LatestRelease {
@@ -177,6 +202,9 @@ function Get-HveCoreFileDrift {
         Path              = $Path
         PinnedUpstreamSha = if ($pinnedUp) { $pinnedUp } else { '' }
         LatestUpstreamSha = if ($latestUp) { $latestUp } else { '' }
+        PinnedRef         = $PinnedRef
+        LatestRef         = $LatestRef
+        ComparisonUrl     = "https://github.com/$Repo/compare/$PinnedRef...$LatestRef"
         Drift             = ($state -ne 'current')
         State             = $state
     }
@@ -213,7 +241,10 @@ function Format-HveCoreDriftRow {
     $status = Get-HveCoreStateLabel -State $File.State
     $pSha = if ($File.PinnedUpstreamSha) { $File.PinnedUpstreamSha.Substring(0, [Math]::Min(7, $File.PinnedUpstreamSha.Length)) } else { '' }
     $lSha = if ($File.LatestUpstreamSha) { $File.LatestUpstreamSha.Substring(0, [Math]::Min(7, $File.LatestUpstreamSha.Length)) } else { '' }
-    return "| ``$($File.Path)`` | $pSha | $lSha | $status |"
+    $pRef = if ($File.PinnedRef -match '^[0-9a-fA-F]{40}$') { $File.PinnedRef.Substring(0, 7) } else { $File.PinnedRef }
+    $lRef = if ($File.LatestRef -match '^[0-9a-fA-F]{40}$') { $File.LatestRef.Substring(0, 7) } else { $File.LatestRef }
+    $comparison = if ($File.ComparisonUrl) { "[$pRef → $lRef]($($File.ComparisonUrl))" } else { '' }
+    return "| ``$($File.Path)`` | $comparison | $pSha | $lSha | $status |"
 }
 
 function Format-HveCoreIssueBody {
@@ -244,13 +275,13 @@ Drift baseline: ``$($pin.PinnedTag)`` (``UPSTREAM_REF`` in ``$($pin.File)``)
 
 ### Derived Files
 
-| File | Pinned Upstream blob | Latest Upstream blob | Status |
-|------|----------------------|----------------------|--------|
+| File | Upstream comparison | Pinned Upstream blob | Latest Upstream blob | Status |
+|------|---------------------|----------------------|----------------------|--------|
 $fileRows
 
 ### How to Refresh
 
-Review the upstream changes and port any relevant ones into the locally-adapted copy; do not blindly overwrite (these files carry intentional local adaptations). Compare link: https://github.com/microsoft/hve-core/compare/$compareBase...$($Result.LatestTag)
+Review the upstream changes and port any relevant ones into the locally-adapted copy; do not blindly overwrite (these files carry intentional local adaptations). Each row links to its exact baseline comparison. Release baseline: https://github.com/microsoft/hve-core/compare/$compareBase...$($Result.LatestTag)
 
 Run ``npm run lint:ps`` and ``npm run test:ps`` after changes.
 
@@ -279,17 +310,23 @@ function Format-HveCoreJobSummary {
         $fStatus = Get-HveCoreStateLabel -State $f.State
         $pSha = if ($f.PinnedUpstreamSha) { $f.PinnedUpstreamSha.Substring(0, [Math]::Min(7, $f.PinnedUpstreamSha.Length)) } else { '' }
         $lSha = if ($f.LatestUpstreamSha) { $f.LatestUpstreamSha.Substring(0, [Math]::Min(7, $f.LatestUpstreamSha.Length)) } else { '' }
-        "| $($f.Path) | $pSha | $lSha | $fStatus |"
+        $pRef = if ($f.PinnedRef -match '^[0-9a-fA-F]{40}$') { $f.PinnedRef.Substring(0, 7) } else { $f.PinnedRef }
+        $lRef = if ($f.LatestRef -match '^[0-9a-fA-F]{40}$') { $f.LatestRef.Substring(0, 7) } else { $f.LatestRef }
+        $comparison = if ($f.ComparisonUrl) { "[$pRef → $lRef]($($f.ComparisonUrl))" } else { '' }
+        "| $($f.Path) | $comparison | $pSha | $lSha | $fStatus |"
     }
+
+    $mainSummary = if ($Result.LatestMainSha) { "`nUpstream main: $($Result.LatestMainSha)" } else { '' }
 
     return @"
 ## hve-core Upstream Freshness
 
 Latest release: $($Result.LatestTag)
 Drift baseline: $($pin.PinnedTag)
+$mainSummary
 
-| Derived File | Pinned blob | Latest blob | Status |
-|--------------|-------------|-------------|--------|
+| Derived File | Upstream comparison | Pinned blob | Latest blob | Status |
+|--------------|---------------------|-------------|-------------|--------|
 $($fileRows -join "`n")
 "@
 }
@@ -364,6 +401,8 @@ function Invoke-HveCoreFreshnessCheck {
 
         $latestSha = Resolve-HveCoreCommitSha -Repo $script:UpstreamRepo -Ref $latestTag
         Write-Host "Latest hve-core release: $latestTag ($latestSha)"
+        $latestMainSha = Resolve-HveCoreCommitSha -Repo $script:UpstreamRepo -Ref 'main'
+        Write-Host "Latest hve-core main: $latestMainSha"
 
         $pinRef = Get-PinnedHveCoreRef -Path $script:SetupWorkflow
         if (-not $pinRef -or -not $pinRef.Sha) {
@@ -380,13 +419,29 @@ function Invoke-HveCoreFreshnessCheck {
             File      = $script:SetupWorkflow
         }
 
-        # --- Derived file drift ---
-        $fileResults = foreach ($path in $script:DerivedFiles) {
+        $fileResults = foreach ($file in $script:DerivedFiles) {
+            $path = $file.Path
             if (-not (Test-Path $path)) {
                 throw "Derived file not found locally: $path"
             }
 
-            $r = Get-HveCoreFileDrift -Repo $script:UpstreamRepo -Path $path -PinnedRef $pinRef.Sha -LatestRef $latestTag
+            switch ($file.Baseline) {
+                'source-header' {
+                    $source = Get-HveCoreFileSource -Path $path
+                    if ($source.Path -ne $path) {
+                        throw "Recorded hve-core source path for $path is $($source.Path)"
+                    }
+                    $null = Resolve-HveCoreCommitSha -Repo $script:UpstreamRepo -Ref $source.Sha
+                    $r = Get-HveCoreFileDrift -Repo $script:UpstreamRepo -Path $source.Path -PinnedRef $source.Sha -LatestRef 'main'
+                }
+                'release' {
+                    $r = Get-HveCoreFileDrift -Repo $script:UpstreamRepo -Path $path -PinnedRef $pinRef.Sha -LatestRef $latestTag
+                }
+                default {
+                    throw "Unsupported hve-core baseline '$($file.Baseline)' for $path"
+                }
+            }
+
             $icon = if ($r.Drift) { 'DRIFT' } else { 'OK' }
             Write-Host "$icon $path : $($r.State)"
             $r
@@ -400,6 +455,7 @@ function Invoke-HveCoreFreshnessCheck {
         [ordered]@{
             LatestTag = $latestTag
             LatestUrl = $latestUrl
+            LatestMainSha = $latestMainSha
             Pin       = $pin
             Files     = $fileResults
         } | ConvertTo-Json -Depth 5 | Set-Content $ResultsFile
@@ -440,7 +496,7 @@ if ($MyInvocation.InvocationName -ne '.') {
         Write-Host "Results File   : $ResultsFile"
         Write-Host "Repo Root      : $resolvedRoot"
         Write-Host 'Derived Files :'
-        $script:DerivedFiles | ForEach-Object { Write-Host "  - $_" }
+        $script:DerivedFiles | ForEach-Object { Write-Host "  - $($_.Path) [$($_.Baseline)]" }
         exit 0
     }
 

--- a/scripts/security/Test-HveCoreFreshness.ps1
+++ b/scripts/security/Test-HveCoreFreshness.ps1
@@ -114,11 +114,15 @@ function Get-HveCoreFileSource {
     }
 
     $content = Get-Content -Path $Path -Raw
-    $pattern = 'Adapted from\s+microsoft/hve-core\s+(scripts/security/\S+\.ps1)\s+as of commit\s+([0-9a-fA-F]{40})'
-    $match = [regex]::Match($content, $pattern)
-    if (-not $match.Success) {
+    $pattern = 'Adapted from\s+microsoft/hve-core\s+(\S+)\s+as of commit\s+([0-9a-fA-F]{40})(?:\.|\s|$)'
+    $sourceMatches = [regex]::Matches($content, $pattern)
+    if ($sourceMatches.Count -eq 0) {
         throw "Could not extract hve-core source revision from $Path"
     }
+    if ($sourceMatches.Count -gt 1) {
+        throw "Found multiple hve-core source revisions in $Path"
+    }
+    $match = $sourceMatches[0]
 
     return [ordered]@{
         Path = $match.Groups[1].Value
@@ -146,8 +150,8 @@ function Select-LatestRelease {
 function Get-DriftState {
     <#
     .SYNOPSIS
-        Classify a derived file's state from its pinned and latest upstream blob SHAs.
-        Returns 'missing-upstream', 'drift', or 'current'.
+        Classify a derived file's state from its baseline and target upstream blob SHAs.
+        Returns 'missing-baseline', 'missing-upstream', 'drift', or 'current'.
     #>
     [CmdletBinding()]
     param(
@@ -157,6 +161,7 @@ function Get-DriftState {
 
     $p = $PinnedUpstreamSha.ToLowerInvariant()
     $l = $LatestUpstreamSha.ToLowerInvariant()
+    if (-not $p) { return 'missing-baseline' }
     if (-not $l) { return 'missing-upstream' }
     if ($p -ne $l) { return 'drift' }
     return 'current'
@@ -200,11 +205,10 @@ function Get-HveCoreFileDrift {
     )
 
     $pinnedUp = Get-HveCoreBlobSha -Repo $Repo -Path $Path -Ref $PinnedRef
-    if (-not $pinnedUp) {
-        throw "Baseline file not found upstream: ${Path}@${PinnedRef}"
-    }
     $latestUp = Get-HveCoreBlobSha -Repo $Repo -Path $Path -Ref $LatestRef
     $state = Get-DriftState -PinnedUpstreamSha $pinnedUp -LatestUpstreamSha $latestUp
+    $pinnedRefUrl = [uri]::EscapeDataString($PinnedRef)
+    $latestRefUrl = [uri]::EscapeDataString($LatestRef)
 
     return [ordered]@{
         Path              = $Path
@@ -212,7 +216,7 @@ function Get-HveCoreFileDrift {
         LatestUpstreamSha = if ($latestUp) { $latestUp } else { '' }
         PinnedRef         = $PinnedRef
         LatestRef         = $LatestRef
-        ComparisonUrl     = "https://github.com/$Repo/compare/$PinnedRef...$LatestRef"
+        ComparisonUrl     = "https://github.com/$Repo/compare/$pinnedRefUrl...$latestRefUrl"
         Drift             = ($state -ne 'current')
         State             = $state
     }
@@ -230,12 +234,33 @@ function Get-HveCoreStateLabel {
 
     switch ($State) {
         'drift'            { return '⚠️ Upstream advanced' }
+        'missing-baseline' { return '❓ Not found at baseline ref' }
         'missing-upstream' { return '❓ Not found at target ref' }
+        'error'            { return '❌ Check failed' }
         default            { return '✅ Current' }
     }
 }
 
-function Get-HveCoreDriftCells {
+function ConvertTo-HveCoreMarkdownText {
+    <#
+    .SYNOPSIS
+        Encodes untrusted text for safe use inside a markdown table or link label.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][AllowEmptyString()][string]$Value
+    )
+
+    return ([System.Net.WebUtility]::HtmlEncode($Value) `
+            -replace '\[', '&#91;' `
+            -replace '\]', '&#93;' `
+            -replace '\(', '&#40;' `
+            -replace '\)', '&#41;' `
+            -replace '\|', '&#124;' `
+            -replace '`', '&#96;')
+}
+
+function Format-HveCoreDriftCells {
     <#
     .SYNOPSIS
         Formats the shared display values for a drift record.
@@ -249,9 +274,25 @@ function Get-HveCoreDriftCells {
     $lSha = if ($File.LatestUpstreamSha) { $File.LatestUpstreamSha.Substring(0, [Math]::Min($script:ShortShaLength, $File.LatestUpstreamSha.Length)) } else { '' }
     $pRef = if ($File.PinnedRef -match $script:FullShaPattern) { $File.PinnedRef.Substring(0, $script:ShortShaLength) } else { $File.PinnedRef }
     $lRef = if ($File.LatestRef -match $script:FullShaPattern) { $File.LatestRef.Substring(0, $script:ShortShaLength) } else { $File.LatestRef }
+    $pRef = ConvertTo-HveCoreMarkdownText -Value $pRef
+    $lRef = ConvertTo-HveCoreMarkdownText -Value $lRef
+
+    $status = Get-HveCoreStateLabel -State $File.State
+    if ($File.State -eq 'error' -and $File.Error) {
+        $message = "$($File.Error)" -replace '[\r\n]+', ' '
+        $message = ConvertTo-HveCoreMarkdownText -Value $message
+        $status = "$status — <code>$message</code>"
+    }
+
+    $baseline = switch ($File.Baseline) {
+        'source-header' { 'Source header' }
+        'release' { 'Release' }
+        default { "$($File.Baseline)" }
+    }
 
     return [ordered]@{
-        Status     = Get-HveCoreStateLabel -State $File.State
+        Baseline   = $baseline
+        Status     = $status
         PinnedSha  = $pSha
         LatestSha  = $lSha
         Comparison = if ($File.ComparisonUrl) { "[$pRef → $lRef]($($File.ComparisonUrl))" } else { '' }
@@ -269,8 +310,8 @@ function Format-HveCoreDriftRow {
         [Parameter(Mandatory)][object]$File
     )
 
-    $cells = Get-HveCoreDriftCells -File $File
-    return "| ``$($File.Path)`` | $($cells.Comparison) | $($cells.PinnedSha) | $($cells.LatestSha) | $($cells.Status) |"
+    $cells = Format-HveCoreDriftCells -File $File
+    return "| ``$($File.Path)`` | $($cells.Baseline) | $($cells.Comparison) | $($cells.PinnedSha) | $($cells.LatestSha) | $($cells.Status) |"
 }
 
 function Format-HveCoreIssueBody {
@@ -287,11 +328,14 @@ function Format-HveCoreIssueBody {
 
     $pin = $Result.Pin
     $files = @($Result.Files)
-    $latestLink = "[$($Result.LatestTag)]($($Result.LatestUrl))"
+    $latestTagText = ConvertTo-HveCoreMarkdownText -Value $Result.LatestTag
+    $latestLink = "[$latestTagText]($($Result.LatestUrl))"
 
     $fileRows = ($files | ForEach-Object { Format-HveCoreDriftRow -File $_ }) -join "`n"
 
     $compareBase = if ($pin.PinnedTag -ne 'unknown') { $pin.PinnedTag } else { $pin.PinnedSha }
+    $compareBase = [uri]::EscapeDataString($compareBase)
+    $latestTagUrl = [uri]::EscapeDataString($Result.LatestTag)
 
     return @"
 ## hve-core Upstream Freshness Report
@@ -302,13 +346,13 @@ Source-header target: ``$($Result.LatestMainSha)``
 
 ### Derived Files
 
-| File | Upstream comparison | Pinned Upstream blob | Latest Upstream blob | Status |
-|------|---------------------|----------------------|----------------------|--------|
+| File | Baseline | Upstream comparison | Baseline upstream blob | Target upstream blob | Status |
+|------|----------|---------------------|------------------------|----------------------|--------|
 $fileRows
 
 ### How to Refresh
 
-Review the upstream changes and port any relevant ones into the locally-adapted copy; do not blindly overwrite (these files carry intentional local adaptations). Each row links to its exact baseline comparison. After refreshing a source-header file, update its ``as of commit`` SHA to the reviewed upstream revision. Release baseline: https://github.com/microsoft/hve-core/compare/$compareBase...$($Result.LatestTag)
+Review the upstream changes and port any relevant ones into the locally-adapted copy; do not blindly overwrite (these files carry intentional local adaptations). Each row links to its exact baseline comparison. After refreshing a source-header file, update its ``as of commit`` SHA to the reviewed upstream revision. Release baseline: https://github.com/microsoft/hve-core/compare/$compareBase...$latestTagUrl
 
 Run ``npm run lint:ps`` and ``npm run test:ps`` after changes.
 
@@ -334,8 +378,8 @@ function Format-HveCoreJobSummary {
     $files = @($Result.Files)
 
     $fileRows = foreach ($f in $files) {
-        $cells = Get-HveCoreDriftCells -File $f
-        "| $($f.Path) | $($cells.Comparison) | $($cells.PinnedSha) | $($cells.LatestSha) | $($cells.Status) |"
+        $cells = Format-HveCoreDriftCells -File $f
+        "| $($f.Path) | $($cells.Baseline) | $($cells.Comparison) | $($cells.PinnedSha) | $($cells.LatestSha) | $($cells.Status) |"
     }
 
     return @"
@@ -345,8 +389,8 @@ Latest release: $($Result.LatestTag)
 Release-file baseline: $($pin.PinnedTag)
 Source-header target: $($Result.LatestMainSha)
 
-| Derived File | Upstream comparison | Pinned blob | Latest blob | Status |
-|--------------|---------------------|-------------|-------------|--------|
+| Derived File | Baseline | Upstream comparison | Baseline blob | Target blob | Status |
+|--------------|----------|---------------------|---------------|-------------|--------|
 $($fileRows -join "`n")
 "@
 }
@@ -498,7 +542,24 @@ function Invoke-HveCoreFreshnessCheck {
 
         $fileResults = foreach ($file in $script:DerivedFiles) {
             $path = $file.Path
-            $r = Get-HveCoreFileDriftForBaseline -File $file -PinnedReleaseSha $pinRef.Sha -LatestReleaseTag $latestTag -LatestMainSha $latestMainSha
+            try {
+                $r = Get-HveCoreFileDriftForBaseline -File $file -PinnedReleaseSha $pinRef.Sha -LatestReleaseTag $latestTag -LatestMainSha $latestMainSha
+                $r['Baseline'] = $file.Baseline
+            }
+            catch {
+                $r = [ordered]@{
+                    Path              = $path
+                    Baseline          = $file.Baseline
+                    PinnedUpstreamSha = ''
+                    LatestUpstreamSha = ''
+                    PinnedRef         = ''
+                    LatestRef         = ''
+                    ComparisonUrl     = ''
+                    Drift             = $true
+                    State             = 'error'
+                    Error             = $_.Exception.Message
+                }
+            }
 
             $icon = if ($r.Drift) { 'DRIFT' } else { 'OK' }
             Write-Host "$icon $path : $($r.State)"

--- a/scripts/security/Test-HveCoreFreshness.ps1
+++ b/scripts/security/Test-HveCoreFreshness.ps1
@@ -5,7 +5,7 @@
 
 <#
 .SYNOPSIS
-    Checks hve-core-derived files against the latest upstream release.
+    Checks hve-core-derived files against their reviewed upstream baselines.
 
 .DESCRIPTION
     Compares each hve-core-derived file's upstream blob SHA at its reviewed source
@@ -54,7 +54,11 @@ $script:UpstreamRepo = 'microsoft/hve-core'
 $script:SetupWorkflow = '.github/workflows/copilot-setup-steps.yml'
 $script:IssueMarker = 'automation:hve-core-freshness'
 $script:IssueSearch = "in:body $script:IssueMarker is:open"
+$script:FullShaPattern = '^[0-9a-fA-F]{40}$'
+$script:ShortShaLength = 7
 
+# Release entries use the RPI pin; source-header entries require the exact header
+# "Adapted from microsoft/hve-core <path> as of commit <40-hex SHA>" and track main.
 # Blob-to-blob comparisons avoid false drift from intentional local adaptations.
 $script:DerivedFiles = @(
     [ordered]@{ Path = 'scripts/security/Modules/SecurityHelpers.psm1'; Baseline = 'release' }
@@ -111,13 +115,14 @@ function Get-HveCoreFileSource {
 
     $content = Get-Content -Path $Path -Raw
     $pattern = 'Adapted from\s+microsoft/hve-core\s+(scripts/security/\S+\.ps1)\s+as of commit\s+([0-9a-fA-F]{40})'
-    if ($content -notmatch $pattern) {
+    $match = [regex]::Match($content, $pattern)
+    if (-not $match.Success) {
         throw "Could not extract hve-core source revision from $Path"
     }
 
     return [ordered]@{
-        Path = $Matches[1]
-        Sha  = $Matches[2].ToLowerInvariant()
+        Path = $match.Groups[1].Value
+        Sha  = $match.Groups[2].Value.ToLowerInvariant()
     }
 }
 
@@ -182,8 +187,8 @@ function Get-HveCoreBlobSha {
 function Get-HveCoreFileDrift {
     <#
     .SYNOPSIS
-        Compares a single upstream path's blob SHA at the pinned ref against the latest
-        release and returns a drift record. Local copies are never consulted, so local
+        Compares a single upstream path's blob SHA at its baseline ref against its target
+        ref and returns a drift record. Local copies are never consulted, so local
         adaptations cannot cause false drift.
     #>
     [CmdletBinding()]
@@ -195,6 +200,9 @@ function Get-HveCoreFileDrift {
     )
 
     $pinnedUp = Get-HveCoreBlobSha -Repo $Repo -Path $Path -Ref $PinnedRef
+    if (-not $pinnedUp) {
+        throw "Baseline file not found upstream: ${Path}@${PinnedRef}"
+    }
     $latestUp = Get-HveCoreBlobSha -Repo $Repo -Path $Path -Ref $LatestRef
     $state = Get-DriftState -PinnedUpstreamSha $pinnedUp -LatestUpstreamSha $latestUp
 
@@ -222,29 +230,47 @@ function Get-HveCoreStateLabel {
 
     switch ($State) {
         'drift'            { return '⚠️ Upstream advanced' }
-        'missing-upstream' { return '❓ Not found at latest release' }
+        'missing-upstream' { return '❓ Not found at target ref' }
         default            { return '✅ Current' }
     }
 }
 
-function Format-HveCoreDriftRow {
+function Get-HveCoreDriftCells {
     <#
     .SYNOPSIS
-        Formats one drift record as a markdown table row: path, short pinned/latest blob
-        SHAs, and a status label.
+        Formats the shared display values for a drift record.
     #>
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)][object]$File
     )
 
-    $status = Get-HveCoreStateLabel -State $File.State
-    $pSha = if ($File.PinnedUpstreamSha) { $File.PinnedUpstreamSha.Substring(0, [Math]::Min(7, $File.PinnedUpstreamSha.Length)) } else { '' }
-    $lSha = if ($File.LatestUpstreamSha) { $File.LatestUpstreamSha.Substring(0, [Math]::Min(7, $File.LatestUpstreamSha.Length)) } else { '' }
-    $pRef = if ($File.PinnedRef -match '^[0-9a-fA-F]{40}$') { $File.PinnedRef.Substring(0, 7) } else { $File.PinnedRef }
-    $lRef = if ($File.LatestRef -match '^[0-9a-fA-F]{40}$') { $File.LatestRef.Substring(0, 7) } else { $File.LatestRef }
-    $comparison = if ($File.ComparisonUrl) { "[$pRef → $lRef]($($File.ComparisonUrl))" } else { '' }
-    return "| ``$($File.Path)`` | $comparison | $pSha | $lSha | $status |"
+    $pSha = if ($File.PinnedUpstreamSha) { $File.PinnedUpstreamSha.Substring(0, [Math]::Min($script:ShortShaLength, $File.PinnedUpstreamSha.Length)) } else { '' }
+    $lSha = if ($File.LatestUpstreamSha) { $File.LatestUpstreamSha.Substring(0, [Math]::Min($script:ShortShaLength, $File.LatestUpstreamSha.Length)) } else { '' }
+    $pRef = if ($File.PinnedRef -match $script:FullShaPattern) { $File.PinnedRef.Substring(0, $script:ShortShaLength) } else { $File.PinnedRef }
+    $lRef = if ($File.LatestRef -match $script:FullShaPattern) { $File.LatestRef.Substring(0, $script:ShortShaLength) } else { $File.LatestRef }
+
+    return [ordered]@{
+        Status     = Get-HveCoreStateLabel -State $File.State
+        PinnedSha  = $pSha
+        LatestSha  = $lSha
+        Comparison = if ($File.ComparisonUrl) { "[$pRef → $lRef]($($File.ComparisonUrl))" } else { '' }
+    }
+}
+
+function Format-HveCoreDriftRow {
+    <#
+    .SYNOPSIS
+        Formats one drift record as a markdown table row with its upstream comparison,
+        short baseline/target blob SHAs, and status label.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][object]$File
+    )
+
+    $cells = Get-HveCoreDriftCells -File $File
+    return "| ``$($File.Path)`` | $($cells.Comparison) | $($cells.PinnedSha) | $($cells.LatestSha) | $($cells.Status) |"
 }
 
 function Format-HveCoreIssueBody {
@@ -271,7 +297,8 @@ function Format-HveCoreIssueBody {
 ## hve-core Upstream Freshness Report
 
 Latest reviewed hve-core release: $latestLink
-Drift baseline: ``$($pin.PinnedTag)`` (``UPSTREAM_REF`` in ``$($pin.File)``)
+Release-file baseline: ``$($pin.PinnedTag)`` (``UPSTREAM_REF`` in ``$($pin.File)``)
+Source-header target: ``$($Result.LatestMainSha)``
 
 ### Derived Files
 
@@ -281,7 +308,7 @@ $fileRows
 
 ### How to Refresh
 
-Review the upstream changes and port any relevant ones into the locally-adapted copy; do not blindly overwrite (these files carry intentional local adaptations). Each row links to its exact baseline comparison. Release baseline: https://github.com/microsoft/hve-core/compare/$compareBase...$($Result.LatestTag)
+Review the upstream changes and port any relevant ones into the locally-adapted copy; do not blindly overwrite (these files carry intentional local adaptations). Each row links to its exact baseline comparison. After refreshing a source-header file, update its ``as of commit`` SHA to the reviewed upstream revision. Release baseline: https://github.com/microsoft/hve-core/compare/$compareBase...$($Result.LatestTag)
 
 Run ``npm run lint:ps`` and ``npm run test:ps`` after changes.
 
@@ -307,23 +334,16 @@ function Format-HveCoreJobSummary {
     $files = @($Result.Files)
 
     $fileRows = foreach ($f in $files) {
-        $fStatus = Get-HveCoreStateLabel -State $f.State
-        $pSha = if ($f.PinnedUpstreamSha) { $f.PinnedUpstreamSha.Substring(0, [Math]::Min(7, $f.PinnedUpstreamSha.Length)) } else { '' }
-        $lSha = if ($f.LatestUpstreamSha) { $f.LatestUpstreamSha.Substring(0, [Math]::Min(7, $f.LatestUpstreamSha.Length)) } else { '' }
-        $pRef = if ($f.PinnedRef -match '^[0-9a-fA-F]{40}$') { $f.PinnedRef.Substring(0, 7) } else { $f.PinnedRef }
-        $lRef = if ($f.LatestRef -match '^[0-9a-fA-F]{40}$') { $f.LatestRef.Substring(0, 7) } else { $f.LatestRef }
-        $comparison = if ($f.ComparisonUrl) { "[$pRef → $lRef]($($f.ComparisonUrl))" } else { '' }
-        "| $($f.Path) | $comparison | $pSha | $lSha | $fStatus |"
+        $cells = Get-HveCoreDriftCells -File $f
+        "| $($f.Path) | $($cells.Comparison) | $($cells.PinnedSha) | $($cells.LatestSha) | $($cells.Status) |"
     }
-
-    $mainSummary = if ($Result.LatestMainSha) { "`nUpstream main: $($Result.LatestMainSha)" } else { '' }
 
     return @"
 ## hve-core Upstream Freshness
 
 Latest release: $($Result.LatestTag)
-Drift baseline: $($pin.PinnedTag)
-$mainSummary
+Release-file baseline: $($pin.PinnedTag)
+Source-header target: $($Result.LatestMainSha)
 
 | Derived File | Upstream comparison | Pinned blob | Latest blob | Status |
 |--------------|---------------------|-------------|-------------|--------|
@@ -379,6 +399,63 @@ function Resolve-HveCoreCommitSha {
     return ("$sha").Trim()
 }
 
+function Assert-HveCoreCommitOnMain {
+    <#
+    .SYNOPSIS
+        Verifies that a recorded source commit is an ancestor of upstream main.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$Repo,
+        [Parameter(Mandatory)][string]$CommitSha,
+        [Parameter(Mandatory)][string]$MainSha
+    )
+
+    $mergeBase = gh api "repos/$Repo/compare/$CommitSha...$MainSha" --jq '.merge_base_commit.sha' 2>&1
+    if ($LASTEXITCODE -ne 0 -or -not $mergeBase) {
+        throw "Could not verify source commit '$CommitSha' against upstream main in ${Repo}: $mergeBase"
+    }
+    if (("$mergeBase").Trim() -ne $CommitSha) {
+        throw "Recorded source commit '$CommitSha' is not an ancestor of upstream main '$MainSha'"
+    }
+}
+
+function Get-HveCoreFileDriftForBaseline {
+    <#
+    .SYNOPSIS
+        Resolves one derived-file baseline and returns its upstream drift record.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][object]$File,
+        [Parameter(Mandatory)][string]$PinnedReleaseSha,
+        [Parameter(Mandatory)][string]$LatestReleaseTag,
+        [Parameter(Mandatory)][string]$LatestMainSha
+    )
+
+    $path = $File.Path
+    if (-not (Test-Path $path)) {
+        throw "Derived file not found locally: $path"
+    }
+
+    switch ($File.Baseline) {
+        'source-header' {
+            $source = Get-HveCoreFileSource -Path $path
+            if ($source.Path -ne $path) {
+                throw "Vendored path '$path' must match its recorded hve-core source path, but the header records '$($source.Path)'"
+            }
+            Assert-HveCoreCommitOnMain -Repo $script:UpstreamRepo -CommitSha $source.Sha -MainSha $LatestMainSha
+            return Get-HveCoreFileDrift -Repo $script:UpstreamRepo -Path $source.Path -PinnedRef $source.Sha -LatestRef $LatestMainSha
+        }
+        'release' {
+            return Get-HveCoreFileDrift -Repo $script:UpstreamRepo -Path $path -PinnedRef $PinnedReleaseSha -LatestRef $LatestReleaseTag
+        }
+        default {
+            throw "Unsupported hve-core baseline '$($File.Baseline)' for $path"
+        }
+    }
+}
+
 # ============================================================
 # Orchestration
 # ============================================================
@@ -421,26 +498,7 @@ function Invoke-HveCoreFreshnessCheck {
 
         $fileResults = foreach ($file in $script:DerivedFiles) {
             $path = $file.Path
-            if (-not (Test-Path $path)) {
-                throw "Derived file not found locally: $path"
-            }
-
-            switch ($file.Baseline) {
-                'source-header' {
-                    $source = Get-HveCoreFileSource -Path $path
-                    if ($source.Path -ne $path) {
-                        throw "Recorded hve-core source path for $path is $($source.Path)"
-                    }
-                    $null = Resolve-HveCoreCommitSha -Repo $script:UpstreamRepo -Ref $source.Sha
-                    $r = Get-HveCoreFileDrift -Repo $script:UpstreamRepo -Path $source.Path -PinnedRef $source.Sha -LatestRef 'main'
-                }
-                'release' {
-                    $r = Get-HveCoreFileDrift -Repo $script:UpstreamRepo -Path $path -PinnedRef $pinRef.Sha -LatestRef $latestTag
-                }
-                default {
-                    throw "Unsupported hve-core baseline '$($file.Baseline)' for $path"
-                }
-            }
+            $r = Get-HveCoreFileDriftForBaseline -File $file -PinnedReleaseSha $pinRef.Sha -LatestReleaseTag $latestTag -LatestMainSha $latestMainSha
 
             $icon = if ($r.Drift) { 'DRIFT' } else { 'OK' }
             Write-Host "$icon $path : $($r.State)"
@@ -453,11 +511,11 @@ function Invoke-HveCoreFreshnessCheck {
         Write-Host "`nStale: $driftCount / $($fileResults.Count) derived files drifted"
 
         [ordered]@{
-            LatestTag = $latestTag
-            LatestUrl = $latestUrl
+            LatestTag     = $latestTag
+            LatestUrl     = $latestUrl
             LatestMainSha = $latestMainSha
-            Pin       = $pin
-            Files     = $fileResults
+            Pin           = $pin
+            Files         = $fileResults
         } | ConvertTo-Json -Depth 5 | Set-Content $ResultsFile
 
         return [ordered]@{ StaleCount = $staleCount; LatestTag = $latestTag }

--- a/scripts/security/Test-HveCoreFreshness.ps1
+++ b/scripts/security/Test-HveCoreFreshness.ps1
@@ -57,6 +57,10 @@ $script:IssueSearch = "in:body $script:IssueMarker is:open"
 $script:FullShaPattern = '^[0-9a-fA-F]{40}$'
 $script:ShortShaLength = 7
 
+class HveCoreFileValidationException : System.Exception {
+    HveCoreFileValidationException([string]$message) : base($message) {}
+}
+
 # Release entries use the RPI pin; source-header entries require the exact header
 # "Adapted from microsoft/hve-core <path> as of commit <40-hex SHA>" and track main.
 # Blob-to-blob comparisons avoid false drift from intentional local adaptations.
@@ -110,17 +114,17 @@ function Get-HveCoreFileSource {
     )
 
     if (-not (Test-Path $Path)) {
-        throw "Derived file not found locally: $Path"
+        throw [HveCoreFileValidationException]::new("Derived file not found locally: $Path")
     }
 
     $content = Get-Content -Path $Path -Raw
     $pattern = 'Adapted from\s+microsoft/hve-core\s+(\S+)\s+as of commit\s+([0-9a-fA-F]{40})(?:\.|\s|$)'
     $sourceMatches = [regex]::Matches($content, $pattern)
     if ($sourceMatches.Count -eq 0) {
-        throw "Could not extract hve-core source revision from $Path"
+        throw [HveCoreFileValidationException]::new("Could not extract hve-core source revision from $Path")
     }
     if ($sourceMatches.Count -gt 1) {
-        throw "Found multiple hve-core source revisions in $Path"
+        throw [HveCoreFileValidationException]::new("Found multiple hve-core source revisions in $Path")
     }
     $match = $sourceMatches[0]
 
@@ -460,7 +464,9 @@ function Assert-HveCoreCommitOnMain {
         throw "Could not verify source commit '$CommitSha' against upstream main in ${Repo}: $mergeBase"
     }
     if (("$mergeBase").Trim() -ne $CommitSha) {
-        throw "Recorded source commit '$CommitSha' is not an ancestor of upstream main '$MainSha'"
+        throw [HveCoreFileValidationException]::new(
+            "Recorded source commit '$CommitSha' is not an ancestor of upstream main '$MainSha'"
+        )
     }
 }
 
@@ -479,14 +485,16 @@ function Get-HveCoreFileDriftForBaseline {
 
     $path = $File.Path
     if (-not (Test-Path $path)) {
-        throw "Derived file not found locally: $path"
+        throw [HveCoreFileValidationException]::new("Derived file not found locally: $path")
     }
 
     switch ($File.Baseline) {
         'source-header' {
             $source = Get-HveCoreFileSource -Path $path
             if ($source.Path -ne $path) {
-                throw "Vendored path '$path' must match its recorded hve-core source path, but the header records '$($source.Path)'"
+                throw [HveCoreFileValidationException]::new(
+                    "Vendored path '$path' must match its recorded hve-core source path, but the header records '$($source.Path)'"
+                )
             }
             Assert-HveCoreCommitOnMain -Repo $script:UpstreamRepo -CommitSha $source.Sha -MainSha $LatestMainSha
             return Get-HveCoreFileDrift -Repo $script:UpstreamRepo -Path $source.Path -PinnedRef $source.Sha -LatestRef $LatestMainSha
@@ -495,7 +503,7 @@ function Get-HveCoreFileDriftForBaseline {
             return Get-HveCoreFileDrift -Repo $script:UpstreamRepo -Path $path -PinnedRef $PinnedReleaseSha -LatestRef $LatestReleaseTag
         }
         default {
-            throw "Unsupported hve-core baseline '$($File.Baseline)' for $path"
+            throw [HveCoreFileValidationException]::new("Unsupported hve-core baseline '$($File.Baseline)' for $path")
         }
     }
 }
@@ -546,7 +554,7 @@ function Invoke-HveCoreFreshnessCheck {
                 $r = Get-HveCoreFileDriftForBaseline -File $file -PinnedReleaseSha $pinRef.Sha -LatestReleaseTag $latestTag -LatestMainSha $latestMainSha
                 $r['Baseline'] = $file.Baseline
             }
-            catch {
+            catch [HveCoreFileValidationException] {
                 $r = [ordered]@{
                     Path              = $path
                     Baseline          = $file.Baseline

--- a/scripts/security/Test-HveCoreFreshness.ps1
+++ b/scripts/security/Test-HveCoreFreshness.ps1
@@ -118,8 +118,13 @@ function Get-HveCoreFileSource {
     }
 
     $content = Get-Content -Path $Path -Raw
+    $headerEnd = $content.IndexOf('#>')
+    if ($headerEnd -lt 0) {
+        throw [HveCoreFileValidationException]::new("Could not find a comment-based help header in $Path")
+    }
+    $header = $content.Substring(0, $headerEnd + 2)
     $pattern = 'Adapted from\s+microsoft/hve-core\s+(\S+)\s+as of commit\s+([0-9a-fA-F]{40})(?:\.|\s|$)'
-    $sourceMatches = [regex]::Matches($content, $pattern)
+    $sourceMatches = [regex]::Matches($header, $pattern)
     if ($sourceMatches.Count -eq 0) {
         throw [HveCoreFileValidationException]::new("Could not extract hve-core source revision from $Path")
     }
@@ -155,19 +160,20 @@ function Get-DriftState {
     <#
     .SYNOPSIS
         Classify a derived file's state from its baseline and target upstream blob SHAs.
-        Returns 'missing-baseline', 'missing-upstream', 'drift', or 'current'.
+        Returns 'missing-both', 'missing-baseline', 'missing-target', 'drift', or 'current'.
     #>
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory)][AllowEmptyString()][string]$PinnedUpstreamSha,
-        [Parameter(Mandatory = $false)][AllowEmptyString()][string]$LatestUpstreamSha
+        [Parameter(Mandatory)][AllowEmptyString()][string]$BaselineUpstreamSha,
+        [Parameter(Mandatory = $false)][AllowEmptyString()][string]$TargetUpstreamSha
     )
 
-    $p = $PinnedUpstreamSha.ToLowerInvariant()
-    $l = $LatestUpstreamSha.ToLowerInvariant()
-    if (-not $p) { return 'missing-baseline' }
-    if (-not $l) { return 'missing-upstream' }
-    if ($p -ne $l) { return 'drift' }
+    $baseline = $BaselineUpstreamSha.ToLowerInvariant()
+    $target = $TargetUpstreamSha.ToLowerInvariant()
+    if (-not $baseline -and -not $target) { return 'missing-both' }
+    if (-not $baseline) { return 'missing-baseline' }
+    if (-not $target) { return 'missing-target' }
+    if ($baseline -ne $target) { return 'drift' }
     return 'current'
 }
 
@@ -183,10 +189,10 @@ function Get-HveCoreBlobSha {
         [Parameter(Mandatory)][string]$Ref
     )
 
-    $out = gh api "repos/$Repo/contents/$Path`?ref=$Ref" --jq '.sha' 2>&1
+    $out = gh api --method GET "repos/$Repo/contents/$Path" -f "ref=$Ref" --jq '.sha' 2>&1
     if ($LASTEXITCODE -eq 0) { return ("$out").Trim() }
 
-    # A genuine 404 means the file is absent at that ref (a real 'missing-upstream').
+    # A genuine 404 means the file is absent at that ref.
     # Any other failure (transient, auth, rate limit) must fail loudly rather than
     # masquerade as drift and file a false tracking issue.
     if ("$out" -match 'HTTP 404|Not Found') { return '' }
@@ -204,25 +210,25 @@ function Get-HveCoreFileDrift {
     param(
         [Parameter(Mandatory)][string]$Repo,
         [Parameter(Mandatory)][string]$Path,
-        [Parameter(Mandatory)][string]$PinnedRef,
-        [Parameter(Mandatory)][string]$LatestRef
+        [Parameter(Mandatory)][string]$BaselineRef,
+        [Parameter(Mandatory)][string]$TargetRef
     )
 
-    $pinnedUp = Get-HveCoreBlobSha -Repo $Repo -Path $Path -Ref $PinnedRef
-    $latestUp = Get-HveCoreBlobSha -Repo $Repo -Path $Path -Ref $LatestRef
-    $state = Get-DriftState -PinnedUpstreamSha $pinnedUp -LatestUpstreamSha $latestUp
-    $pinnedRefUrl = [uri]::EscapeDataString($PinnedRef)
-    $latestRefUrl = [uri]::EscapeDataString($LatestRef)
+    $baselineUpstreamSha = Get-HveCoreBlobSha -Repo $Repo -Path $Path -Ref $BaselineRef
+    $targetUpstreamSha = Get-HveCoreBlobSha -Repo $Repo -Path $Path -Ref $TargetRef
+    $state = Get-DriftState -BaselineUpstreamSha $baselineUpstreamSha -TargetUpstreamSha $targetUpstreamSha
+    $baselineRefUrl = [uri]::EscapeDataString($BaselineRef)
+    $targetRefUrl = [uri]::EscapeDataString($TargetRef)
 
     return [ordered]@{
-        Path              = $Path
-        PinnedUpstreamSha = if ($pinnedUp) { $pinnedUp } else { '' }
-        LatestUpstreamSha = if ($latestUp) { $latestUp } else { '' }
-        PinnedRef         = $PinnedRef
-        LatestRef         = $LatestRef
-        ComparisonUrl     = "https://github.com/$Repo/compare/$pinnedRefUrl...$latestRefUrl"
-        Drift             = ($state -ne 'current')
-        State             = $state
+        Path                = $Path
+        BaselineUpstreamSha = if ($baselineUpstreamSha) { $baselineUpstreamSha } else { '' }
+        TargetUpstreamSha   = if ($targetUpstreamSha) { $targetUpstreamSha } else { '' }
+        BaselineRef         = $BaselineRef
+        TargetRef           = $TargetRef
+        ComparisonUrl       = "https://github.com/$Repo/compare/$baselineRefUrl...$targetRefUrl"
+        Drift               = ($state -ne 'current')
+        State               = $state
     }
 }
 
@@ -238,8 +244,9 @@ function Get-HveCoreStateLabel {
 
     switch ($State) {
         'drift'            { return '⚠️ Upstream advanced' }
+        'missing-both'     { return '❓ Not found at either ref' }
         'missing-baseline' { return '❓ Not found at baseline ref' }
-        'missing-upstream' { return '❓ Not found at target ref' }
+        'missing-target'   { return '❓ Not found at target ref' }
         'error'            { return '❌ Check failed' }
         default            { return '✅ Current' }
     }
@@ -274,12 +281,12 @@ function Format-HveCoreDriftCells {
         [Parameter(Mandatory)][object]$File
     )
 
-    $pSha = if ($File.PinnedUpstreamSha) { $File.PinnedUpstreamSha.Substring(0, [Math]::Min($script:ShortShaLength, $File.PinnedUpstreamSha.Length)) } else { '' }
-    $lSha = if ($File.LatestUpstreamSha) { $File.LatestUpstreamSha.Substring(0, [Math]::Min($script:ShortShaLength, $File.LatestUpstreamSha.Length)) } else { '' }
-    $pRef = if ($File.PinnedRef -match $script:FullShaPattern) { $File.PinnedRef.Substring(0, $script:ShortShaLength) } else { $File.PinnedRef }
-    $lRef = if ($File.LatestRef -match $script:FullShaPattern) { $File.LatestRef.Substring(0, $script:ShortShaLength) } else { $File.LatestRef }
-    $pRef = ConvertTo-HveCoreMarkdownText -Value $pRef
-    $lRef = ConvertTo-HveCoreMarkdownText -Value $lRef
+    $baselineSha = if ($File.BaselineUpstreamSha) { $File.BaselineUpstreamSha.Substring(0, [Math]::Min($script:ShortShaLength, $File.BaselineUpstreamSha.Length)) } else { '' }
+    $targetSha = if ($File.TargetUpstreamSha) { $File.TargetUpstreamSha.Substring(0, [Math]::Min($script:ShortShaLength, $File.TargetUpstreamSha.Length)) } else { '' }
+    $baselineRef = if ($File.BaselineRef -match $script:FullShaPattern) { $File.BaselineRef.Substring(0, $script:ShortShaLength) } else { $File.BaselineRef }
+    $targetRef = if ($File.TargetRef -match $script:FullShaPattern) { $File.TargetRef.Substring(0, $script:ShortShaLength) } else { $File.TargetRef }
+    $baselineRef = ConvertTo-HveCoreMarkdownText -Value $baselineRef
+    $targetRef = ConvertTo-HveCoreMarkdownText -Value $targetRef
 
     $status = Get-HveCoreStateLabel -State $File.State
     if ($File.State -eq 'error' -and $File.Error) {
@@ -291,15 +298,18 @@ function Format-HveCoreDriftCells {
     $baseline = switch ($File.Baseline) {
         'source-header' { 'Source header' }
         'release' { 'Release' }
-        default { "$($File.Baseline)" }
+        default {
+            $baselineText = if ($File.Baseline) { "$($File.Baseline)" } else { 'unknown' }
+            ConvertTo-HveCoreMarkdownText -Value $baselineText
+        }
     }
 
     return [ordered]@{
         Baseline   = $baseline
         Status     = $status
-        PinnedSha  = $pSha
-        LatestSha  = $lSha
-        Comparison = if ($File.ComparisonUrl) { "[$pRef → $lRef]($($File.ComparisonUrl))" } else { '' }
+        BaselineSha = $baselineSha
+        TargetSha   = $targetSha
+        Comparison = if ($File.ComparisonUrl) { "[$baselineRef → $targetRef]($($File.ComparisonUrl))" } else { '' }
     }
 }
 
@@ -315,7 +325,22 @@ function Format-HveCoreDriftRow {
     )
 
     $cells = Format-HveCoreDriftCells -File $File
-    return "| ``$($File.Path)`` | $($cells.Baseline) | $($cells.Comparison) | $($cells.PinnedSha) | $($cells.LatestSha) | $($cells.Status) |"
+    return "| ``$($File.Path)`` | $($cells.Baseline) | $($cells.Comparison) | $($cells.BaselineSha) | $($cells.TargetSha) | $($cells.Status) |"
+}
+
+function Get-HveCoreTrustedReleaseUrl {
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$Value
+    )
+
+    $uri = $null
+    if (-not [uri]::TryCreate($Value, [UriKind]::Absolute, [ref]$uri) -or
+        $uri.Scheme -ne 'https' -or
+        $uri.Host -ne 'github.com') {
+        throw "Unexpected hve-core release URL: $Value"
+    }
+    return $uri.AbsoluteUri
 }
 
 function Format-HveCoreIssueBody {
@@ -333,7 +358,8 @@ function Format-HveCoreIssueBody {
     $pin = $Result.Pin
     $files = @($Result.Files)
     $latestTagText = ConvertTo-HveCoreMarkdownText -Value $Result.LatestTag
-    $latestLink = "[$latestTagText]($($Result.LatestUrl))"
+    $latestUrl = Get-HveCoreTrustedReleaseUrl -Value $Result.LatestUrl
+    $latestLink = "[$latestTagText]($latestUrl)"
 
     $fileRows = ($files | ForEach-Object { Format-HveCoreDriftRow -File $_ }) -join "`n"
 
@@ -347,6 +373,7 @@ function Format-HveCoreIssueBody {
 Latest reviewed hve-core release: $latestLink
 Release-file baseline: ``$($pin.PinnedTag)`` (``UPSTREAM_REF`` in ``$($pin.File)``)
 Source-header target: ``$($Result.LatestMainSha)``
+Action required: $($Result.DriftCount) drifted, $($Result.ErrorCount) check errors
 
 ### Derived Files
 
@@ -383,7 +410,7 @@ function Format-HveCoreJobSummary {
 
     $fileRows = foreach ($f in $files) {
         $cells = Format-HveCoreDriftCells -File $f
-        "| $($f.Path) | $($cells.Baseline) | $($cells.Comparison) | $($cells.PinnedSha) | $($cells.LatestSha) | $($cells.Status) |"
+        "| $($f.Path) | $($cells.Baseline) | $($cells.Comparison) | $($cells.BaselineSha) | $($cells.TargetSha) | $($cells.Status) |"
     }
 
     return @"
@@ -392,6 +419,7 @@ function Format-HveCoreJobSummary {
 Latest release: $($Result.LatestTag)
 Release-file baseline: $($pin.PinnedTag)
 Source-header target: $($Result.LatestMainSha)
+Action required: $($Result.DriftCount) drifted, $($Result.ErrorCount) check errors
 
 | Derived File | Baseline | Upstream comparison | Baseline blob | Target blob | Status |
 |--------------|----------|---------------------|---------------|-------------|--------|
@@ -440,7 +468,8 @@ function Resolve-HveCoreCommitSha {
         [Parameter(Mandatory)][string]$Ref
     )
 
-    $sha = gh api "repos/$Repo/commits/$Ref" --jq '.sha' 2>&1
+    $encodedRef = [uri]::EscapeDataString($Ref)
+    $sha = gh api "repos/$Repo/commits/$encodedRef" --jq '.sha' 2>&1
     if ($LASTEXITCODE -ne 0 -or -not $sha) {
         throw "Could not resolve ref '$Ref' in ${Repo}: $sha"
     }
@@ -451,6 +480,9 @@ function Assert-HveCoreCommitOnMain {
     <#
     .SYNOPSIS
         Verifies that a recorded source commit is an ancestor of upstream main.
+    .DESCRIPTION
+        Throws HveCoreFileValidationException for an invalid recorded commit.
+        Upstream API, authentication, and transport failures remain fatal.
     #>
     [CmdletBinding()]
     param(
@@ -461,6 +493,11 @@ function Assert-HveCoreCommitOnMain {
 
     $mergeBase = gh api "repos/$Repo/compare/$CommitSha...$MainSha" --jq '.merge_base_commit.sha' 2>&1
     if ($LASTEXITCODE -ne 0 -or -not $mergeBase) {
+        if ("$mergeBase" -match 'HTTP 404|Not Found|No common ancestor') {
+            throw [HveCoreFileValidationException]::new(
+                "Recorded source commit '$CommitSha' could not be compared with upstream main '$MainSha'"
+            )
+        }
         throw "Could not verify source commit '$CommitSha' against upstream main in ${Repo}: $mergeBase"
     }
     if (("$mergeBase").Trim() -ne $CommitSha) {
@@ -497,10 +534,10 @@ function Get-HveCoreFileDriftForBaseline {
                 )
             }
             Assert-HveCoreCommitOnMain -Repo $script:UpstreamRepo -CommitSha $source.Sha -MainSha $LatestMainSha
-            return Get-HveCoreFileDrift -Repo $script:UpstreamRepo -Path $source.Path -PinnedRef $source.Sha -LatestRef $LatestMainSha
+            return Get-HveCoreFileDrift -Repo $script:UpstreamRepo -Path $source.Path -BaselineRef $source.Sha -TargetRef $LatestMainSha
         }
         'release' {
-            return Get-HveCoreFileDrift -Repo $script:UpstreamRepo -Path $path -PinnedRef $PinnedReleaseSha -LatestRef $LatestReleaseTag
+            return Get-HveCoreFileDrift -Repo $script:UpstreamRepo -Path $path -BaselineRef $PinnedReleaseSha -TargetRef $LatestReleaseTag
         }
         default {
             throw [HveCoreFileValidationException]::new("Unsupported hve-core baseline '$($File.Baseline)' for $path")
@@ -556,16 +593,16 @@ function Invoke-HveCoreFreshnessCheck {
             }
             catch [HveCoreFileValidationException] {
                 $r = [ordered]@{
-                    Path              = $path
-                    Baseline          = $file.Baseline
-                    PinnedUpstreamSha = ''
-                    LatestUpstreamSha = ''
-                    PinnedRef         = ''
-                    LatestRef         = ''
-                    ComparisonUrl     = ''
-                    Drift             = $true
-                    State             = 'error'
-                    Error             = $_.Exception.Message
+                    Path                = $path
+                    Baseline            = $file.Baseline
+                    BaselineUpstreamSha = ''
+                    TargetUpstreamSha   = ''
+                    BaselineRef         = ''
+                    TargetRef           = ''
+                    ComparisonUrl       = ''
+                    Drift               = $false
+                    State               = 'error'
+                    Error               = $_.Exception.Message
                 }
             }
 
@@ -576,18 +613,26 @@ function Invoke-HveCoreFreshnessCheck {
         $fileResults = @($fileResults)
 
         $driftCount = @($fileResults | Where-Object { $_.Drift }).Count
-        $staleCount = $driftCount
-        Write-Host "`nStale: $driftCount / $($fileResults.Count) derived files drifted"
+        $errorCount = @($fileResults | Where-Object { $_.State -eq 'error' }).Count
+        $attentionCount = $driftCount + $errorCount
+        Write-Host "`nAction required: $driftCount drifted, $errorCount check errors"
 
         [ordered]@{
             LatestTag     = $latestTag
             LatestUrl     = $latestUrl
             LatestMainSha = $latestMainSha
+            DriftCount    = $driftCount
+            ErrorCount    = $errorCount
             Pin           = $pin
             Files         = $fileResults
         } | ConvertTo-Json -Depth 5 | Set-Content $ResultsFile
 
-        return [ordered]@{ StaleCount = $staleCount; LatestTag = $latestTag }
+        return [ordered]@{
+            AttentionCount = $attentionCount
+            DriftCount     = $driftCount
+            ErrorCount     = $errorCount
+            LatestTag      = $latestTag
+        }
     }
     finally {
         Pop-Location
@@ -637,7 +682,9 @@ if ($MyInvocation.InvocationName -ne '.') {
     try {
         $outcome = Invoke-HveCoreFreshnessCheck -RepoRoot $resolvedRoot -ResultsFile $ResultsFile
         if ($env:GITHUB_OUTPUT) {
-            "stale-count=$($outcome.StaleCount)" >> $env:GITHUB_OUTPUT
+            "attention-count=$($outcome.AttentionCount)" >> $env:GITHUB_OUTPUT
+            "drift-count=$($outcome.DriftCount)" >> $env:GITHUB_OUTPUT
+            "error-count=$($outcome.ErrorCount)" >> $env:GITHUB_OUTPUT
         }
         exit 0
     }

--- a/scripts/security/Test-WorkflowPermissions.ps1
+++ b/scripts/security/Test-WorkflowPermissions.ps1
@@ -20,7 +20,7 @@
     and zero false positives.
 
     Adapted from microsoft/hve-core scripts/security/Test-WorkflowPermissions.ps1
-    as of commit 5d663940a203c97d91f30508d41500629d4081cf (2026-06-30). See
+    as of commit 5d663940a203c97d91f30508d41500629d4081cf. See
     docs/security/workflow-permissions.md for the enumerated job-scoped write
     permissions this invariant protects.
 

--- a/scripts/tests/security/Test-HveCoreFreshness.Tests.ps1
+++ b/scripts/tests/security/Test-HveCoreFreshness.Tests.ps1
@@ -557,7 +557,7 @@ Describe 'Invoke-HveCoreFreshnessCheck' -Tag 'Unit' {
         $resultsFile = Join-Path $TestDrive 'results-with-error.json'
         Mock Get-HveCoreFileDriftForBaseline {
             if ($File.Path -eq 'scripts/security/Test-DangerousWorkflow.ps1') {
-                throw 'invalid provenance header'
+                throw [HveCoreFileValidationException]::new('invalid provenance header')
             }
             [ordered]@{
                 Path = $File.Path
@@ -580,5 +580,17 @@ Describe 'Invoke-HveCoreFreshnessCheck' -Tag 'Unit' {
         $failed.State | Should -Be 'error'
         $failed.Error | Should -Be 'invalid provenance header'
         $failed.Drift | Should -BeTrue
+    }
+
+    It 'Propagates upstream failures instead of reporting false drift' {
+        $resultsFile = Join-Path $TestDrive 'results-with-api-error.json'
+        Mock Get-HveCoreFileDriftForBaseline {
+            throw 'gh api failed for scripts/security/Test-DangerousWorkflow.ps1@main'
+        }
+
+        {
+            Invoke-HveCoreFreshnessCheck -RepoRoot $script:RepoRoot -ResultsFile $resultsFile
+        } | Should -Throw '*gh api failed*'
+        Test-Path $resultsFile | Should -BeFalse
     }
 }

--- a/scripts/tests/security/Test-HveCoreFreshness.Tests.ps1
+++ b/scripts/tests/security/Test-HveCoreFreshness.Tests.ps1
@@ -18,6 +18,22 @@ BeforeAll {
 }
 
 Describe 'DerivedFiles configuration' -Tag 'Unit' {
+    It 'Tracks the complete derived-file manifest' {
+        $expected = @(
+            'scripts/security/Modules/SecurityHelpers.psm1|release'
+            'scripts/security/Modules/SecurityClasses.psm1|release'
+            'scripts/linting/Modules/LintingHelpers.psm1|release'
+            'scripts/tests/Mocks/GitMocks.psm1|release'
+            'scripts/lib/Modules/CIHelpers.psm1|release'
+            'scripts/linting/Modules/FrontmatterValidation.psm1|release'
+            'scripts/security/Test-WorkflowPermissions.ps1|source-header'
+            'scripts/security/Test-DangerousWorkflow.ps1|source-header'
+        )
+        $actual = @($script:DerivedFiles | ForEach-Object { "$($_.Path)|$($_.Baseline)" })
+
+        $actual | Should -Be $expected
+    }
+
     It 'Tracks both security linters with source-header baselines' {
         $sourceFiles = @($script:DerivedFiles | Where-Object { $_.Baseline -eq 'source-header' })
 
@@ -91,8 +107,10 @@ Describe 'Get-HveCoreFileSource' -Tag 'Unit' {
     It 'Extracts the source path and normalizes the commit SHA' {
         $path = Join-Path $TestDrive 'derived.ps1'
         @'
+<#
 Adapted from microsoft/hve-core scripts/security/Test-DangerousWorkflow.ps1
 as of commit ABCDEF1234567890ABCDEF1234567890ABCDEF12.
+#>
 '@ | Set-Content -Path $path -Encoding utf8
 
         $source = Get-HveCoreFileSource -Path $path
@@ -104,8 +122,10 @@ as of commit ABCDEF1234567890ABCDEF1234567890ABCDEF12.
     It 'Accepts a source path outside scripts/security' {
         $path = Join-Path $TestDrive 'derived.psm1'
         @'
+<#
 Adapted from microsoft/hve-core scripts/linting/Modules/Example.psm1
 as of commit ABCDEF1234567890ABCDEF1234567890ABCDEF12.
+#>
 '@ | Set-Content -Path $path -Encoding utf8
 
         (Get-HveCoreFileSource -Path $path).Path | Should -Be 'scripts/linting/Modules/Example.psm1'
@@ -114,8 +134,10 @@ as of commit ABCDEF1234567890ABCDEF1234567890ABCDEF12.
     It 'Throws when multiple source headers are present' {
         $path = Join-Path $TestDrive 'duplicate-header.ps1'
         @'
+<#
 Adapted from microsoft/hve-core scripts/security/First.ps1 as of commit aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.
 Adapted from microsoft/hve-core scripts/security/Second.ps1 as of commit bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb.
+#>
 '@ | Set-Content -Path $path -Encoding utf8
 
         { Get-HveCoreFileSource -Path $path } | Should -Throw '*multiple*'
@@ -123,7 +145,36 @@ Adapted from microsoft/hve-core scripts/security/Second.ps1 as of commit bbbbbbb
 
     It 'Throws when the source header is missing' {
         $path = Join-Path $TestDrive 'missing-header.ps1'
-        '# no provenance header' | Set-Content -Path $path -Encoding utf8
+        '<# no provenance header #>' | Set-Content -Path $path -Encoding utf8
+
+        { Get-HveCoreFileSource -Path $path } | Should -Throw '*Could not extract*'
+    }
+
+    It 'Ignores provenance text outside the comment-based help header' {
+        $path = Join-Path $TestDrive 'body-provenance.ps1'
+        @'
+<#
+.SYNOPSIS
+    No provenance record.
+#>
+Write-Host 'Adapted from microsoft/hve-core scripts/security/Fake.ps1 as of commit aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.'
+'@ | Set-Content -Path $path -Encoding utf8
+
+        { Get-HveCoreFileSource -Path $path } | Should -Throw '*Could not extract*'
+    }
+
+    It 'Rejects a truncated commit SHA' {
+        $path = Join-Path $TestDrive 'short-sha.ps1'
+        '<# Adapted from microsoft/hve-core scripts/security/Fake.ps1 as of commit abcdef1. #>' |
+            Set-Content -Path $path -Encoding utf8
+
+        { Get-HveCoreFileSource -Path $path } | Should -Throw '*Could not extract*'
+    }
+
+    It 'Rejects a provenance header from another repository' {
+        $path = Join-Path $TestDrive 'foreign-repo.ps1'
+        '<# Adapted from example/hve-core scripts/security/Fake.ps1 as of commit aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa. #>' |
+            Set-Content -Path $path -Encoding utf8
 
         { Get-HveCoreFileSource -Path $path } | Should -Throw '*Could not extract*'
     }
@@ -134,24 +185,28 @@ Adapted from microsoft/hve-core scripts/security/Second.ps1 as of commit bbbbbbb
 }
 
 Describe 'Get-DriftState' -Tag 'Unit' {
-    It 'Returns current when pinned and latest upstream SHAs match' {
-        Get-DriftState -PinnedUpstreamSha 'abc123' -LatestUpstreamSha 'abc123' | Should -Be 'current'
+    It 'Returns current when baseline and target upstream SHAs match' {
+        Get-DriftState -BaselineUpstreamSha 'abc123' -TargetUpstreamSha 'abc123' | Should -Be 'current'
     }
 
     It 'Returns current when SHAs match case-insensitively' {
-        Get-DriftState -PinnedUpstreamSha 'ABC123' -LatestUpstreamSha 'abc123' | Should -Be 'current'
+        Get-DriftState -BaselineUpstreamSha 'ABC123' -TargetUpstreamSha 'abc123' | Should -Be 'current'
     }
 
     It 'Returns drift when SHAs differ' {
-        Get-DriftState -PinnedUpstreamSha 'abc123' -LatestUpstreamSha 'def456' | Should -Be 'drift'
+        Get-DriftState -BaselineUpstreamSha 'abc123' -TargetUpstreamSha 'def456' | Should -Be 'drift'
     }
 
-    It 'Returns missing-upstream when the latest upstream SHA is empty' {
-        Get-DriftState -PinnedUpstreamSha 'abc123' -LatestUpstreamSha '' | Should -Be 'missing-upstream'
+    It 'Returns missing-target when the target upstream SHA is empty' {
+        Get-DriftState -BaselineUpstreamSha 'abc123' -TargetUpstreamSha '' | Should -Be 'missing-target'
     }
 
-    It 'Returns missing-baseline when the pinned upstream SHA is empty' {
-        Get-DriftState -PinnedUpstreamSha '' -LatestUpstreamSha 'abc123' | Should -Be 'missing-baseline'
+    It 'Returns missing-baseline when the baseline upstream SHA is empty' {
+        Get-DriftState -BaselineUpstreamSha '' -TargetUpstreamSha 'abc123' | Should -Be 'missing-baseline'
+    }
+
+    It 'Returns missing-both when neither upstream SHA exists' {
+        Get-DriftState -BaselineUpstreamSha '' -TargetUpstreamSha '' | Should -Be 'missing-both'
     }
 }
 
@@ -190,29 +245,29 @@ Describe 'Get-HveCoreFileDrift' -Tag 'Unit' {
             $global:LASTEXITCODE = 0
             if ("$args" -match 'ref=PIN') { 'aaaaaaa' } else { 'bbbbbbb' }
         }
-        $r = Get-HveCoreFileDrift -Repo 'o/r' -Path 'p' -PinnedRef 'PIN' -LatestRef 'LATEST'
+        $r = Get-HveCoreFileDrift -Repo 'o/r' -Path 'p' -BaselineRef 'PIN' -TargetRef 'LATEST'
         $r.State | Should -Be 'drift'
         $r.Drift | Should -BeTrue
-        $r.PinnedUpstreamSha | Should -Be 'aaaaaaa'
-        $r.LatestUpstreamSha | Should -Be 'bbbbbbb'
-        $r.PinnedRef | Should -Be 'PIN'
-        $r.LatestRef | Should -Be 'LATEST'
+        $r.BaselineUpstreamSha | Should -Be 'aaaaaaa'
+        $r.TargetUpstreamSha | Should -Be 'bbbbbbb'
+        $r.BaselineRef | Should -Be 'PIN'
+        $r.TargetRef | Should -Be 'LATEST'
         $r.ComparisonUrl | Should -Be 'https://github.com/o/r/compare/PIN...LATEST'
     }
 
     It 'Reports current when the upstream blob is unchanged' {
         Mock gh { $global:LASTEXITCODE = 0; 'samesha' }
-        $r = Get-HveCoreFileDrift -Repo 'o/r' -Path 'p' -PinnedRef 'PIN' -LatestRef 'LATEST'
+        $r = Get-HveCoreFileDrift -Repo 'o/r' -Path 'p' -BaselineRef 'PIN' -TargetRef 'LATEST'
         $r.State | Should -Be 'current'
         $r.Drift | Should -BeFalse
     }
 
-    It 'Reports missing-upstream when the file is absent at the latest ref' {
+    It 'Reports missing-target when the file is absent at the target ref' {
         Mock gh {
             if ("$args" -match 'ref=LATEST') { $global:LASTEXITCODE = 1; 'gh: Not Found (HTTP 404)' }
             else { $global:LASTEXITCODE = 0; 'aaaaaaa' }
         }
-        (Get-HveCoreFileDrift -Repo 'o/r' -Path 'p' -PinnedRef 'PIN' -LatestRef 'LATEST').State | Should -Be 'missing-upstream'
+        (Get-HveCoreFileDrift -Repo 'o/r' -Path 'p' -BaselineRef 'PIN' -TargetRef 'LATEST').State | Should -Be 'missing-target'
     }
 
     It 'Reports missing-baseline when the file is absent at the baseline ref' {
@@ -221,7 +276,7 @@ Describe 'Get-HveCoreFileDrift' -Tag 'Unit' {
             else { $global:LASTEXITCODE = 0; 'bbbbbbb' }
         }
 
-        $r = Get-HveCoreFileDrift -Repo 'o/r' -Path 'p' -PinnedRef 'PIN' -LatestRef 'LATEST'
+        $r = Get-HveCoreFileDrift -Repo 'o/r' -Path 'p' -BaselineRef 'PIN' -TargetRef 'LATEST'
         $r.State | Should -Be 'missing-baseline'
         $r.Drift | Should -BeTrue
     }
@@ -229,7 +284,7 @@ Describe 'Get-HveCoreFileDrift' -Tag 'Unit' {
     It 'URL-encodes refs in comparison links' {
         Mock gh { $global:LASTEXITCODE = 0; 'samesha' }
 
-        $r = Get-HveCoreFileDrift -Repo 'o/r' -Path 'p' -PinnedRef 'v1](https://evil.example)' -LatestRef 'main'
+        $r = Get-HveCoreFileDrift -Repo 'o/r' -Path 'p' -BaselineRef 'v1](https://evil.example)' -TargetRef 'main'
 
         $r.ComparisonUrl | Should -Not -Match '\]\('
         $r.ComparisonUrl | Should -Match 'v1%5D%28https%3A%2F%2Fevil\.example%29'
@@ -257,8 +312,18 @@ Describe 'Assert-HveCoreCommitOnMain' -Tag 'Unit' {
         } | Should -Throw '*not an ancestor*'
     }
 
-    It 'Throws when the compare API fails' {
+    It 'Classifies a missing commit as a file validation failure' {
         Mock gh { $global:LASTEXITCODE = 1; 'gh: Not Found (HTTP 404)' }
+
+        {
+            Assert-HveCoreCommitOnMain -Repo 'o/r' `
+                -CommitSha 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' `
+                -MainSha 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+        } | Should -Throw -ExceptionType ([HveCoreFileValidationException])
+    }
+
+    It 'Propagates a transient compare API failure' {
+        Mock gh { $global:LASTEXITCODE = 1; 'gh: Internal Server Error (HTTP 500)' }
 
         {
             Assert-HveCoreCommitOnMain -Repo 'o/r' `
@@ -298,7 +363,7 @@ Describe 'Get-HveCoreFileDriftForBaseline' -Tag 'Unit' {
             $CommitSha -eq $sourceSha -and $MainSha -eq $mainSha
         }
         Should -Invoke Get-HveCoreFileDrift -Times 1 -Exactly -ParameterFilter {
-            $Path -eq $path -and $PinnedRef -eq $sourceSha -and $LatestRef -eq $mainSha
+            $Path -eq $path -and $BaselineRef -eq $sourceSha -and $TargetRef -eq $mainSha
         }
     }
 
@@ -312,7 +377,7 @@ Describe 'Get-HveCoreFileDriftForBaseline' -Tag 'Unit' {
         $null = Get-HveCoreFileDriftForBaseline -File $file -PinnedReleaseSha 'pin' -LatestReleaseTag 'tag' -LatestMainSha 'main'
 
         Should -Invoke Get-HveCoreFileDrift -Times 1 -Exactly -ParameterFilter {
-            $Path -eq $path -and $PinnedRef -eq 'pin' -and $LatestRef -eq 'tag'
+            $Path -eq $path -and $BaselineRef -eq 'pin' -and $TargetRef -eq 'tag'
         }
         Should -Invoke Get-HveCoreFileSource -Times 0 -Exactly
         Should -Invoke Assert-HveCoreCommitOnMain -Times 0 -Exactly
@@ -354,36 +419,36 @@ Describe 'Get-HveCoreFileDriftForBaseline' -Tag 'Unit' {
 }
 
 Describe 'Format-HveCoreDriftCells' -Tag 'Unit' {
-    It 'Renders missing-upstream records with short and empty SHAs' {
+    It 'Renders missing-target records with short and empty SHAs' {
         $file = [pscustomobject]@{
-            Baseline = 'source-header'
-            PinnedUpstreamSha = 'abc'
-            LatestUpstreamSha = ''
-            PinnedRef = 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
-            LatestRef = 'main'
-            State = 'missing-upstream'
-            ComparisonUrl = ''
+            Baseline            = 'source-header'
+            BaselineUpstreamSha = 'abc'
+            TargetUpstreamSha   = ''
+            BaselineRef         = 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
+            TargetRef           = 'main'
+            State               = 'missing-target'
+            ComparisonUrl       = ''
         }
 
         $cells = Format-HveCoreDriftCells -File $file
 
         $cells.Baseline | Should -Be 'Source header'
-        $cells.PinnedSha | Should -Be 'abc'
-        $cells.LatestSha | Should -BeExactly ''
+        $cells.BaselineSha | Should -Be 'abc'
+        $cells.TargetSha | Should -BeExactly ''
         $cells.Comparison | Should -BeExactly ''
         $cells.Status | Should -Match 'Not found at target ref'
     }
 
     It 'Escapes error details for markdown output' {
         $file = [pscustomobject]@{
-            Baseline = 'release'
-            PinnedUpstreamSha = ''
-            LatestUpstreamSha = ''
-            PinnedRef = ''
-            LatestRef = ''
-            State = 'error'
-            Error = "bad | value`nnext"
-            ComparisonUrl = ''
+            Baseline            = 'release'
+            BaselineUpstreamSha = ''
+            TargetUpstreamSha   = ''
+            BaselineRef         = ''
+            TargetRef           = ''
+            State               = 'error'
+            Error               = "bad | value`nnext"
+            ComparisonUrl       = ''
         }
 
         (Format-HveCoreDriftCells -File $file).Status | Should -Be '❌ Check failed — <code>bad &#124; value next</code>'
@@ -391,13 +456,13 @@ Describe 'Format-HveCoreDriftCells' -Tag 'Unit' {
 
     It 'Escapes ref text in comparison links' {
         $file = [pscustomobject]@{
-            Baseline = 'release'
-            PinnedUpstreamSha = 'abc123'
-            LatestUpstreamSha = 'def456'
-            PinnedRef = 'v1](https://evil.example)'
-            LatestRef = 'main'
-            State = 'drift'
-            ComparisonUrl = 'https://github.com/o/r/compare/v1%5D%28https%3A%2F%2Fevil.example%29...main'
+            Baseline            = 'release'
+            BaselineUpstreamSha = 'abc123'
+            TargetUpstreamSha   = 'def456'
+            BaselineRef         = 'v1](https://evil.example)'
+            TargetRef           = 'main'
+            State               = 'drift'
+            ComparisonUrl       = 'https://github.com/o/r/compare/v1%5D%28https%3A%2F%2Fevil.example%29...main'
         }
 
         $comparison = (Format-HveCoreDriftCells -File $file).Comparison
@@ -407,26 +472,37 @@ Describe 'Format-HveCoreDriftCells' -Tag 'Unit' {
     }
 }
 
+Describe 'ConvertTo-HveCoreMarkdownText' -Tag 'Unit' {
+    It 'Encodes HTML and markdown metacharacters exactly once' {
+        $encoded = ConvertTo-HveCoreMarkdownText -Value '<b>a|b`c[d](e)</b>'
+
+        $encoded | Should -Be '&lt;b&gt;a&#124;b&#96;c&#91;d&#93;&#40;e&#41;&lt;/b&gt;'
+        $encoded | Should -Not -Match '&amp;#'
+    }
+}
+
 Describe 'Format-HveCoreIssueBody' -Tag 'Unit' {
     It 'Formats the issue body with correct markers and links' {
         $r = [pscustomobject]@{
             LatestTag = 'hve-core-v9'
-            LatestUrl = 'http://u'
+            LatestUrl = 'https://github.com/microsoft/hve-core/releases/tag/hve-core-v9'
+            DriftCount = 1
+            ErrorCount = 0
             Pin = [pscustomobject]@{
                 PinnedTag = 'hve-core-v1'
                 File = '.github/workflows/copilot-setup-steps.yml'
             }
             Files = @(
                 [pscustomobject]@{
-                    Path = 'scripts/x.psm1'
-                    Baseline = 'release'
-                    PinnedUpstreamSha = '1111111'
-                    LatestUpstreamSha = '2222222'
-                    PinnedRef = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
-                    LatestRef = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
-                    ComparisonUrl = 'https://github.com/microsoft/hve-core/compare/a...b'
-                    Drift = $true
-                    State = 'drift'
+                    Path                = 'scripts/x.psm1'
+                    Baseline            = 'release'
+                    BaselineUpstreamSha = '1111111'
+                    TargetUpstreamSha   = '2222222'
+                    BaselineRef         = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+                    TargetRef           = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+                    ComparisonUrl       = 'https://github.com/microsoft/hve-core/compare/a...b'
+                    Drift               = $true
+                    State               = 'drift'
                 }
             )
         }
@@ -437,13 +513,17 @@ Describe 'Format-HveCoreIssueBody' -Tag 'Unit' {
         $body | Should -Match 'scripts/x\.psm1'
         $body | Should -Match 'compare/hve-core-v1\.\.\.hve-core-v9'
         $body | Should -Match '\[aaaaaaa → bbbbbbb\]\(https://github\.com/microsoft/hve-core/compare/a\.\.\.b\)'
+        $body | Should -Match 'Action required: 1 drifted, 0 check errors'
+        $body | Should -Match '\| File \| Baseline \| Upstream comparison \| Baseline upstream blob \| Target upstream blob \| Status \|'
         $body | Should -Not -Match '[Pp]ersona'
     }
 
     It 'Falls back to the pinned SHA in the compare link when the tag is unknown' {
         $r = [pscustomobject]@{
             LatestTag = 'hve-core-v9'
-            LatestUrl = 'http://u'
+            LatestUrl = 'https://github.com/microsoft/hve-core/releases/tag/hve-core-v9'
+            DriftCount = 1
+            ErrorCount = 0
             Pin = [pscustomobject]@{
                 PinnedTag = 'unknown'
                 PinnedSha = 'abcdef1234567890'
@@ -451,15 +531,15 @@ Describe 'Format-HveCoreIssueBody' -Tag 'Unit' {
             }
             Files = @(
                 [pscustomobject]@{
-                    Path = 'scripts/x.psm1'
-                    Baseline = 'source-header'
-                    PinnedUpstreamSha = '1111111'
-                    LatestUpstreamSha = '2222222'
-                    PinnedRef = 'hve-core-v1'
-                    LatestRef = 'main'
-                    ComparisonUrl = 'https://github.com/microsoft/hve-core/compare/hve-core-v1...main'
-                    Drift = $true
-                    State = 'drift'
+                    Path                = 'scripts/x.psm1'
+                    Baseline            = 'source-header'
+                    BaselineUpstreamSha = '1111111'
+                    TargetUpstreamSha   = '2222222'
+                    BaselineRef         = 'hve-core-v1'
+                    TargetRef           = 'main'
+                    ComparisonUrl       = 'https://github.com/microsoft/hve-core/compare/hve-core-v1...main'
+                    Drift               = $true
+                    State               = 'drift'
                 }
             )
         }
@@ -468,29 +548,49 @@ Describe 'Format-HveCoreIssueBody' -Tag 'Unit' {
         $body | Should -Match 'compare/abcdef1234567890\.\.\.hve-core-v9'
         $body | Should -Not -Match 'compare/unknown'
     }
+
+    It 'Rejects a release URL outside GitHub' {
+        $r = [pscustomobject]@{
+            LatestTag = 'hve-core-v9'
+            LatestUrl = 'https://evil.example/release'
+            DriftCount = 0
+            ErrorCount = 0
+            Pin = [pscustomobject]@{
+                PinnedTag = 'hve-core-v1'
+                File = '.github/workflows/copilot-setup-steps.yml'
+            }
+            Files = @()
+        }
+
+        {
+            Format-HveCoreIssueBody -Result $r -RunUrl 'http://run' -CheckDate '2026-01-01'
+        } | Should -Throw '*Unexpected hve-core release URL*'
+    }
 }
 
 Describe 'Format-HveCoreJobSummary' -Tag 'Unit' {
     It 'Formats the job summary correctly' {
         $r = [pscustomobject]@{
             LatestTag = 'hve-core-v9'
-            LatestUrl = 'http://u'
+            LatestUrl = 'https://github.com/microsoft/hve-core/releases/tag/hve-core-v9'
             LatestMainSha = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+            DriftCount = 1
+            ErrorCount = 0
             Pin = [pscustomobject]@{
                 PinnedTag = 'hve-core-v1'
                 File = '.github/workflows/copilot-setup-steps.yml'
             }
             Files = @(
                 [pscustomobject]@{
-                    Path = 'scripts/x.psm1'
-                    Baseline = 'source-header'
-                    PinnedUpstreamSha = '1111111'
-                    LatestUpstreamSha = '2222222'
-                    PinnedRef = 'hve-core-v1'
-                    LatestRef = 'main'
-                    ComparisonUrl = 'https://github.com/microsoft/hve-core/compare/hve-core-v1...main'
-                    Drift = $true
-                    State = 'drift'
+                    Path                = 'scripts/x.psm1'
+                    Baseline            = 'source-header'
+                    BaselineUpstreamSha = '1111111'
+                    TargetUpstreamSha   = '2222222'
+                    BaselineRef         = 'hve-core-v1'
+                    TargetRef           = 'main'
+                    ComparisonUrl       = 'https://github.com/microsoft/hve-core/compare/hve-core-v1...main'
+                    Drift               = $true
+                    State               = 'drift'
                 }
             )
         }
@@ -504,6 +604,7 @@ Describe 'Format-HveCoreJobSummary' -Tag 'Unit' {
         $summary | Should -Match '\| 1111111 \| 2222222 \|'
         $summary | Should -Match '\[hve-core-v1 → main\]\(https://github\.com/microsoft/hve-core/compare/hve-core-v1\.\.\.main\)'
         $summary | Should -Match 'Source-header target: b{40}'
+        $summary | Should -Match 'Action required: 1 drifted, 0 check errors'
     }
 }
 
@@ -514,7 +615,7 @@ Describe 'Invoke-HveCoreFreshnessCheck' -Tag 'Unit' {
                     tag_name = 'hve-core-v9'
                     draft = $false
                     created_at = '2026-08-01T00:00:00Z'
-                    html_url = 'https://example.test/release'
+                    html_url = 'https://github.com/microsoft/hve-core/releases/tag/hve-core-v9'
                 })
         }
         Mock Resolve-HveCoreCommitSha {
@@ -527,16 +628,17 @@ Describe 'Invoke-HveCoreFreshnessCheck' -Tag 'Unit' {
                 Sha = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
             }
         }
+
         Mock Get-HveCoreFileDriftForBaseline {
             [ordered]@{
-                Path = $File.Path
-                PinnedUpstreamSha = '1111111'
-                LatestUpstreamSha = '1111111'
-                PinnedRef = 'pin'
-                LatestRef = 'target'
-                ComparisonUrl = 'https://example.test/compare'
-                Drift = $false
-                State = 'current'
+                Path                = $File.Path
+                BaselineUpstreamSha = '1111111'
+                TargetUpstreamSha   = '1111111'
+                BaselineRef         = 'pin'
+                TargetRef           = 'target'
+                ComparisonUrl       = 'https://example.test/compare'
+                Drift               = $false
+                State               = 'current'
             }
         }
     }
@@ -547,8 +649,12 @@ Describe 'Invoke-HveCoreFreshnessCheck' -Tag 'Unit' {
         $outcome = Invoke-HveCoreFreshnessCheck -RepoRoot $script:RepoRoot -ResultsFile $resultsFile
         $result = Get-Content -Path $resultsFile -Raw | ConvertFrom-Json
 
-        $outcome.StaleCount | Should -Be 0
+        $outcome.AttentionCount | Should -Be 0
+        $outcome.DriftCount | Should -Be 0
+        $outcome.ErrorCount | Should -Be 0
         $result.LatestMainSha | Should -Be 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+        $result.DriftCount | Should -Be 0
+        $result.ErrorCount | Should -Be 0
         @($result.Files).Count | Should -Be $script:DerivedFiles.Count
         @($result.Files | Where-Object { $_.Baseline -eq 'source-header' }).Count | Should -Be 2
     }
@@ -560,14 +666,14 @@ Describe 'Invoke-HveCoreFreshnessCheck' -Tag 'Unit' {
                 throw [HveCoreFileValidationException]::new('invalid provenance header')
             }
             [ordered]@{
-                Path = $File.Path
-                PinnedUpstreamSha = '1111111'
-                LatestUpstreamSha = '1111111'
-                PinnedRef = 'pin'
-                LatestRef = 'target'
-                ComparisonUrl = 'https://example.test/compare'
-                Drift = $false
-                State = 'current'
+                Path                = $File.Path
+                BaselineUpstreamSha = '1111111'
+                TargetUpstreamSha   = '1111111'
+                BaselineRef         = 'pin'
+                TargetRef           = 'target'
+                ComparisonUrl       = 'https://example.test/compare'
+                Drift               = $false
+                State               = 'current'
             }
         }
 
@@ -575,11 +681,15 @@ Describe 'Invoke-HveCoreFreshnessCheck' -Tag 'Unit' {
         $result = Get-Content -Path $resultsFile -Raw | ConvertFrom-Json
         $failed = $result.Files | Where-Object { $_.Path -eq 'scripts/security/Test-DangerousWorkflow.ps1' }
 
-        $outcome.StaleCount | Should -Be 1
+        $outcome.AttentionCount | Should -Be 1
+        $outcome.DriftCount | Should -Be 0
+        $outcome.ErrorCount | Should -Be 1
+        $result.DriftCount | Should -Be 0
+        $result.ErrorCount | Should -Be 1
         @($result.Files).Count | Should -Be $script:DerivedFiles.Count
         $failed.State | Should -Be 'error'
         $failed.Error | Should -Be 'invalid provenance header'
-        $failed.Drift | Should -BeTrue
+        $failed.Drift | Should -BeFalse
     }
 
     It 'Propagates upstream failures instead of reporting false drift' {
@@ -592,5 +702,18 @@ Describe 'Invoke-HveCoreFreshnessCheck' -Tag 'Unit' {
             Invoke-HveCoreFreshnessCheck -RepoRoot $script:RepoRoot -ResultsFile $resultsFile
         } | Should -Throw '*gh api failed*'
         Test-Path $resultsFile | Should -BeFalse
+    }
+}
+
+Describe 'Test-HveCoreFreshness entry point' -Tag 'Unit' {
+    It 'Lists derived files and baselines in config preview' {
+        $scriptPath = Join-Path $script:RepoRoot 'scripts/security/Test-HveCoreFreshness.ps1'
+
+        $output = & pwsh -NoProfile -File $scriptPath -ConfigPreview 2>&1
+
+        $LASTEXITCODE | Should -Be 0
+        "$output" | Should -Match 'Test-DangerousWorkflow\.ps1 \[source-header\]'
+        "$output" | Should -Match 'SecurityHelpers\.psm1 \[release\]'
+        "$output" | Should -Not -Match 'OrderedDictionary'
     }
 }

--- a/scripts/tests/security/Test-HveCoreFreshness.Tests.ps1
+++ b/scripts/tests/security/Test-HveCoreFreshness.Tests.ps1
@@ -78,6 +78,14 @@ Describe 'Get-PinnedHveCoreRef' -Tag 'Unit' {
 
         (Get-PinnedHveCoreRef -Path $p).Sha | Should -BeNullOrEmpty
     }
+
+    It 'Returns unknown for an invalid release tag' {
+        $p = Join-Path $TestDrive 'invalid-tag.yml'
+        "env:`n  # microsoft/hve-core release: bad](tag`n  UPSTREAM_REF: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" |
+            Set-Content -Path $p -Encoding utf8
+
+        (Get-PinnedHveCoreRef -Path $p).Tag | Should -Be 'unknown'
+    }
 }
 
 Describe 'Select-LatestRelease' -Tag 'Unit' {
@@ -188,6 +196,13 @@ Write-Host 'Adapted from microsoft/hve-core scripts/security/Fake.ps1 as of comm
 
     It 'Throws when the file does not exist' {
         { Get-HveCoreFileSource -Path (Join-Path $TestDrive 'missing.ps1') } | Should -Throw '*not found locally*'
+    }
+
+    It 'Classifies an empty file as a validation failure' {
+        $path = Join-Path $TestDrive 'empty.ps1'
+        '' | Set-Content -Path $path -NoNewline
+
+        { Get-HveCoreFileSource -Path $path } | Should -Throw -ExceptionType ([HveCoreFileValidationException])
     }
 }
 
@@ -329,6 +344,20 @@ Describe 'Assert-HveCoreCommitOnMain' -Tag 'Unit' {
                 -CommitSha 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' `
                 -MainSha 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
         } | Should -Not -Throw
+        Should -Invoke gh -Times 1 -Exactly -ParameterFilter {
+            "$args" -match 'repos/o/r/compare/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\.\.\.bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' -and
+            "$args" -match '\.merge_base_commit\.sha'
+        }
+    }
+
+    It 'Accepts a merge base whose SHA differs only by case' {
+        Mock gh { $global:LASTEXITCODE = 0; 'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' }
+
+        {
+            Assert-HveCoreCommitOnMain -Repo 'o/r' `
+                -CommitSha 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' `
+                -MainSha 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+        } | Should -Not -Throw
     }
 
     It 'Throws when the recorded commit is not an ancestor of main' {
@@ -396,7 +425,7 @@ Describe 'Get-HveCoreFileDriftForBaseline' -Tag 'Unit' {
         Mock Assert-HveCoreCommitOnMain {}
         Mock Get-HveCoreFileDrift { [pscustomobject]@{ State = 'current'; Drift = $false } }
 
-        $null = Get-HveCoreFileDriftForBaseline -File $file -PinnedReleaseSha 'pin' -LatestReleaseTag 'tag' -LatestMainSha $mainSha
+        $null = Get-HveCoreFileDriftForBaseline -File $file -PinnedReleaseSha 'pin' -LatestReleaseSha 'release-sha' -LatestMainSha $mainSha
 
         Should -Invoke Assert-HveCoreCommitOnMain -Times 1 -Exactly -ParameterFilter {
             $CommitSha -eq $sourceSha -and $MainSha -eq $mainSha
@@ -406,17 +435,17 @@ Describe 'Get-HveCoreFileDriftForBaseline' -Tag 'Unit' {
         }
     }
 
-    It 'Uses the release pin and latest release tag' {
+    It 'Uses the release pin and resolved latest release SHA' {
         $path = 'scripts/security/Modules/SecurityHelpers.psm1'
         $file = [pscustomobject]@{ Path = $path; Baseline = 'release' }
         Mock Get-HveCoreFileSource { throw 'source parser must not run' }
         Mock Assert-HveCoreCommitOnMain { throw 'ancestry check must not run' }
         Mock Get-HveCoreFileDrift { [pscustomobject]@{ State = 'current'; Drift = $false } }
 
-        $null = Get-HveCoreFileDriftForBaseline -File $file -PinnedReleaseSha 'pin' -LatestReleaseTag 'tag' -LatestMainSha 'main'
+        $null = Get-HveCoreFileDriftForBaseline -File $file -PinnedReleaseSha 'pin' -LatestReleaseSha 'release-sha' -LatestMainSha 'main'
 
         Should -Invoke Get-HveCoreFileDrift -Times 1 -Exactly -ParameterFilter {
-            $Path -eq $path -and $BaselineRef -eq 'pin' -and $TargetRef -eq 'tag'
+            $Path -eq $path -and $BaselineRef -eq 'pin' -and $TargetRef -eq 'release-sha'
         }
         Should -Invoke Get-HveCoreFileSource -Times 0 -Exactly
         Should -Invoke Assert-HveCoreCommitOnMain -Times 0 -Exactly
@@ -435,7 +464,7 @@ Describe 'Get-HveCoreFileDriftForBaseline' -Tag 'Unit' {
         }
 
         {
-            Get-HveCoreFileDriftForBaseline -File $file -PinnedReleaseSha 'pin' -LatestReleaseTag 'tag' -LatestMainSha 'main'
+            Get-HveCoreFileDriftForBaseline -File $file -PinnedReleaseSha 'pin' -LatestReleaseSha 'release-sha' -LatestMainSha 'main'
         } | Should -Throw '*must match its recorded*'
     }
 
@@ -452,7 +481,7 @@ Describe 'Get-HveCoreFileDriftForBaseline' -Tag 'Unit' {
         }
 
         {
-            Get-HveCoreFileDriftForBaseline -File $file -PinnedReleaseSha 'pin' -LatestReleaseTag 'tag' -LatestMainSha 'main'
+            Get-HveCoreFileDriftForBaseline -File $file -PinnedReleaseSha 'pin' -LatestReleaseSha 'release-sha' -LatestMainSha 'main'
         } | Should -Throw '*must match its recorded*'
     }
 
@@ -460,7 +489,7 @@ Describe 'Get-HveCoreFileDriftForBaseline' -Tag 'Unit' {
         $file = [pscustomobject]@{ Path = 'scripts/security/Test-DangerousWorkflow.ps1'; Baseline = 'bogus' }
 
         {
-            Get-HveCoreFileDriftForBaseline -File $file -PinnedReleaseSha 'pin' -LatestReleaseTag 'tag' -LatestMainSha 'main'
+            Get-HveCoreFileDriftForBaseline -File $file -PinnedReleaseSha 'pin' -LatestReleaseSha 'release-sha' -LatestMainSha 'main'
         } | Should -Throw '*Unsupported hve-core baseline*'
     }
 
@@ -469,8 +498,24 @@ Describe 'Get-HveCoreFileDriftForBaseline' -Tag 'Unit' {
         $file = [pscustomobject]@{ Path = 'scripts/security/Missing.ps1'; Baseline = 'release' }
 
         {
-            Get-HveCoreFileDriftForBaseline -File $file -PinnedReleaseSha 'pin' -LatestReleaseTag 'tag' -LatestMainSha 'main'
+            Get-HveCoreFileDriftForBaseline -File $file -PinnedReleaseSha 'pin' -LatestReleaseSha 'release-sha' -LatestMainSha 'main'
         } | Should -Throw '*not found locally*'
+    }
+
+    It 'Rejects a source header whose recorded path is absent at its recorded commit' {
+        $path = 'scripts/security/Test-DangerousWorkflow.ps1'
+        $file = [pscustomobject]@{ Path = $path; Baseline = 'source-header' }
+        Mock Get-HveCoreFileSource {
+            [pscustomobject]@{ Path = $path; Sha = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' }
+        }
+        Mock Assert-HveCoreCommitOnMain {}
+        Mock Get-HveCoreFileDrift {
+            [pscustomobject]@{ State = 'missing-baseline'; Drift = $true }
+        }
+
+        {
+            Get-HveCoreFileDriftForBaseline -File $file -PinnedReleaseSha 'pin' -LatestReleaseSha 'release-sha' -LatestMainSha 'main'
+        } | Should -Throw '*absent at its recorded commit*'
     }
 }
 
@@ -703,6 +748,52 @@ Describe 'Format-HveCoreJobSummary' -Tag 'Unit' {
         $summary | Should -Match 'Source-header target: b{40}'
         $summary | Should -Match 'Action required: 1 drifted, 0 check errors'
     }
+
+    It 'Escapes untrusted refs in the job summary' {
+        $r = [pscustomobject]@{
+            LatestTag = 'v1|spoof'
+            LatestMainSha = 'main](https://evil.example)'
+            DriftCount = 0
+            ErrorCount = 0
+            Pin = [pscustomobject]@{ PinnedTag = 'pin`value' }
+            Files = @()
+        }
+
+        $summary = Format-HveCoreJobSummary -Result $r
+
+        $summary | Should -Match 'v1&#124;spoof'
+        $summary | Should -Match 'main&#93;&#40;https://evil\.example&#41;'
+        $summary | Should -Match 'pin&#96;value'
+    }
+}
+
+Describe 'Get-HveCoreReleases' -Tag 'Unit' {
+    It 'Parses release objects from the GitHub API' {
+        Mock gh {
+            $global:LASTEXITCODE = 0
+            '[{"tag_name":"v1","draft":false},{"tag_name":"v2","draft":true}]'
+        }
+
+        $releases = @(Get-HveCoreReleases -Repo 'o/r')
+
+        $releases.Count | Should -Be 2
+        $releases[0].tag_name | Should -Be 'v1'
+        Should -Invoke gh -Times 1 -Exactly -ParameterFilter {
+            "$args" -match 'repos/o/r/releases\?per_page=30'
+        }
+    }
+
+    It 'Throws when the GitHub API fails' {
+        Mock gh { $global:LASTEXITCODE = 1; 'HTTP 403 rate limit' }
+
+        { Get-HveCoreReleases -Repo 'o/r' } | Should -Throw '*cannot produce reliable results*'
+    }
+
+    It 'Throws when the GitHub API returns no payload' {
+        Mock gh { $global:LASTEXITCODE = 0; '' }
+
+        { Get-HveCoreReleases -Repo 'o/r' } | Should -Throw '*cannot produce reliable results*'
+    }
 }
 
 Describe 'Invoke-HveCoreFreshnessCheck' -Tag 'Unit' {
@@ -750,6 +841,7 @@ Describe 'Invoke-HveCoreFreshnessCheck' -Tag 'Unit' {
         $outcome.DriftCount | Should -Be 0
         $outcome.ErrorCount | Should -Be 0
         $result.LatestMainSha | Should -Be 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+        $result.LatestReleaseSha | Should -Be 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
         $result.DriftCount | Should -Be 0
         $result.ErrorCount | Should -Be 0
         @($result.Files).Count | Should -Be $script:DerivedFiles.Count
@@ -896,6 +988,27 @@ Describe 'Write-HveCoreGitHubOutputs' -Tag 'Unit' {
             'drift-count=1'
             'error-count=1'
         )
+    }
+
+    It 'Matches every workflow output consumer' {
+        $outputPath = Join-Path $TestDrive 'github-output-contract.txt'
+        $outcome = [pscustomobject]@{
+            AttentionCount = 0
+            DriftCount = 0
+            ErrorCount = 0
+        }
+        Write-HveCoreGitHubOutputs -Outcome $outcome -Path $outputPath
+        $emitted = @(Get-Content -Path $outputPath | ForEach-Object { ($_ -split '=', 2)[0] })
+        $workflowPath = Join-Path $script:RepoRoot '.github/workflows/check-hve-core-freshness.yml'
+        $workflow = Get-Content -Path $workflowPath -Raw
+        $referenced = @([regex]::Matches($workflow, 'steps\.check\.outputs\.([a-z-]+)') |
+                ForEach-Object { $_.Groups[1].Value } |
+                Select-Object -Unique)
+
+        $referenced | Should -Be @('attention-count', 'drift-count', 'error-count')
+        foreach ($name in $referenced) {
+            $emitted | Should -Contain $name
+        }
     }
 }
 

--- a/scripts/tests/security/Test-HveCoreFreshness.Tests.ps1
+++ b/scripts/tests/security/Test-HveCoreFreshness.Tests.ps1
@@ -71,6 +71,13 @@ Describe 'Get-PinnedHveCoreRef' -Tag 'Unit' {
         $ref.Sha | Should -BeNullOrEmpty
         $ref.Tag | Should -Be 'unknown'
     }
+
+    It 'Rejects a shortened or suffixed UPSTREAM_REF' {
+        $p = Join-Path $TestDrive 'invalid-ref.yml'
+        "env:`n  UPSTREAM_REF: deadbeef-fix" | Set-Content -Path $p -Encoding utf8
+
+        (Get-PinnedHveCoreRef -Path $p).Sha | Should -BeNullOrEmpty
+    }
 }
 
 Describe 'Select-LatestRelease' -Tag 'Unit' {
@@ -212,8 +219,15 @@ Describe 'Get-DriftState' -Tag 'Unit' {
 
 Describe 'Get-HveCoreBlobSha' -Tag 'Unit' {
     It 'Returns the trimmed blob SHA on success' {
-        Mock gh { $global:LASTEXITCODE = 0; 'abc123def456' }
-        Get-HveCoreBlobSha -Repo 'o/r' -Path 'p' -Ref 'ref' | Should -Be 'abc123def456'
+        Mock gh { $global:LASTEXITCODE = 0; 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' }
+        Get-HveCoreBlobSha -Repo 'o/r' -Path 'p' -Ref 'ref' |
+            Should -Be 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+    }
+
+    It 'Throws when a successful response is not exactly one blob SHA' {
+        Mock gh { $global:LASTEXITCODE = 0; "warning`naaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" }
+
+        { Get-HveCoreBlobSha -Repo 'o/r' -Path 'p' -Ref 'ref' } | Should -Throw '*invalid blob SHA*'
     }
 
     It 'Returns empty string on a genuine 404 (file absent at ref)' {
@@ -237,26 +251,33 @@ Describe 'Resolve-HveCoreCommitSha' -Tag 'Unit' {
         Mock gh { $global:LASTEXITCODE = 1; 'gh: Not Found (HTTP 404)' }
         { Resolve-HveCoreCommitSha -Repo 'o/r' -Ref 'definitely-not-a-ref' } | Should -Throw
     }
+
+    It 'Throws when a successful response is not exactly one commit SHA' {
+        Mock gh { $global:LASTEXITCODE = 0; "warning`ndeadbeefdeadbeefdeadbeefdeadbeefdeadbeef" }
+
+        { Resolve-HveCoreCommitSha -Repo 'o/r' -Ref 'v1' } | Should -Throw '*invalid commit SHA*'
+    }
 }
 
 Describe 'Get-HveCoreFileDrift' -Tag 'Unit' {
     It 'Reports drift when the upstream blob changed between refs' {
         Mock gh {
             $global:LASTEXITCODE = 0
-            if ("$args" -match 'ref=PIN') { 'aaaaaaa' } else { 'bbbbbbb' }
+            if ("$args" -match 'ref=PIN') { 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' }
+            else { 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' }
         }
         $r = Get-HveCoreFileDrift -Repo 'o/r' -Path 'p' -BaselineRef 'PIN' -TargetRef 'LATEST'
         $r.State | Should -Be 'drift'
         $r.Drift | Should -BeTrue
-        $r.BaselineUpstreamSha | Should -Be 'aaaaaaa'
-        $r.TargetUpstreamSha | Should -Be 'bbbbbbb'
+        $r.BaselineUpstreamSha | Should -Be 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+        $r.TargetUpstreamSha | Should -Be 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
         $r.BaselineRef | Should -Be 'PIN'
         $r.TargetRef | Should -Be 'LATEST'
         $r.ComparisonUrl | Should -Be 'https://github.com/o/r/compare/PIN...LATEST'
     }
 
     It 'Reports current when the upstream blob is unchanged' {
-        Mock gh { $global:LASTEXITCODE = 0; 'samesha' }
+        Mock gh { $global:LASTEXITCODE = 0; 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' }
         $r = Get-HveCoreFileDrift -Repo 'o/r' -Path 'p' -BaselineRef 'PIN' -TargetRef 'LATEST'
         $r.State | Should -Be 'current'
         $r.Drift | Should -BeFalse
@@ -265,7 +286,7 @@ Describe 'Get-HveCoreFileDrift' -Tag 'Unit' {
     It 'Reports missing-target when the file is absent at the target ref' {
         Mock gh {
             if ("$args" -match 'ref=LATEST') { $global:LASTEXITCODE = 1; 'gh: Not Found (HTTP 404)' }
-            else { $global:LASTEXITCODE = 0; 'aaaaaaa' }
+            else { $global:LASTEXITCODE = 0; 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' }
         }
         (Get-HveCoreFileDrift -Repo 'o/r' -Path 'p' -BaselineRef 'PIN' -TargetRef 'LATEST').State | Should -Be 'missing-target'
     }
@@ -273,7 +294,7 @@ Describe 'Get-HveCoreFileDrift' -Tag 'Unit' {
     It 'Reports missing-baseline when the file is absent at the baseline ref' {
         Mock gh {
             if ("$args" -match 'ref=PIN') { $global:LASTEXITCODE = 1; 'gh: Not Found (HTTP 404)' }
-            else { $global:LASTEXITCODE = 0; 'bbbbbbb' }
+            else { $global:LASTEXITCODE = 0; 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' }
         }
 
         $r = Get-HveCoreFileDrift -Repo 'o/r' -Path 'p' -BaselineRef 'PIN' -TargetRef 'LATEST'
@@ -281,8 +302,16 @@ Describe 'Get-HveCoreFileDrift' -Tag 'Unit' {
         $r.Drift | Should -BeTrue
     }
 
+    It 'Classifies a path missing at both refs as a validation failure' {
+        Mock gh { $global:LASTEXITCODE = 1; 'gh: Not Found (HTTP 404)' }
+
+        {
+            Get-HveCoreFileDrift -Repo 'o/r' -Path 'p' -BaselineRef 'PIN' -TargetRef 'LATEST'
+        } | Should -Throw -ExceptionType ([HveCoreFileValidationException])
+    }
+
     It 'URL-encodes refs in comparison links' {
-        Mock gh { $global:LASTEXITCODE = 0; 'samesha' }
+        Mock gh { $global:LASTEXITCODE = 0; 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' }
 
         $r = Get-HveCoreFileDrift -Repo 'o/r' -Path 'p' -BaselineRef 'v1](https://evil.example)' -TargetRef 'main'
 
@@ -341,6 +370,16 @@ Describe 'Assert-HveCoreCommitOnMain' -Tag 'Unit' {
                 -MainSha 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
         } | Should -Throw '*Could not verify source commit*'
     }
+
+    It 'Classifies no common ancestor as a file validation failure' {
+        Mock gh { $global:LASTEXITCODE = 1; 'gh: No common ancestor between the refs' }
+
+        {
+            Assert-HveCoreCommitOnMain -Repo 'o/r' `
+                -CommitSha 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' `
+                -MainSha 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+        } | Should -Throw -ExceptionType ([HveCoreFileValidationException])
+    }
 }
 
 Describe 'Get-HveCoreFileDriftForBaseline' -Tag 'Unit' {
@@ -391,6 +430,23 @@ Describe 'Get-HveCoreFileDriftForBaseline' -Tag 'Unit' {
         Mock Get-HveCoreFileSource {
             [pscustomobject]@{
                 Path = 'scripts/security/Other.ps1'
+                Sha = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+            }
+        }
+
+        {
+            Get-HveCoreFileDriftForBaseline -File $file -PinnedReleaseSha 'pin' -LatestReleaseTag 'tag' -LatestMainSha 'main'
+        } | Should -Throw '*must match its recorded*'
+    }
+
+    It 'Rejects a case-mismatched recorded upstream path' {
+        $file = [pscustomobject]@{
+            Path = 'scripts/security/Test-DangerousWorkflow.ps1'
+            Baseline = 'source-header'
+        }
+        Mock Get-HveCoreFileSource {
+            [pscustomobject]@{
+                Path = 'scripts/security/test-dangerousworkflow.ps1'
                 Sha = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
             }
         }
@@ -469,6 +525,23 @@ Describe 'Format-HveCoreDriftCells' -Tag 'Unit' {
 
         $comparison | Should -Not -Match '\]\(https://evil'
         $comparison | Should -Match 'v1&#93;&#40;https://evil\.example&#41;'
+    }
+
+    It 'Escapes an unrecognized baseline label' {
+        $file = [pscustomobject]@{
+            Baseline            = 'weird](https://evil.example)'
+            BaselineUpstreamSha = ''
+            TargetUpstreamSha   = ''
+            BaselineRef         = ''
+            TargetRef           = ''
+            State               = 'error'
+            ComparisonUrl       = ''
+        }
+
+        $baseline = (Format-HveCoreDriftCells -File $file).Baseline
+
+        $baseline | Should -Match '&#93;&#40;'
+        $baseline | Should -Not -Match '\]\(https://evil'
     }
 }
 
@@ -566,6 +639,30 @@ Describe 'Format-HveCoreIssueBody' -Tag 'Unit' {
             Format-HveCoreIssueBody -Result $r -RunUrl 'http://run' -CheckDate '2026-01-01'
         } | Should -Throw '*Unexpected hve-core release URL*'
     }
+
+    It 'Rejects non-HTTPS and lookalike release URLs' -ForEach @(
+        'http://github.com/microsoft/hve-core/releases/tag/v1'
+        'https://github.com.evil.example/microsoft/hve-core/releases/tag/v1'
+        'not-a-url'
+        '//github.com/microsoft/hve-core/releases/tag/v1'
+    ) {
+        $r = [pscustomobject]@{
+            LatestTag = 'hve-core-v9'
+            LatestUrl = $_
+            LatestMainSha = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+            DriftCount = 0
+            ErrorCount = 0
+            Pin = [pscustomobject]@{
+                PinnedTag = 'hve-core-v1'
+                File = '.github/workflows/copilot-setup-steps.yml'
+            }
+            Files = @()
+        }
+
+        {
+            Format-HveCoreIssueBody -Result $r -RunUrl 'http://run' -CheckDate '2026-01-01'
+        } | Should -Throw '*Unexpected hve-core release URL*'
+    }
 }
 
 Describe 'Format-HveCoreJobSummary' -Tag 'Unit' {
@@ -599,7 +696,7 @@ Describe 'Format-HveCoreJobSummary' -Tag 'Unit' {
         $summary | Should -Match 'hve-core-v9'
         $summary | Should -Match 'scripts/x\.psm1'
         $summary | Should -Match '⚠️ Upstream advanced'
-        $summary | Should -Match '\| Derived File \| Baseline \| Upstream comparison \| Baseline blob \| Target blob \| Status \|'
+        $summary | Should -Match '\| File \| Baseline \| Upstream comparison \| Baseline upstream blob \| Target upstream blob \| Status \|'
         $summary | Should -Match '\| Source header \|'
         $summary | Should -Match '\| 1111111 \| 2222222 \|'
         $summary | Should -Match '\[hve-core-v1 → main\]\(https://github\.com/microsoft/hve-core/compare/hve-core-v1\.\.\.main\)'
@@ -692,6 +789,63 @@ Describe 'Invoke-HveCoreFreshnessCheck' -Tag 'Unit' {
         $failed.Drift | Should -BeFalse
     }
 
+    It 'Counts drift and validation errors independently' {
+        $resultsFile = Join-Path $TestDrive 'results-with-drift-and-error.json'
+        Mock Get-HveCoreFileDriftForBaseline {
+            if ($File.Path -eq 'scripts/security/Test-DangerousWorkflow.ps1') {
+                throw [HveCoreFileValidationException]::new('invalid provenance header')
+            }
+            $isDrift = $File.Path -eq 'scripts/security/Test-WorkflowPermissions.ps1'
+            [ordered]@{
+                Path                = $File.Path
+                BaselineUpstreamSha = '1111111111111111111111111111111111111111'
+                TargetUpstreamSha   = if ($isDrift) { '2222222222222222222222222222222222222222' } else { '1111111111111111111111111111111111111111' }
+                BaselineRef         = 'pin'
+                TargetRef           = 'target'
+                ComparisonUrl       = 'https://example.test/compare'
+                Drift               = $isDrift
+                State               = if ($isDrift) { 'drift' } else { 'current' }
+            }
+        }
+
+        $outcome = Invoke-HveCoreFreshnessCheck -RepoRoot $script:RepoRoot -ResultsFile $resultsFile
+        $result = Get-Content -Path $resultsFile -Raw | ConvertFrom-Json
+
+        $outcome.AttentionCount | Should -Be 2
+        $outcome.DriftCount | Should -Be 1
+        $outcome.ErrorCount | Should -Be 1
+        $result.DriftCount | Should -Be 1
+        $result.ErrorCount | Should -Be 1
+    }
+
+    It 'Throws before checking files when UPSTREAM_REF is unavailable' {
+        $resultsFile = Join-Path $TestDrive 'results-without-pin.json'
+        Mock Get-PinnedHveCoreRef { $null }
+
+        {
+            Invoke-HveCoreFreshnessCheck -RepoRoot $script:RepoRoot -ResultsFile $resultsFile
+        } | Should -Throw '*Could not extract UPSTREAM_REF*'
+        Should -Invoke Get-HveCoreFileDriftForBaseline -Times 0 -Exactly
+        Test-Path $resultsFile | Should -BeFalse
+    }
+
+    It 'Throws before checking files when the pinned ref does not resolve' {
+        $resultsFile = Join-Path $TestDrive 'results-with-invalid-pin.json'
+        Mock Resolve-HveCoreCommitSha {
+            if ($Ref -eq 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa') {
+                throw 'invalid pinned ref'
+            }
+            if ($Ref -eq 'main') { 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' }
+            else { 'cccccccccccccccccccccccccccccccccccccccc' }
+        }
+
+        {
+            Invoke-HveCoreFreshnessCheck -RepoRoot $script:RepoRoot -ResultsFile $resultsFile
+        } | Should -Throw '*invalid pinned ref*'
+        Should -Invoke Get-HveCoreFileDriftForBaseline -Times 0 -Exactly
+        Test-Path $resultsFile | Should -BeFalse
+    }
+
     It 'Propagates upstream failures instead of reporting false drift' {
         $resultsFile = Join-Path $TestDrive 'results-with-api-error.json'
         Mock Get-HveCoreFileDriftForBaseline {
@@ -702,6 +856,46 @@ Describe 'Invoke-HveCoreFreshnessCheck' -Tag 'Unit' {
             Invoke-HveCoreFreshnessCheck -RepoRoot $script:RepoRoot -ResultsFile $resultsFile
         } | Should -Throw '*gh api failed*'
         Test-Path $resultsFile | Should -BeFalse
+    }
+}
+
+Describe 'Get-HveCoreTrackingIssue' -Tag 'Unit' {
+    It 'Returns the trimmed issue number' {
+        Mock gh { $global:LASTEXITCODE = 0; " 42 `n" }
+
+        Get-HveCoreTrackingIssue | Should -Be '42'
+    }
+
+    It 'Returns null when no issue exists' {
+        Mock gh { $global:LASTEXITCODE = 0; '' }
+
+        Get-HveCoreTrackingIssue | Should -BeNullOrEmpty
+    }
+
+    It 'Throws when the issue lookup fails' {
+        Mock gh { $global:LASTEXITCODE = 1; 'gh: API rate limit exceeded' }
+
+        { Get-HveCoreTrackingIssue } | Should -Throw '*Could not query existing*'
+    }
+}
+
+Describe 'Write-HveCoreGitHubOutputs' -Tag 'Unit' {
+    It 'Emits all freshness counters exactly once' {
+        $outputPath = Join-Path $TestDrive 'github-output.txt'
+        $outcome = [pscustomobject]@{
+            AttentionCount = 2
+            DriftCount = 1
+            ErrorCount = 1
+        }
+
+        Write-HveCoreGitHubOutputs -Outcome $outcome -Path $outputPath
+        $lines = @(Get-Content -Path $outputPath)
+
+        $lines | Should -Be @(
+            'attention-count=2'
+            'drift-count=1'
+            'error-count=1'
+        )
     }
 }
 

--- a/scripts/tests/security/Test-HveCoreFreshness.Tests.ps1
+++ b/scripts/tests/security/Test-HveCoreFreshness.Tests.ps1
@@ -66,6 +66,32 @@ Describe 'Select-LatestRelease' -Tag 'Unit' {
     }
 }
 
+Describe 'Get-HveCoreFileSource' -Tag 'Unit' {
+    It 'Extracts the source path and normalizes the commit SHA' {
+        $path = Join-Path $TestDrive 'derived.ps1'
+        @'
+Adapted from microsoft/hve-core scripts/security/Test-DangerousWorkflow.ps1
+as of commit ABCDEF1234567890ABCDEF1234567890ABCDEF12.
+'@ | Set-Content -Path $path -Encoding utf8
+
+        $source = Get-HveCoreFileSource -Path $path
+
+        $source.Path | Should -Be 'scripts/security/Test-DangerousWorkflow.ps1'
+        $source.Sha | Should -Be 'abcdef1234567890abcdef1234567890abcdef12'
+    }
+
+    It 'Throws when the source header is missing' {
+        $path = Join-Path $TestDrive 'missing-header.ps1'
+        '# no provenance header' | Set-Content -Path $path -Encoding utf8
+
+        { Get-HveCoreFileSource -Path $path } | Should -Throw '*Could not extract*'
+    }
+
+    It 'Throws when the file does not exist' {
+        { Get-HveCoreFileSource -Path (Join-Path $TestDrive 'missing.ps1') } | Should -Throw '*not found locally*'
+    }
+}
+
 Describe 'Get-DriftState' -Tag 'Unit' {
     It 'Returns current when pinned and latest upstream SHAs match' {
         Get-DriftState -PinnedUpstreamSha 'abc123' -LatestUpstreamSha 'abc123' | Should -Be 'current'
@@ -124,6 +150,9 @@ Describe 'Get-HveCoreFileDrift' -Tag 'Unit' {
         $r.Drift | Should -BeTrue
         $r.PinnedUpstreamSha | Should -Be 'aaaaaaa'
         $r.LatestUpstreamSha | Should -Be 'bbbbbbb'
+        $r.PinnedRef | Should -Be 'PIN'
+        $r.LatestRef | Should -Be 'LATEST'
+        $r.ComparisonUrl | Should -Be 'https://github.com/o/r/compare/PIN...LATEST'
     }
 
     It 'Reports current when the upstream blob is unchanged' {
@@ -139,6 +168,96 @@ Describe 'Get-HveCoreFileDrift' -Tag 'Unit' {
             else { $global:LASTEXITCODE = 0; 'aaaaaaa' }
         }
         (Get-HveCoreFileDrift -Repo 'o/r' -Path 'p' -PinnedRef 'PIN' -LatestRef 'LATEST').State | Should -Be 'missing-upstream'
+    }
+
+    It 'Throws when the file is absent at the baseline ref' {
+        Mock gh {
+            if ("$args" -match 'ref=PIN') { $global:LASTEXITCODE = 1; 'gh: Not Found (HTTP 404)' }
+            else { $global:LASTEXITCODE = 0; 'bbbbbbb' }
+        }
+
+        { Get-HveCoreFileDrift -Repo 'o/r' -Path 'p' -PinnedRef 'PIN' -LatestRef 'LATEST' } |
+            Should -Throw '*Baseline file not found upstream*'
+    }
+}
+
+Describe 'Assert-HveCoreCommitOnMain' -Tag 'Unit' {
+    It 'Accepts a commit whose merge base with main is itself' {
+        Mock gh { $global:LASTEXITCODE = 0; 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' }
+
+        {
+            Assert-HveCoreCommitOnMain -Repo 'o/r' `
+                -CommitSha 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' `
+                -MainSha 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+        } | Should -Not -Throw
+    }
+
+    It 'Throws when the recorded commit is not an ancestor of main' {
+        Mock gh { $global:LASTEXITCODE = 0; 'cccccccccccccccccccccccccccccccccccccccc' }
+
+        {
+            Assert-HveCoreCommitOnMain -Repo 'o/r' `
+                -CommitSha 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' `
+                -MainSha 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+        } | Should -Throw '*not an ancestor*'
+    }
+}
+
+Describe 'Get-HveCoreFileDriftForBaseline' -Tag 'Unit' {
+    It 'Uses the source-header SHA and resolved main SHA' {
+        $path = 'scripts/security/Test-DangerousWorkflow.ps1'
+        $sourceSha = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+        $mainSha = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+        $file = [pscustomobject]@{ Path = $path; Baseline = 'source-header' }
+        Mock Get-HveCoreFileSource { [pscustomobject]@{ Path = $path; Sha = $sourceSha } }
+        Mock Assert-HveCoreCommitOnMain {}
+        Mock Get-HveCoreFileDrift { [pscustomobject]@{ State = 'current'; Drift = $false } }
+
+        $null = Get-HveCoreFileDriftForBaseline -File $file -PinnedReleaseSha 'pin' -LatestReleaseTag 'tag' -LatestMainSha $mainSha
+
+        Should -Invoke Assert-HveCoreCommitOnMain -Times 1 -ParameterFilter {
+            $CommitSha -eq $sourceSha -and $MainSha -eq $mainSha
+        }
+        Should -Invoke Get-HveCoreFileDrift -Times 1 -ParameterFilter {
+            $Path -eq $path -and $PinnedRef -eq $sourceSha -and $LatestRef -eq $mainSha
+        }
+    }
+
+    It 'Uses the release pin and latest release tag' {
+        $path = 'scripts/security/Modules/SecurityHelpers.psm1'
+        $file = [pscustomobject]@{ Path = $path; Baseline = 'release' }
+        Mock Get-HveCoreFileDrift { [pscustomobject]@{ State = 'current'; Drift = $false } }
+
+        $null = Get-HveCoreFileDriftForBaseline -File $file -PinnedReleaseSha 'pin' -LatestReleaseTag 'tag' -LatestMainSha 'main'
+
+        Should -Invoke Get-HveCoreFileDrift -Times 1 -ParameterFilter {
+            $Path -eq $path -and $PinnedRef -eq 'pin' -and $LatestRef -eq 'tag'
+        }
+    }
+
+    It 'Throws when the recorded upstream path differs from the local path' {
+        $file = [pscustomobject]@{
+            Path = 'scripts/security/Test-DangerousWorkflow.ps1'
+            Baseline = 'source-header'
+        }
+        Mock Get-HveCoreFileSource {
+            [pscustomobject]@{
+                Path = 'scripts/security/Other.ps1'
+                Sha = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+            }
+        }
+
+        {
+            Get-HveCoreFileDriftForBaseline -File $file -PinnedReleaseSha 'pin' -LatestReleaseTag 'tag' -LatestMainSha 'main'
+        } | Should -Throw '*must match its recorded*'
+    }
+
+    It 'Throws on an unsupported baseline' {
+        $file = [pscustomobject]@{ Path = 'scripts/security/Test-DangerousWorkflow.ps1'; Baseline = 'bogus' }
+
+        {
+            Get-HveCoreFileDriftForBaseline -File $file -PinnedReleaseSha 'pin' -LatestReleaseTag 'tag' -LatestMainSha 'main'
+        } | Should -Throw '*Unsupported hve-core baseline*'
     }
 }
 
@@ -156,6 +275,9 @@ Describe 'Format-HveCoreIssueBody' -Tag 'Unit' {
                     Path = 'scripts/x.psm1'
                     PinnedUpstreamSha = '1111111'
                     LatestUpstreamSha = '2222222'
+                    PinnedRef = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+                    LatestRef = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+                    ComparisonUrl = 'https://github.com/microsoft/hve-core/compare/a...b'
                     Drift = $true
                     State = 'drift'
                 }
@@ -167,6 +289,7 @@ Describe 'Format-HveCoreIssueBody' -Tag 'Unit' {
         $body | Should -Match 'hve-core-v9'
         $body | Should -Match 'scripts/x\.psm1'
         $body | Should -Match 'compare/hve-core-v1\.\.\.hve-core-v9'
+        $body | Should -Match '\[aaaaaaa → bbbbbbb\]\(https://github\.com/microsoft/hve-core/compare/a\.\.\.b\)'
         $body | Should -Not -Match '[Pp]ersona'
     }
 
@@ -184,6 +307,9 @@ Describe 'Format-HveCoreIssueBody' -Tag 'Unit' {
                     Path = 'scripts/x.psm1'
                     PinnedUpstreamSha = '1111111'
                     LatestUpstreamSha = '2222222'
+                    PinnedRef = 'hve-core-v1'
+                    LatestRef = 'main'
+                    ComparisonUrl = 'https://github.com/microsoft/hve-core/compare/hve-core-v1...main'
                     Drift = $true
                     State = 'drift'
                 }
@@ -201,6 +327,7 @@ Describe 'Format-HveCoreJobSummary' -Tag 'Unit' {
         $r = [pscustomobject]@{
             LatestTag = 'hve-core-v9'
             LatestUrl = 'http://u'
+            LatestMainSha = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
             Pin = [pscustomobject]@{
                 PinnedTag = 'hve-core-v1'
                 File = '.github/workflows/copilot-setup-steps.yml'
@@ -210,6 +337,9 @@ Describe 'Format-HveCoreJobSummary' -Tag 'Unit' {
                     Path = 'scripts/x.psm1'
                     PinnedUpstreamSha = '1111111'
                     LatestUpstreamSha = '2222222'
+                    PinnedRef = 'hve-core-v1'
+                    LatestRef = 'main'
+                    ComparisonUrl = 'https://github.com/microsoft/hve-core/compare/hve-core-v1...main'
                     Drift = $true
                     State = 'drift'
                 }
@@ -220,7 +350,9 @@ Describe 'Format-HveCoreJobSummary' -Tag 'Unit' {
         $summary | Should -Match 'hve-core-v9'
         $summary | Should -Match 'scripts/x\.psm1'
         $summary | Should -Match '⚠️ Upstream advanced'
-        $summary | Should -Match '\| Pinned blob \| Latest blob \|'
+        $summary | Should -Match '\| Derived File \| Upstream comparison \| Pinned blob \| Latest blob \| Status \|'
         $summary | Should -Match '\| 1111111 \| 2222222 \|'
+        $summary | Should -Match '\[hve-core-v1 → main\]\(https://github\.com/microsoft/hve-core/compare/hve-core-v1\.\.\.main\)'
+        $summary | Should -Match 'Source-header target: b{40}'
     }
 }

--- a/scripts/tests/security/Test-HveCoreFreshness.Tests.ps1
+++ b/scripts/tests/security/Test-HveCoreFreshness.Tests.ps1
@@ -6,6 +6,7 @@
 BeforeAll {
     . $PSScriptRoot/../../security/Test-HveCoreFreshness.ps1
 
+    $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
     $script:SetupPath = Join-Path $TestDrive 'copilot-setup-steps.yml'
     @'
       - name: Bootstrap hve-core RPI persona
@@ -14,6 +15,26 @@ BeforeAll {
           UPSTREAM_REF: e69486a5f809ede45c63c0a31358c12912bd5168
         run: echo bootstrap
 '@ | Set-Content -Path $script:SetupPath -Encoding utf8
+}
+
+Describe 'DerivedFiles configuration' -Tag 'Unit' {
+    It 'Tracks both security linters with source-header baselines' {
+        $sourceFiles = @($script:DerivedFiles | Where-Object { $_.Baseline -eq 'source-header' })
+
+        $sourceFiles.Count | Should -Be 2
+        $sourceFiles.Path | Should -Contain 'scripts/security/Test-WorkflowPermissions.ps1'
+        $sourceFiles.Path | Should -Contain 'scripts/security/Test-DangerousWorkflow.ps1'
+    }
+
+    It 'Parses the provenance header of every source-header entry' {
+        $sourceFiles = @($script:DerivedFiles | Where-Object { $_.Baseline -eq 'source-header' })
+
+        foreach ($file in $sourceFiles) {
+            $source = Get-HveCoreFileSource -Path (Join-Path $script:RepoRoot $file.Path)
+            $source.Path | Should -Be $file.Path
+            $source.Sha | Should -Match '^[0-9a-f]{40}$'
+        }
+    }
 }
 
 Describe 'Get-PinnedHveCoreRef' -Tag 'Unit' {
@@ -80,6 +101,26 @@ as of commit ABCDEF1234567890ABCDEF1234567890ABCDEF12.
         $source.Sha | Should -Be 'abcdef1234567890abcdef1234567890abcdef12'
     }
 
+    It 'Accepts a source path outside scripts/security' {
+        $path = Join-Path $TestDrive 'derived.psm1'
+        @'
+Adapted from microsoft/hve-core scripts/linting/Modules/Example.psm1
+as of commit ABCDEF1234567890ABCDEF1234567890ABCDEF12.
+'@ | Set-Content -Path $path -Encoding utf8
+
+        (Get-HveCoreFileSource -Path $path).Path | Should -Be 'scripts/linting/Modules/Example.psm1'
+    }
+
+    It 'Throws when multiple source headers are present' {
+        $path = Join-Path $TestDrive 'duplicate-header.ps1'
+        @'
+Adapted from microsoft/hve-core scripts/security/First.ps1 as of commit aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.
+Adapted from microsoft/hve-core scripts/security/Second.ps1 as of commit bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb.
+'@ | Set-Content -Path $path -Encoding utf8
+
+        { Get-HveCoreFileSource -Path $path } | Should -Throw '*multiple*'
+    }
+
     It 'Throws when the source header is missing' {
         $path = Join-Path $TestDrive 'missing-header.ps1'
         '# no provenance header' | Set-Content -Path $path -Encoding utf8
@@ -107,6 +148,10 @@ Describe 'Get-DriftState' -Tag 'Unit' {
 
     It 'Returns missing-upstream when the latest upstream SHA is empty' {
         Get-DriftState -PinnedUpstreamSha 'abc123' -LatestUpstreamSha '' | Should -Be 'missing-upstream'
+    }
+
+    It 'Returns missing-baseline when the pinned upstream SHA is empty' {
+        Get-DriftState -PinnedUpstreamSha '' -LatestUpstreamSha 'abc123' | Should -Be 'missing-baseline'
     }
 }
 
@@ -170,14 +215,24 @@ Describe 'Get-HveCoreFileDrift' -Tag 'Unit' {
         (Get-HveCoreFileDrift -Repo 'o/r' -Path 'p' -PinnedRef 'PIN' -LatestRef 'LATEST').State | Should -Be 'missing-upstream'
     }
 
-    It 'Throws when the file is absent at the baseline ref' {
+    It 'Reports missing-baseline when the file is absent at the baseline ref' {
         Mock gh {
             if ("$args" -match 'ref=PIN') { $global:LASTEXITCODE = 1; 'gh: Not Found (HTTP 404)' }
             else { $global:LASTEXITCODE = 0; 'bbbbbbb' }
         }
 
-        { Get-HveCoreFileDrift -Repo 'o/r' -Path 'p' -PinnedRef 'PIN' -LatestRef 'LATEST' } |
-            Should -Throw '*Baseline file not found upstream*'
+        $r = Get-HveCoreFileDrift -Repo 'o/r' -Path 'p' -PinnedRef 'PIN' -LatestRef 'LATEST'
+        $r.State | Should -Be 'missing-baseline'
+        $r.Drift | Should -BeTrue
+    }
+
+    It 'URL-encodes refs in comparison links' {
+        Mock gh { $global:LASTEXITCODE = 0; 'samesha' }
+
+        $r = Get-HveCoreFileDrift -Repo 'o/r' -Path 'p' -PinnedRef 'v1](https://evil.example)' -LatestRef 'main'
+
+        $r.ComparisonUrl | Should -Not -Match '\]\('
+        $r.ComparisonUrl | Should -Match 'v1%5D%28https%3A%2F%2Fevil\.example%29'
     }
 }
 
@@ -201,9 +256,33 @@ Describe 'Assert-HveCoreCommitOnMain' -Tag 'Unit' {
                 -MainSha 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
         } | Should -Throw '*not an ancestor*'
     }
+
+    It 'Throws when the compare API fails' {
+        Mock gh { $global:LASTEXITCODE = 1; 'gh: Not Found (HTTP 404)' }
+
+        {
+            Assert-HveCoreCommitOnMain -Repo 'o/r' `
+                -CommitSha 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' `
+                -MainSha 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+        } | Should -Throw '*Could not verify source commit*'
+    }
+
+    It 'Throws when the compare API returns no merge base' {
+        Mock gh { $global:LASTEXITCODE = 0; '' }
+
+        {
+            Assert-HveCoreCommitOnMain -Repo 'o/r' `
+                -CommitSha 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' `
+                -MainSha 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+        } | Should -Throw '*Could not verify source commit*'
+    }
 }
 
 Describe 'Get-HveCoreFileDriftForBaseline' -Tag 'Unit' {
+    BeforeEach {
+        Mock Test-Path { $true }
+    }
+
     It 'Uses the source-header SHA and resolved main SHA' {
         $path = 'scripts/security/Test-DangerousWorkflow.ps1'
         $sourceSha = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
@@ -215,10 +294,10 @@ Describe 'Get-HveCoreFileDriftForBaseline' -Tag 'Unit' {
 
         $null = Get-HveCoreFileDriftForBaseline -File $file -PinnedReleaseSha 'pin' -LatestReleaseTag 'tag' -LatestMainSha $mainSha
 
-        Should -Invoke Assert-HveCoreCommitOnMain -Times 1 -ParameterFilter {
+        Should -Invoke Assert-HveCoreCommitOnMain -Times 1 -Exactly -ParameterFilter {
             $CommitSha -eq $sourceSha -and $MainSha -eq $mainSha
         }
-        Should -Invoke Get-HveCoreFileDrift -Times 1 -ParameterFilter {
+        Should -Invoke Get-HveCoreFileDrift -Times 1 -Exactly -ParameterFilter {
             $Path -eq $path -and $PinnedRef -eq $sourceSha -and $LatestRef -eq $mainSha
         }
     }
@@ -226,13 +305,17 @@ Describe 'Get-HveCoreFileDriftForBaseline' -Tag 'Unit' {
     It 'Uses the release pin and latest release tag' {
         $path = 'scripts/security/Modules/SecurityHelpers.psm1'
         $file = [pscustomobject]@{ Path = $path; Baseline = 'release' }
+        Mock Get-HveCoreFileSource { throw 'source parser must not run' }
+        Mock Assert-HveCoreCommitOnMain { throw 'ancestry check must not run' }
         Mock Get-HveCoreFileDrift { [pscustomobject]@{ State = 'current'; Drift = $false } }
 
         $null = Get-HveCoreFileDriftForBaseline -File $file -PinnedReleaseSha 'pin' -LatestReleaseTag 'tag' -LatestMainSha 'main'
 
-        Should -Invoke Get-HveCoreFileDrift -Times 1 -ParameterFilter {
+        Should -Invoke Get-HveCoreFileDrift -Times 1 -Exactly -ParameterFilter {
             $Path -eq $path -and $PinnedRef -eq 'pin' -and $LatestRef -eq 'tag'
         }
+        Should -Invoke Get-HveCoreFileSource -Times 0 -Exactly
+        Should -Invoke Assert-HveCoreCommitOnMain -Times 0 -Exactly
     }
 
     It 'Throws when the recorded upstream path differs from the local path' {
@@ -259,6 +342,69 @@ Describe 'Get-HveCoreFileDriftForBaseline' -Tag 'Unit' {
             Get-HveCoreFileDriftForBaseline -File $file -PinnedReleaseSha 'pin' -LatestReleaseTag 'tag' -LatestMainSha 'main'
         } | Should -Throw '*Unsupported hve-core baseline*'
     }
+
+    It 'Throws when the derived file is missing locally' {
+        Mock Test-Path { $false }
+        $file = [pscustomobject]@{ Path = 'scripts/security/Missing.ps1'; Baseline = 'release' }
+
+        {
+            Get-HveCoreFileDriftForBaseline -File $file -PinnedReleaseSha 'pin' -LatestReleaseTag 'tag' -LatestMainSha 'main'
+        } | Should -Throw '*not found locally*'
+    }
+}
+
+Describe 'Format-HveCoreDriftCells' -Tag 'Unit' {
+    It 'Renders missing-upstream records with short and empty SHAs' {
+        $file = [pscustomobject]@{
+            Baseline = 'source-header'
+            PinnedUpstreamSha = 'abc'
+            LatestUpstreamSha = ''
+            PinnedRef = 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
+            LatestRef = 'main'
+            State = 'missing-upstream'
+            ComparisonUrl = ''
+        }
+
+        $cells = Format-HveCoreDriftCells -File $file
+
+        $cells.Baseline | Should -Be 'Source header'
+        $cells.PinnedSha | Should -Be 'abc'
+        $cells.LatestSha | Should -BeExactly ''
+        $cells.Comparison | Should -BeExactly ''
+        $cells.Status | Should -Match 'Not found at target ref'
+    }
+
+    It 'Escapes error details for markdown output' {
+        $file = [pscustomobject]@{
+            Baseline = 'release'
+            PinnedUpstreamSha = ''
+            LatestUpstreamSha = ''
+            PinnedRef = ''
+            LatestRef = ''
+            State = 'error'
+            Error = "bad | value`nnext"
+            ComparisonUrl = ''
+        }
+
+        (Format-HveCoreDriftCells -File $file).Status | Should -Be '❌ Check failed — <code>bad &#124; value next</code>'
+    }
+
+    It 'Escapes ref text in comparison links' {
+        $file = [pscustomobject]@{
+            Baseline = 'release'
+            PinnedUpstreamSha = 'abc123'
+            LatestUpstreamSha = 'def456'
+            PinnedRef = 'v1](https://evil.example)'
+            LatestRef = 'main'
+            State = 'drift'
+            ComparisonUrl = 'https://github.com/o/r/compare/v1%5D%28https%3A%2F%2Fevil.example%29...main'
+        }
+
+        $comparison = (Format-HveCoreDriftCells -File $file).Comparison
+
+        $comparison | Should -Not -Match '\]\(https://evil'
+        $comparison | Should -Match 'v1&#93;&#40;https://evil\.example&#41;'
+    }
 }
 
 Describe 'Format-HveCoreIssueBody' -Tag 'Unit' {
@@ -273,6 +419,7 @@ Describe 'Format-HveCoreIssueBody' -Tag 'Unit' {
             Files = @(
                 [pscustomobject]@{
                     Path = 'scripts/x.psm1'
+                    Baseline = 'release'
                     PinnedUpstreamSha = '1111111'
                     LatestUpstreamSha = '2222222'
                     PinnedRef = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
@@ -305,6 +452,7 @@ Describe 'Format-HveCoreIssueBody' -Tag 'Unit' {
             Files = @(
                 [pscustomobject]@{
                     Path = 'scripts/x.psm1'
+                    Baseline = 'source-header'
                     PinnedUpstreamSha = '1111111'
                     LatestUpstreamSha = '2222222'
                     PinnedRef = 'hve-core-v1'
@@ -335,6 +483,7 @@ Describe 'Format-HveCoreJobSummary' -Tag 'Unit' {
             Files = @(
                 [pscustomobject]@{
                     Path = 'scripts/x.psm1'
+                    Baseline = 'source-header'
                     PinnedUpstreamSha = '1111111'
                     LatestUpstreamSha = '2222222'
                     PinnedRef = 'hve-core-v1'
@@ -350,9 +499,86 @@ Describe 'Format-HveCoreJobSummary' -Tag 'Unit' {
         $summary | Should -Match 'hve-core-v9'
         $summary | Should -Match 'scripts/x\.psm1'
         $summary | Should -Match '⚠️ Upstream advanced'
-        $summary | Should -Match '\| Derived File \| Upstream comparison \| Pinned blob \| Latest blob \| Status \|'
+        $summary | Should -Match '\| Derived File \| Baseline \| Upstream comparison \| Baseline blob \| Target blob \| Status \|'
+        $summary | Should -Match '\| Source header \|'
         $summary | Should -Match '\| 1111111 \| 2222222 \|'
         $summary | Should -Match '\[hve-core-v1 → main\]\(https://github\.com/microsoft/hve-core/compare/hve-core-v1\.\.\.main\)'
         $summary | Should -Match 'Source-header target: b{40}'
+    }
+}
+
+Describe 'Invoke-HveCoreFreshnessCheck' -Tag 'Unit' {
+    BeforeEach {
+        Mock Get-HveCoreReleases {
+            @([pscustomobject]@{
+                    tag_name = 'hve-core-v9'
+                    draft = $false
+                    created_at = '2026-08-01T00:00:00Z'
+                    html_url = 'https://example.test/release'
+                })
+        }
+        Mock Resolve-HveCoreCommitSha {
+            if ($Ref -eq 'main') { 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' }
+            else { 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' }
+        }
+        Mock Get-PinnedHveCoreRef {
+            [ordered]@{
+                Tag = 'hve-core-v1'
+                Sha = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+            }
+        }
+        Mock Get-HveCoreFileDriftForBaseline {
+            [ordered]@{
+                Path = $File.Path
+                PinnedUpstreamSha = '1111111'
+                LatestUpstreamSha = '1111111'
+                PinnedRef = 'pin'
+                LatestRef = 'target'
+                ComparisonUrl = 'https://example.test/compare'
+                Drift = $false
+                State = 'current'
+            }
+        }
+    }
+
+    It 'Writes the resolved main SHA and all configured files to results JSON' {
+        $resultsFile = Join-Path $TestDrive 'results.json'
+
+        $outcome = Invoke-HveCoreFreshnessCheck -RepoRoot $script:RepoRoot -ResultsFile $resultsFile
+        $result = Get-Content -Path $resultsFile -Raw | ConvertFrom-Json
+
+        $outcome.StaleCount | Should -Be 0
+        $result.LatestMainSha | Should -Be 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+        @($result.Files).Count | Should -Be $script:DerivedFiles.Count
+        @($result.Files | Where-Object { $_.Baseline -eq 'source-header' }).Count | Should -Be 2
+    }
+
+    It 'Records a file-level error and continues checking remaining files' {
+        $resultsFile = Join-Path $TestDrive 'results-with-error.json'
+        Mock Get-HveCoreFileDriftForBaseline {
+            if ($File.Path -eq 'scripts/security/Test-DangerousWorkflow.ps1') {
+                throw 'invalid provenance header'
+            }
+            [ordered]@{
+                Path = $File.Path
+                PinnedUpstreamSha = '1111111'
+                LatestUpstreamSha = '1111111'
+                PinnedRef = 'pin'
+                LatestRef = 'target'
+                ComparisonUrl = 'https://example.test/compare'
+                Drift = $false
+                State = 'current'
+            }
+        }
+
+        $outcome = Invoke-HveCoreFreshnessCheck -RepoRoot $script:RepoRoot -ResultsFile $resultsFile
+        $result = Get-Content -Path $resultsFile -Raw | ConvertFrom-Json
+        $failed = $result.Files | Where-Object { $_.Path -eq 'scripts/security/Test-DangerousWorkflow.ps1' }
+
+        $outcome.StaleCount | Should -Be 1
+        @($result.Files).Count | Should -Be $script:DerivedFiles.Count
+        $failed.State | Should -Be 'error'
+        $failed.Error | Should -Be 'invalid provenance header'
+        $failed.Drift | Should -BeTrue
     }
 }


### PR DESCRIPTION
## Summary

- Compare release-baseline modules between the pinned `UPSTREAM_REF` and one immutable resolved latest-release commit; compare source-header security linters between their recorded source commit and one immutable resolved upstream `main` commit.
- Report upstream drift and local validation errors separately in JSON, workflow outputs, and job summaries.
- Keep upstream drift as an issue-triaged signal while failing the workflow for invalid local provenance.
- Validate provenance paths, full commit SHAs, API responses, release tags, release URLs, and Markdown rendering at trust boundaries.
- Enforce the script-to-workflow output contract and fail when tracking-issue updates do not succeed.
- Expand Pester coverage for the complete manifest, API request shapes, report formatting, orchestration, and workflow consumers.

## Validation

- Affected security Pester suites: 163 passed
- PSScriptAnalyzer: 4 changed PowerShell files, 0 errors, 0 warnings
- Runtime smoke tests: freshness preview, live comparison, malformed provenance, clean scans, violations, and invalid paths
- `git diff --check`
