### PR TITLE
fix(scripts): extend hve-core linter freshness

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -338,6 +338,10 @@ The `Physical-AI RPI` umbrella (`.github/agents/physical-ai-rpi.agent.md`) and i
 
 See [docs/reference/copilot-artifacts.md](../docs/reference/copilot-artifacts.md) for the full umbrella/worker rationale.
 
+## hve-core Derived Files
+
+Follow the baseline conventions in [`scripts/README.md`](../scripts/README.md). `scripts/security/Test-HveCoreFreshness.ps1` compares source-header entries with a resolved upstream `main` commit and release entries with the RPI `UPSTREAM_REF` and a resolved latest non-draft release commit.
+
 ## Git Workflow
 
 Full specification in `.github/instructions/commit-message.instructions.md`.

--- a/.github/workflows/check-hve-core-freshness.yml
+++ b/.github/workflows/check-hve-core-freshness.yml
@@ -31,30 +31,35 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Check hve-core-derived files against latest release
+      - name: Check hve-core-derived files against reviewed upstream baselines
         id: check
         env:
           GH_TOKEN: ${{ github.token }}
         run: ./scripts/security/Test-HveCoreFreshness.ps1
 
       - name: Create or update tracking issue
-        if: steps.check.outputs.stale-count != '0'
+        if: "!cancelled() && steps.check.outputs.attention-count != '' && steps.check.outputs.attention-count != '0'"
         env:
           GH_TOKEN: ${{ github.token }}
-          STALE_COUNT: ${{ steps.check.outputs.stale-count }}
+          DRIFT_COUNT: ${{ steps.check.outputs.drift-count }}
+          ERROR_COUNT: ${{ steps.check.outputs.error-count }}
         run: |
           . ./scripts/security/Test-HveCoreFreshness.ps1
           $data = Get-Content 'hve-core-freshness-results.json' -Raw | ConvertFrom-Json
           $runUrl = "$env:GITHUB_SERVER_URL/$env:GITHUB_REPOSITORY/actions/runs/$env:GITHUB_RUN_ID"
           $checkDate = Get-Date -Format 'yyyy-MM-dd' -AsUTC
           $body = Format-HveCoreIssueBody -Result $data -RunUrl $runUrl -CheckDate $checkDate
-          $title = "security: hve-core upstream updates available ($env:STALE_COUNT stale)"
+          $title = "security: hve-core freshness needs attention ($env:DRIFT_COUNT drifted, $env:ERROR_COUNT check errors)"
           $existing = Get-HveCoreTrackingIssue
-          if ($existing) { gh issue edit $existing --title $title --body $body; gh issue comment $existing --body "🔄 Weekly scan: $env:STALE_COUNT item(s) stale as of $checkDate. [Workflow run]($runUrl)." }
+          if ($existing) {
+            gh issue edit $existing --title $title --body $body
+            if ($LASTEXITCODE -ne 0) { throw "Could not update hve-core freshness issue #$existing" }
+            gh issue comment $existing --body "🔄 Weekly scan: $env:DRIFT_COUNT drifted, $env:ERROR_COUNT check errors as of $checkDate. [Workflow run]($runUrl)."
+          }
           else { gh issue create --title $title --body $body --label "dependencies,automated,needs-triage" }
 
       - name: Close resolved tracking issue
-        if: steps.check.outputs.stale-count == '0'
+        if: steps.check.outputs.attention-count == '0'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -71,13 +71,15 @@ Security scanning and dependency management scripts.
 | `security/Test-DependencyPinning.ps1` | Validate dependency pinning compliance                                                        |
 | `security/Test-SHAStaleness.ps1`      | Check for outdated SHA pins                                                                   |
 | `security/Test-BinaryFreshness.ps1`   | Validate pinned binary hashes and Helm chart versions; emits SARIF for GitHub Security tab    |
-| `security/Test-HveCoreFreshness.ps1`  | Check hve-core-derived modules against the latest upstream release                            |
+| `security/Test-HveCoreFreshness.ps1`  | Check hve-core-derived files against their reviewed release or source-header baselines        |
 | `security/zap-to-sarif.py`            | Convert ZAP results to SARIF format                                                           |
 | `update-chart-hashes.sh`              | Refresh pinned Helm chart versions and SHA-256 hashes in `infrastructure/setup/defaults.conf` |
 
 The `Test-BinaryFreshness.ps1` script is invoked by the `check-binary-integrity.yml` workflow on a weekly schedule. It downloads each pinned GPG key, installer, and CLI archive, compares SHA-256 hashes against the values pinned in `.devcontainer/install-dev-deps.sh` and `.devcontainer/devcontainer.json`, and queries upstream Helm repositories for chart version drift. Findings are written to `binary-freshness-results.sarif` with per-rule `helpUri` values pointing at the appropriate remediation script.
 
-The `Test-HveCoreFreshness.ps1` script is invoked by the `check-hve-core-freshness.yml` workflow on a weekly schedule. For every hve-core-derived module, it compares the **upstream** blob SHA at the pinned `UPSTREAM_REF` (the last reviewed upstream ref) against the newest non-draft `microsoft/hve-core` release. Comparing blobs, not release tags, means a stale signal is a real upstream change rather than an unrelated prerelease.
+The `Test-HveCoreFreshness.ps1` script is invoked by the `check-hve-core-freshness.yml` workflow on a weekly schedule. Each derived file declares a baseline. `release` files compare the **upstream** blob SHA at the pinned `UPSTREAM_REF` against one resolved, immutable newest non-draft release revision. `source-header` files compare the revision recorded in their header against one resolved, immutable upstream `main` revision. This reports relevant upstream changes before they appear in a release.
+
+Source-header files must include `Adapted from microsoft/hve-core <upstream-path> as of commit <40-hex SHA>`. Comparing upstream blobs avoids false drift from intentional local adaptations.
 
 ### 🔗 Where Pins Live
 

--- a/scripts/security/Test-DangerousWorkflow.ps1
+++ b/scripts/security/Test-DangerousWorkflow.ps1
@@ -18,7 +18,7 @@
       the pull-request head ref, executing untrusted code in a privileged context.
 
     Adapted from microsoft/hve-core scripts/security/Test-DangerousWorkflow.ps1
-    as of commit b70237d08d5caf6918b9de9952a243a8588b92dc (2026-07-02).
+    as of commit b70237d08d5caf6918b9de9952a243a8588b92dc.
 
     Local divergences from upstream (each marked inline with a '# LOCAL' comment):
 

--- a/scripts/security/Test-HveCoreFreshness.ps1
+++ b/scripts/security/Test-HveCoreFreshness.ps1
@@ -5,15 +5,16 @@
 
 <#
 .SYNOPSIS
-    Checks hve-core-derived files against the latest upstream release.
+    Checks hve-core-derived files against their reviewed upstream baselines.
 
 .DESCRIPTION
-    Resolves the newest non-draft microsoft/hve-core release and compares each
-    hve-core-derived file's upstream blob SHA at the pinned UPSTREAM_REF (the last
-    reviewed upstream ref, read from the RPI bootstrap workflow) against the same
-    upstream path at the latest release. Writes a JSON results file consumed by the
-    tracking-issue steps and, when running under GitHub Actions, emits the stale item
-    count to GITHUB_OUTPUT.
+    Compares each hve-core-derived file's upstream blob SHA at its reviewed source
+    revision against its current upstream target. Modules use the RPI bootstrap's
+    pinned UPSTREAM_REF and the latest release. Security linters use the source
+    revision recorded in their headers and upstream main, which also covers files
+    not present in a release. Writes a JSON results file consumed by the tracking-
+    issue steps and, under GitHub Actions, emits attention-count, drift-count, and
+    error-count to GITHUB_OUTPUT.
 
 .PARAMETER ResultsFile
     Output JSON results path. Default: hve-core-freshness-results.json.
@@ -54,18 +55,25 @@ $script:UpstreamRepo = 'microsoft/hve-core'
 $script:SetupWorkflow = '.github/workflows/copilot-setup-steps.yml'
 $script:IssueMarker = 'automation:hve-core-freshness'
 $script:IssueSearch = "in:body $script:IssueMarker is:open"
+$script:FullShaPattern = '^[0-9a-fA-F]{40}$'
+$script:ShortShaLength = 7
 
-# These are hve-core-derived modules; the check compares each file's UPSTREAM blob SHA
-# at the pinned ref vs the latest release, so local adaptations never cause false drift.
-# "drift" means upstream changed the file since the pinned ref and the change should
-# be reviewed and ported.
+class HveCoreFileValidationException : System.Exception {
+    HveCoreFileValidationException([string]$message) : base($message) {}
+}
+
+# Release entries use the RPI pin; source-header entries require the exact header
+# "Adapted from microsoft/hve-core <path> as of commit <40-hex SHA>" and track main.
+# Blob-to-blob comparisons avoid false drift from intentional local adaptations.
 $script:DerivedFiles = @(
-    'scripts/security/Modules/SecurityHelpers.psm1'
-    'scripts/security/Modules/SecurityClasses.psm1'
-    'scripts/linting/Modules/LintingHelpers.psm1'
-    'scripts/tests/Mocks/GitMocks.psm1'
-    'scripts/lib/Modules/CIHelpers.psm1'
-    'scripts/linting/Modules/FrontmatterValidation.psm1'
+    [ordered]@{ Path = 'scripts/security/Modules/SecurityHelpers.psm1'; Baseline = 'release' }
+    [ordered]@{ Path = 'scripts/security/Modules/SecurityClasses.psm1'; Baseline = 'release' }
+    [ordered]@{ Path = 'scripts/linting/Modules/LintingHelpers.psm1'; Baseline = 'release' }
+    [ordered]@{ Path = 'scripts/tests/Mocks/GitMocks.psm1'; Baseline = 'release' }
+    [ordered]@{ Path = 'scripts/lib/Modules/CIHelpers.psm1'; Baseline = 'release' }
+    [ordered]@{ Path = 'scripts/linting/Modules/FrontmatterValidation.psm1'; Baseline = 'release' }
+    [ordered]@{ Path = 'scripts/security/Test-WorkflowPermissions.ps1'; Baseline = 'source-header' }
+    [ordered]@{ Path = 'scripts/security/Test-DangerousWorkflow.ps1'; Baseline = 'source-header' }
 )
 
 # ============================================================
@@ -90,10 +98,54 @@ function Get-PinnedHveCoreRef {
     }
 
     $content = Get-Content -Path $Path -Raw
-    $sha = if ($content -match 'UPSTREAM_REF:\s*([0-9a-fA-F]{7,40})') { $Matches[1] } else { $null }
-    $tag = if ($content -match 'hve-core release:\s*(\S+)') { $Matches[1] } else { 'unknown' }
+    $sha = if ($content -match '(?m)^\s*UPSTREAM_REF:\s*[''"]?([0-9a-fA-F]{40})[''"]?\s*(?:#.*)?$') {
+        $Matches[1]
+    }
+    else {
+        $null
+    }
+    $tag = if ($content -match 'hve-core release:\s*([A-Za-z0-9._/+.-]{1,128})(?:\s|$)') { $Matches[1] } else { 'unknown' }
 
     return [ordered]@{ Tag = $tag; Sha = $sha }
+}
+
+function Get-HveCoreFileSource {
+    <#
+    .SYNOPSIS
+        Reads an hve-core source path and commit from a vendored file's header.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][string]$Path
+    )
+
+    if (-not (Test-Path $Path)) {
+        throw [HveCoreFileValidationException]::new("Derived file not found locally: $Path")
+    }
+
+    $content = Get-Content -Path $Path -Raw
+    if ([string]::IsNullOrWhiteSpace($content)) {
+        throw [HveCoreFileValidationException]::new("Derived file is empty: $Path")
+    }
+    $headerEnd = $content.IndexOf('#>')
+    if ($headerEnd -lt 0) {
+        throw [HveCoreFileValidationException]::new("Could not find a comment-based help header in $Path")
+    }
+    $header = $content.Substring(0, $headerEnd + 2)
+    $pattern = 'Adapted from\s+microsoft/hve-core\s+(\S+)\s+as of commit\s+([0-9a-fA-F]{40})(?:\.|\s|$)'
+    $sourceMatches = [regex]::Matches($header, $pattern)
+    if ($sourceMatches.Count -eq 0) {
+        throw [HveCoreFileValidationException]::new("Could not extract hve-core source revision from $Path")
+    }
+    if ($sourceMatches.Count -gt 1) {
+        throw [HveCoreFileValidationException]::new("Found multiple hve-core source revisions in $Path")
+    }
+    $match = $sourceMatches[0]
+
+    return [ordered]@{
+        Path = $match.Groups[1].Value
+        Sha  = $match.Groups[2].Value.ToLowerInvariant()
+    }
 }
 
 function Select-LatestRelease {
@@ -116,19 +168,21 @@ function Select-LatestRelease {
 function Get-DriftState {
     <#
     .SYNOPSIS
-        Classify a derived file's state from its pinned and latest upstream blob SHAs.
-        Returns 'missing-upstream', 'drift', or 'current'.
+        Classify a derived file's state from its baseline and target upstream blob SHAs.
+        Returns 'missing-both', 'missing-baseline', 'missing-target', 'drift', or 'current'.
     #>
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory)][AllowEmptyString()][string]$PinnedUpstreamSha,
-        [Parameter(Mandatory = $false)][AllowEmptyString()][string]$LatestUpstreamSha
+        [Parameter(Mandatory)][AllowEmptyString()][string]$BaselineUpstreamSha,
+        [Parameter(Mandatory)][AllowEmptyString()][string]$TargetUpstreamSha
     )
 
-    $p = $PinnedUpstreamSha.ToLowerInvariant()
-    $l = $LatestUpstreamSha.ToLowerInvariant()
-    if (-not $l) { return 'missing-upstream' }
-    if ($p -ne $l) { return 'drift' }
+    $baseline = $BaselineUpstreamSha.ToLowerInvariant()
+    $target = $TargetUpstreamSha.ToLowerInvariant()
+    if (-not $baseline -and -not $target) { return 'missing-both' }
+    if (-not $baseline) { return 'missing-baseline' }
+    if (-not $target) { return 'missing-target' }
+    if ($baseline -ne $target) { return 'drift' }
     return 'current'
 }
 
@@ -144,41 +198,57 @@ function Get-HveCoreBlobSha {
         [Parameter(Mandatory)][string]$Ref
     )
 
-    $out = gh api "repos/$Repo/contents/$Path`?ref=$Ref" --jq '.sha' 2>&1
-    if ($LASTEXITCODE -eq 0) { return ("$out").Trim() }
+    $out = gh api --method GET "repos/$Repo/contents/$Path" -f "ref=$Ref" --jq '.sha' 2>&1
+    if ($LASTEXITCODE -eq 0) {
+        $sha = ("$out").Trim()
+        if ($sha -notmatch $script:FullShaPattern) {
+            throw "gh api returned an invalid blob SHA for ${Path}@${Ref}: $out"
+        }
+        return $sha
+    }
 
-    # A genuine 404 means the file is absent at that ref (a real 'missing-upstream').
+    # A genuine 404 means the file is absent at that ref.
     # Any other failure (transient, auth, rate limit) must fail loudly rather than
     # masquerade as drift and file a false tracking issue.
-    if ("$out" -match 'HTTP 404|Not Found') { return '' }
+    if ("$out" -match 'HTTP 404') { return '' }
     throw "gh api failed for ${Path}@${Ref}: $out"
 }
 
 function Get-HveCoreFileDrift {
     <#
     .SYNOPSIS
-        Compares a single upstream path's blob SHA at the pinned ref against the latest
-        release and returns a drift record. Local copies are never consulted, so local
+        Compares a single upstream path's blob SHA at its baseline ref against its target
+        ref and returns a drift record. Local copies are never consulted, so local
         adaptations cannot cause false drift.
     #>
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)][string]$Repo,
         [Parameter(Mandatory)][string]$Path,
-        [Parameter(Mandatory)][string]$PinnedRef,
-        [Parameter(Mandatory)][string]$LatestRef
+        [Parameter(Mandatory)][string]$BaselineRef,
+        [Parameter(Mandatory)][string]$TargetRef
     )
 
-    $pinnedUp = Get-HveCoreBlobSha -Repo $Repo -Path $Path -Ref $PinnedRef
-    $latestUp = Get-HveCoreBlobSha -Repo $Repo -Path $Path -Ref $LatestRef
-    $state = Get-DriftState -PinnedUpstreamSha $pinnedUp -LatestUpstreamSha $latestUp
+    $baselineUpstreamSha = Get-HveCoreBlobSha -Repo $Repo -Path $Path -Ref $BaselineRef
+    $targetUpstreamSha = Get-HveCoreBlobSha -Repo $Repo -Path $Path -Ref $TargetRef
+    $state = Get-DriftState -BaselineUpstreamSha $baselineUpstreamSha -TargetUpstreamSha $targetUpstreamSha
+    if ($state -eq 'missing-both') {
+        throw [HveCoreFileValidationException]::new(
+            "Upstream path '$Path' is absent at both baseline ref '$BaselineRef' and target ref '$TargetRef'"
+        )
+    }
+    $baselineRefUrl = [uri]::EscapeDataString($BaselineRef)
+    $targetRefUrl = [uri]::EscapeDataString($TargetRef)
 
     return [ordered]@{
-        Path              = $Path
-        PinnedUpstreamSha = if ($pinnedUp) { $pinnedUp } else { '' }
-        LatestUpstreamSha = if ($latestUp) { $latestUp } else { '' }
-        Drift             = ($state -ne 'current')
-        State             = $state
+        Path                = $Path
+        BaselineUpstreamSha = $baselineUpstreamSha
+        TargetUpstreamSha   = $targetUpstreamSha
+        BaselineRef         = $BaselineRef
+        TargetRef           = $TargetRef
+        ComparisonUrl       = "https://github.com/$Repo/compare/$baselineRefUrl...$targetRefUrl"
+        Drift               = ($state -ne 'current')
+        State               = $state
     }
 }
 
@@ -194,26 +264,133 @@ function Get-HveCoreStateLabel {
 
     switch ($State) {
         'drift'            { return '⚠️ Upstream advanced' }
-        'missing-upstream' { return '❓ Not found at latest release' }
-        default            { return '✅ Current' }
+        'missing-baseline' { return '❓ Not found at baseline ref' }
+        'missing-target'   { return '❓ Not found at target ref' }
+        'error'            { return '❌ Check failed' }
+        'current'          { return '✅ Current' }
+        default {
+            $stateText = ConvertTo-HveCoreMarkdownText -Value $State
+            return "❓ Unknown state: $stateText"
+        }
     }
 }
 
-function Format-HveCoreDriftRow {
+function ConvertTo-HveCoreMarkdownText {
     <#
     .SYNOPSIS
-        Formats one drift record as a markdown table row: path, short pinned/latest blob
-        SHAs, and a status label.
+        Encodes untrusted text for safe use inside a markdown table or link label.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][AllowEmptyString()][string]$Value
+    )
+
+    return ([System.Net.WebUtility]::HtmlEncode($Value) `
+            -replace '\[', '&#91;' `
+            -replace '\]', '&#93;' `
+            -replace '\(', '&#40;' `
+            -replace '\)', '&#41;' `
+            -replace '\|', '&#124;' `
+            -replace '`', '&#96;')
+}
+
+function Get-HveCoreShortSha {
+    <#
+    .SYNOPSIS
+        Shortens a SHA for display while preserving empty and short values.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][AllowEmptyString()][string]$Value
+    )
+
+    return $Value.Substring(0, [Math]::Min($script:ShortShaLength, $Value.Length))
+}
+
+function Format-HveCoreDriftCells {
+    <#
+    .SYNOPSIS
+        Formats the shared display values for a drift record.
     #>
     [CmdletBinding()]
     param(
         [Parameter(Mandatory)][object]$File
     )
 
+    $baselineSha = Get-HveCoreShortSha -Value $File.BaselineUpstreamSha
+    $targetSha = Get-HveCoreShortSha -Value $File.TargetUpstreamSha
+    $baselineRef = if ($File.BaselineRef -match $script:FullShaPattern) {
+        Get-HveCoreShortSha -Value $File.BaselineRef
+    }
+    else {
+        $File.BaselineRef
+    }
+    $targetRef = if ($File.TargetRef -match $script:FullShaPattern) {
+        Get-HveCoreShortSha -Value $File.TargetRef
+    }
+    else {
+        $File.TargetRef
+    }
+    $baselineRef = ConvertTo-HveCoreMarkdownText -Value $baselineRef
+    $targetRef = ConvertTo-HveCoreMarkdownText -Value $targetRef
+
     $status = Get-HveCoreStateLabel -State $File.State
-    $pSha = if ($File.PinnedUpstreamSha) { $File.PinnedUpstreamSha.Substring(0, [Math]::Min(7, $File.PinnedUpstreamSha.Length)) } else { '' }
-    $lSha = if ($File.LatestUpstreamSha) { $File.LatestUpstreamSha.Substring(0, [Math]::Min(7, $File.LatestUpstreamSha.Length)) } else { '' }
-    return "| ``$($File.Path)`` | $pSha | $lSha | $status |"
+    if ($File.State -eq 'error' -and $File.Error) {
+        $message = "$($File.Error)" -replace '[\r\n]+', ' '
+        $message = ConvertTo-HveCoreMarkdownText -Value $message
+        $status = "$status — <code>$message</code>"
+    }
+
+    $baseline = switch ($File.Baseline) {
+        'source-header' { 'Source header' }
+        'release' { 'Release' }
+        default {
+            $baselineText = if ($File.Baseline) { "$($File.Baseline)" } else { 'unknown' }
+            ConvertTo-HveCoreMarkdownText -Value $baselineText
+        }
+    }
+
+    return [ordered]@{
+        Baseline    = $baseline
+        Status      = $status
+        BaselineSha = $baselineSha
+        TargetSha   = $targetSha
+        Comparison  = if ($File.ComparisonUrl) { "[$baselineRef → $targetRef]($($File.ComparisonUrl))" } else { '' }
+    }
+}
+
+function Format-HveCoreDriftRow {
+    <#
+    .SYNOPSIS
+        Formats one drift record as a markdown table row with its upstream comparison,
+        short baseline/target blob SHAs, and status label.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][object]$File
+    )
+
+    $cells = Format-HveCoreDriftCells -File $File
+    return "| ``$($File.Path)`` | $($cells.Baseline) | $($cells.Comparison) | $($cells.BaselineSha) | $($cells.TargetSha) | $($cells.Status) |"
+}
+
+function Get-HveCoreTrustedReleaseUrl {
+    <#
+    .SYNOPSIS
+        Validates that a release URL is an absolute HTTPS URL on github.com.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][AllowNull()][AllowEmptyString()][string]$Value
+    )
+
+    $uri = $null
+    if (-not [uri]::TryCreate($Value, [UriKind]::Absolute, [ref]$uri) -or
+        $uri.Scheme -ne 'https' -or
+        $uri.Host -ne 'github.com') {
+        throw "Unexpected hve-core release URL: $Value"
+    }
+    return $uri.AbsoluteUri
 }
 
 function Format-HveCoreIssueBody {
@@ -230,27 +407,35 @@ function Format-HveCoreIssueBody {
 
     $pin = $Result.Pin
     $files = @($Result.Files)
-    $latestLink = "[$($Result.LatestTag)]($($Result.LatestUrl))"
+    $latestTagText = ConvertTo-HveCoreMarkdownText -Value $Result.LatestTag
+    $latestUrl = Get-HveCoreTrustedReleaseUrl -Value $Result.LatestUrl
+    $latestLink = "[$latestTagText]($latestUrl)"
+    $pinnedTagText = ConvertTo-HveCoreMarkdownText -Value $pin.PinnedTag
+    $latestMainShaText = ConvertTo-HveCoreMarkdownText -Value $Result.LatestMainSha
 
     $fileRows = ($files | ForEach-Object { Format-HveCoreDriftRow -File $_ }) -join "`n"
 
     $compareBase = if ($pin.PinnedTag -ne 'unknown') { $pin.PinnedTag } else { $pin.PinnedSha }
+    $compareBase = [uri]::EscapeDataString($compareBase)
+    $latestTagUrl = [uri]::EscapeDataString($Result.LatestTag)
 
     return @"
 ## hve-core Upstream Freshness Report
 
-Latest reviewed hve-core release: $latestLink
-Drift baseline: ``$($pin.PinnedTag)`` (``UPSTREAM_REF`` in ``$($pin.File)``)
+Latest hve-core release: $latestLink
+Release-file baseline: ``$pinnedTagText`` (``UPSTREAM_REF`` in ``$($pin.File)``)
+Source-header target: ``$latestMainShaText``
+Action required: $($Result.DriftCount) drifted, $($Result.ErrorCount) check errors
 
 ### Derived Files
 
-| File | Pinned Upstream blob | Latest Upstream blob | Status |
-|------|----------------------|----------------------|--------|
+| File | Baseline | Upstream comparison | Baseline upstream blob | Target upstream blob | Status |
+|------|----------|---------------------|------------------------|----------------------|--------|
 $fileRows
 
 ### How to Refresh
 
-Review the upstream changes and port any relevant ones into the locally-adapted copy; do not blindly overwrite (these files carry intentional local adaptations). Compare link: https://github.com/microsoft/hve-core/compare/$compareBase...$($Result.LatestTag)
+Review the upstream changes and port any relevant ones into the locally-adapted copy; do not blindly overwrite (these files carry intentional local adaptations). Each row links to its exact baseline comparison. After refreshing a source-header file, update its ``as of commit`` SHA to the reviewed upstream revision. Release baseline: https://github.com/microsoft/hve-core/compare/$compareBase...$latestTagUrl
 
 Run ``npm run lint:ps`` and ``npm run test:ps`` after changes.
 
@@ -275,21 +460,21 @@ function Format-HveCoreJobSummary {
     $pin = $Result.Pin
     $files = @($Result.Files)
 
-    $fileRows = foreach ($f in $files) {
-        $fStatus = Get-HveCoreStateLabel -State $f.State
-        $pSha = if ($f.PinnedUpstreamSha) { $f.PinnedUpstreamSha.Substring(0, [Math]::Min(7, $f.PinnedUpstreamSha.Length)) } else { '' }
-        $lSha = if ($f.LatestUpstreamSha) { $f.LatestUpstreamSha.Substring(0, [Math]::Min(7, $f.LatestUpstreamSha.Length)) } else { '' }
-        "| $($f.Path) | $pSha | $lSha | $fStatus |"
-    }
+    $latestTagText = ConvertTo-HveCoreMarkdownText -Value $Result.LatestTag
+    $pinnedTagText = ConvertTo-HveCoreMarkdownText -Value $pin.PinnedTag
+    $latestMainShaText = ConvertTo-HveCoreMarkdownText -Value $Result.LatestMainSha
+    $fileRows = $files | ForEach-Object { Format-HveCoreDriftRow -File $_ }
 
     return @"
 ## hve-core Upstream Freshness
 
-Latest release: $($Result.LatestTag)
-Drift baseline: $($pin.PinnedTag)
+Latest release: $latestTagText
+Release-file baseline: $pinnedTagText
+Source-header target: $latestMainShaText
+Action required: $($Result.DriftCount) drifted, $($Result.ErrorCount) check errors
 
-| Derived File | Pinned blob | Latest blob | Status |
-|--------------|-------------|-------------|--------|
+| File | Baseline | Upstream comparison | Baseline upstream blob | Target upstream blob | Status |
+|------|----------|---------------------|------------------------|----------------------|--------|
 $($fileRows -join "`n")
 "@
 }
@@ -302,8 +487,10 @@ function Get-HveCoreTrackingIssue {
     [CmdletBinding()]
     param()
 
-    $n = gh issue list --search $script:IssueSearch --limit 1 --json number --jq '.[0].number // empty'
-    if ($LASTEXITCODE -ne 0) { return $null }
+    $n = gh issue list --search $script:IssueSearch --limit 1 --json number --jq '.[0].number // empty' 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        throw "Could not query existing hve-core freshness issue: $n"
+    }
     return $(if ($n) { $n.Trim() } else { $null })
 }
 
@@ -335,11 +522,59 @@ function Resolve-HveCoreCommitSha {
         [Parameter(Mandatory)][string]$Ref
     )
 
-    $sha = gh api "repos/$Repo/commits/$Ref" --jq '.sha' 2>&1
+    $encodedRef = [uri]::EscapeDataString($Ref)
+    $sha = gh api "repos/$Repo/commits/$encodedRef" --jq '.sha' 2>&1
     if ($LASTEXITCODE -ne 0 -or -not $sha) {
         throw "Could not resolve ref '$Ref' in ${Repo}: $sha"
     }
-    return ("$sha").Trim()
+    $sha = ("$sha").Trim()
+    if ($sha -notmatch $script:FullShaPattern) {
+        throw "Could not resolve ref '$Ref' in ${Repo}: invalid commit SHA '$sha'"
+    }
+    return $sha
+}
+
+function Get-HveCoreFileDriftForBaseline {
+    <#
+    .SYNOPSIS
+        Resolves one derived-file baseline and returns its upstream drift record.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][object]$File,
+        [Parameter(Mandatory)][string]$PinnedReleaseSha,
+        [Parameter(Mandatory)][string]$LatestReleaseSha,
+        [Parameter(Mandatory)][string]$LatestMainSha
+    )
+
+    $path = $File.Path
+    if (-not (Test-Path $path)) {
+        throw [HveCoreFileValidationException]::new("Derived file not found locally: $path")
+    }
+
+    switch ($File.Baseline) {
+        'source-header' {
+            $source = Get-HveCoreFileSource -Path $path
+            if ($source.Path -cne $path) {
+                throw [HveCoreFileValidationException]::new(
+                    "Vendored path '$path' must match its recorded hve-core source path, but the header records '$($source.Path)'"
+                )
+            }
+            $result = Get-HveCoreFileDrift -Repo $script:UpstreamRepo -Path $source.Path -BaselineRef $source.Sha -TargetRef $LatestMainSha
+            if ($result.State -eq 'missing-baseline') {
+                throw [HveCoreFileValidationException]::new(
+                    "Recorded source path '$($source.Path)' is absent at its recorded commit '$($source.Sha)'"
+                )
+            }
+            return $result
+        }
+        'release' {
+            return Get-HveCoreFileDrift -Repo $script:UpstreamRepo -Path $path -BaselineRef $PinnedReleaseSha -TargetRef $LatestReleaseSha
+        }
+        default {
+            throw [HveCoreFileValidationException]::new("Unsupported hve-core baseline '$($File.Baseline)' for $path")
+        }
+    }
 }
 
 # ============================================================
@@ -364,6 +599,8 @@ function Invoke-HveCoreFreshnessCheck {
 
         $latestSha = Resolve-HveCoreCommitSha -Repo $script:UpstreamRepo -Ref $latestTag
         Write-Host "Latest hve-core release: $latestTag ($latestSha)"
+        $latestMainSha = Resolve-HveCoreCommitSha -Repo $script:UpstreamRepo -Ref 'main'
+        Write-Host "Latest hve-core main: $latestMainSha"
 
         $pinRef = Get-PinnedHveCoreRef -Path $script:SetupWorkflow
         if (-not $pinRef -or -not $pinRef.Sha) {
@@ -380,35 +617,90 @@ function Invoke-HveCoreFreshnessCheck {
             File      = $script:SetupWorkflow
         }
 
-        # --- Derived file drift ---
-        $fileResults = foreach ($path in $script:DerivedFiles) {
-            if (-not (Test-Path $path)) {
-                throw "Derived file not found locally: $path"
+        $fileResults = foreach ($file in $script:DerivedFiles) {
+            $path = $file.Path
+            try {
+                $r = Get-HveCoreFileDriftForBaseline -File $file -PinnedReleaseSha $pinRef.Sha -LatestReleaseSha $latestSha -LatestMainSha $latestMainSha
+                $r['Baseline'] = $file.Baseline
+            }
+            catch [HveCoreFileValidationException] {
+                $r = [ordered]@{
+                    Path                = $path
+                    Baseline            = $file.Baseline
+                    BaselineUpstreamSha = ''
+                    TargetUpstreamSha   = ''
+                    BaselineRef         = ''
+                    TargetRef           = ''
+                    ComparisonUrl       = ''
+                    Drift               = $false
+                    State               = 'error'
+                    Error               = $_.Exception.Message
+                }
             }
 
-            $r = Get-HveCoreFileDrift -Repo $script:UpstreamRepo -Path $path -PinnedRef $pinRef.Sha -LatestRef $latestTag
-            $icon = if ($r.Drift) { 'DRIFT' } else { 'OK' }
-            Write-Host "$icon $path : $($r.State)"
+            $status = if ($r.State -eq 'error') { 'ERROR' } elseif ($r.Drift) { 'DRIFT' } else { 'OK' }
+            Write-Host "$status $path : $($r.State)"
             $r
         }
         $fileResults = @($fileResults)
 
         $driftCount = @($fileResults | Where-Object { $_.Drift }).Count
-        $staleCount = $driftCount
-        Write-Host "`nStale: $driftCount / $($fileResults.Count) derived files drifted"
+        $errorCount = @($fileResults | Where-Object { $_.State -eq 'error' }).Count
+        $attentionCount = $driftCount + $errorCount
+        Write-Host "`nAction required: $driftCount drifted, $errorCount check errors"
 
         [ordered]@{
-            LatestTag = $latestTag
-            LatestUrl = $latestUrl
-            Pin       = $pin
-            Files     = $fileResults
+            LatestTag     = $latestTag
+            LatestReleaseSha = $latestSha
+            LatestUrl     = $latestUrl
+            LatestMainSha = $latestMainSha
+            DriftCount    = $driftCount
+            ErrorCount    = $errorCount
+            Pin           = $pin
+            Files         = $fileResults
         } | ConvertTo-Json -Depth 5 | Set-Content $ResultsFile
 
-        return [ordered]@{ StaleCount = $staleCount; LatestTag = $latestTag }
+        return [ordered]@{
+            AttentionCount = $attentionCount
+            DriftCount     = $driftCount
+            ErrorCount     = $errorCount
+            LatestTag      = $latestTag
+        }
     }
     finally {
         Pop-Location
     }
+}
+
+function Write-HveCoreGitHubOutputs {
+    <#
+    .SYNOPSIS
+        Appends freshness counters to a GitHub Actions output file.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][object]$Outcome,
+        [Parameter(Mandatory)][string]$Path
+    )
+
+    "attention-count=$($Outcome.AttentionCount)" >> $Path
+    "drift-count=$($Outcome.DriftCount)" >> $Path
+    "error-count=$($Outcome.ErrorCount)" >> $Path
+}
+
+function Get-HveCoreFreshnessExitCode {
+    <#
+    .SYNOPSIS
+        Returns a non-zero exit code for validation errors while leaving drift as
+        an issue-triaged signal.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)][object]$Outcome
+    )
+
+    if ($Outcome.ErrorCount -gt 0) { return 2 }
+    return 0
 }
 
 function Resolve-RepoRoot {
@@ -440,7 +732,7 @@ if ($MyInvocation.InvocationName -ne '.') {
         Write-Host "Results File   : $ResultsFile"
         Write-Host "Repo Root      : $resolvedRoot"
         Write-Host 'Derived Files :'
-        $script:DerivedFiles | ForEach-Object { Write-Host "  - $_" }
+        $script:DerivedFiles | ForEach-Object { Write-Host "  - $($_.Path) [$($_.Baseline)]" }
         exit 0
     }
 
@@ -454,9 +746,13 @@ if ($MyInvocation.InvocationName -ne '.') {
     try {
         $outcome = Invoke-HveCoreFreshnessCheck -RepoRoot $resolvedRoot -ResultsFile $ResultsFile
         if ($env:GITHUB_OUTPUT) {
-            "stale-count=$($outcome.StaleCount)" >> $env:GITHUB_OUTPUT
+            Write-HveCoreGitHubOutputs -Outcome $outcome -Path $env:GITHUB_OUTPUT
         }
-        exit 0
+        $exitCode = Get-HveCoreFreshnessExitCode -Outcome $outcome
+        if ($exitCode -ne 0) {
+            Write-Error -ErrorAction Continue "hve-core freshness check failed with $($outcome.ErrorCount) validation error(s)"
+        }
+        exit $exitCode
     }
     catch {
         Write-Error $_

--- a/scripts/security/Test-WorkflowPermissions.ps1
+++ b/scripts/security/Test-WorkflowPermissions.ps1
@@ -20,7 +20,7 @@
     and zero false positives.
 
     Adapted from microsoft/hve-core scripts/security/Test-WorkflowPermissions.ps1
-    as of commit 5d663940a203c97d91f30508d41500629d4081cf (2026-06-30). See
+    as of commit 5d663940a203c97d91f30508d41500629d4081cf. See
     docs/security/workflow-permissions.md for the enumerated job-scoped write
     permissions this invariant protects.
 

--- a/scripts/tests/security/Test-HveCoreFreshness.Tests.ps1
+++ b/scripts/tests/security/Test-HveCoreFreshness.Tests.ps1
@@ -6,6 +6,7 @@
 BeforeAll {
     . $PSScriptRoot/../../security/Test-HveCoreFreshness.ps1
 
+    $script:RepoRoot = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
     $script:SetupPath = Join-Path $TestDrive 'copilot-setup-steps.yml'
     @'
       - name: Bootstrap hve-core RPI persona
@@ -14,6 +15,57 @@ BeforeAll {
           UPSTREAM_REF: e69486a5f809ede45c63c0a31358c12912bd5168
         run: echo bootstrap
 '@ | Set-Content -Path $script:SetupPath -Encoding utf8
+}
+
+Describe 'DerivedFiles configuration' -Tag 'Unit' {
+    It 'Tracks the complete derived-file manifest' {
+        $expected = @(
+            'scripts/security/Modules/SecurityHelpers.psm1|release'
+            'scripts/security/Modules/SecurityClasses.psm1|release'
+            'scripts/linting/Modules/LintingHelpers.psm1|release'
+            'scripts/tests/Mocks/GitMocks.psm1|release'
+            'scripts/lib/Modules/CIHelpers.psm1|release'
+            'scripts/linting/Modules/FrontmatterValidation.psm1|release'
+            'scripts/security/Test-WorkflowPermissions.ps1|source-header'
+            'scripts/security/Test-DangerousWorkflow.ps1|source-header'
+        )
+        $actual = @($script:DerivedFiles | ForEach-Object { "$($_.Path)|$($_.Baseline)" })
+
+        $actual | Should -Be $expected
+    }
+
+    It 'Tracks both security linters with source-header baselines' {
+        $sourceFiles = @($script:DerivedFiles | Where-Object { $_.Baseline -eq 'source-header' })
+
+        $sourceFiles.Count | Should -Be 2
+        $sourceFiles.Path | Should -Contain 'scripts/security/Test-WorkflowPermissions.ps1'
+        $sourceFiles.Path | Should -Contain 'scripts/security/Test-DangerousWorkflow.ps1'
+    }
+
+    It 'Parses the provenance header of every source-header entry' {
+        $sourceFiles = @($script:DerivedFiles | Where-Object { $_.Baseline -eq 'source-header' })
+
+        foreach ($file in $sourceFiles) {
+            $source = Get-HveCoreFileSource -Path (Join-Path $script:RepoRoot $file.Path)
+            $source.Path | Should -Be $file.Path
+            $source.Sha | Should -Match '^[0-9a-f]{40}$'
+        }
+    }
+
+    It 'Tracks every security script with an hve-core provenance header' {
+        $provenancePattern = 'Adapted from\s+microsoft/hve-core\s+\S+\s+as of commit\s+[0-9a-fA-F]{40}'
+        $securityRoot = Join-Path $script:RepoRoot 'scripts/security'
+        $provenanceFiles = @(Get-ChildItem -Path $securityRoot -Filter '*.ps1' -Recurse |
+                Where-Object { (Get-Content -Path $_.FullName -Raw) -match $provenancePattern } |
+                ForEach-Object { [IO.Path]::GetRelativePath($script:RepoRoot, $_.FullName).Replace('\', '/') } |
+                Sort-Object)
+        $sourceFiles = @($script:DerivedFiles |
+                Where-Object { $_.Baseline -eq 'source-header' } |
+                ForEach-Object { $_.Path } |
+                Sort-Object)
+
+        $sourceFiles | Should -Be $provenanceFiles
+    }
 }
 
 Describe 'Get-PinnedHveCoreRef' -Tag 'Unit' {
@@ -33,6 +85,21 @@ Describe 'Get-PinnedHveCoreRef' -Tag 'Unit' {
         $ref = Get-PinnedHveCoreRef -Path $p
         $ref.Sha | Should -BeNullOrEmpty
         $ref.Tag | Should -Be 'unknown'
+    }
+
+    It 'Rejects a shortened or suffixed UPSTREAM_REF' {
+        $p = Join-Path $TestDrive 'invalid-ref.yml'
+        "env:`n  UPSTREAM_REF: deadbeef-fix" | Set-Content -Path $p -Encoding utf8
+
+        (Get-PinnedHveCoreRef -Path $p).Sha | Should -BeNullOrEmpty
+    }
+
+    It 'Returns unknown for an invalid release tag' {
+        $p = Join-Path $TestDrive 'invalid-tag.yml'
+        "env:`n  # microsoft/hve-core release: bad](tag`n  UPSTREAM_REF: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" |
+            Set-Content -Path $p -Encoding utf8
+
+        (Get-PinnedHveCoreRef -Path $p).Tag | Should -Be 'unknown'
     }
 }
 
@@ -66,28 +133,131 @@ Describe 'Select-LatestRelease' -Tag 'Unit' {
     }
 }
 
+Describe 'Get-HveCoreFileSource' -Tag 'Unit' {
+    It 'Extracts the source path and normalizes the commit SHA' {
+        $path = Join-Path $TestDrive 'derived.ps1'
+        @'
+<#
+Adapted from microsoft/hve-core scripts/security/Test-DangerousWorkflow.ps1
+as of commit ABCDEF1234567890ABCDEF1234567890ABCDEF12.
+#>
+'@ | Set-Content -Path $path -Encoding utf8
+
+        $source = Get-HveCoreFileSource -Path $path
+
+        $source.Path | Should -Be 'scripts/security/Test-DangerousWorkflow.ps1'
+        $source.Sha | Should -Be 'abcdef1234567890abcdef1234567890abcdef12'
+    }
+
+    It 'Accepts a source path outside scripts/security' {
+        $path = Join-Path $TestDrive 'derived.psm1'
+        @'
+<#
+Adapted from microsoft/hve-core scripts/linting/Modules/Example.psm1
+as of commit ABCDEF1234567890ABCDEF1234567890ABCDEF12.
+#>
+'@ | Set-Content -Path $path -Encoding utf8
+
+        (Get-HveCoreFileSource -Path $path).Path | Should -Be 'scripts/linting/Modules/Example.psm1'
+    }
+
+    It 'Throws when multiple source headers are present' {
+        $path = Join-Path $TestDrive 'duplicate-header.ps1'
+        @'
+<#
+Adapted from microsoft/hve-core scripts/security/First.ps1 as of commit aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.
+Adapted from microsoft/hve-core scripts/security/Second.ps1 as of commit bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb.
+#>
+'@ | Set-Content -Path $path -Encoding utf8
+
+        { Get-HveCoreFileSource -Path $path } | Should -Throw '*multiple*'
+    }
+
+    It 'Throws when the source header is missing' {
+        $path = Join-Path $TestDrive 'missing-header.ps1'
+        '<# no provenance header #>' | Set-Content -Path $path -Encoding utf8
+
+        { Get-HveCoreFileSource -Path $path } | Should -Throw '*Could not extract*'
+    }
+
+    It 'Ignores provenance text outside the comment-based help header' {
+        $path = Join-Path $TestDrive 'body-provenance.ps1'
+        @'
+<#
+.SYNOPSIS
+    No provenance record.
+#>
+Write-Host 'Adapted from microsoft/hve-core scripts/security/Fake.ps1 as of commit aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa.'
+'@ | Set-Content -Path $path -Encoding utf8
+
+        { Get-HveCoreFileSource -Path $path } | Should -Throw '*Could not extract*'
+    }
+
+    It 'Rejects a truncated commit SHA' {
+        $path = Join-Path $TestDrive 'short-sha.ps1'
+        '<# Adapted from microsoft/hve-core scripts/security/Fake.ps1 as of commit abcdef1. #>' |
+            Set-Content -Path $path -Encoding utf8
+
+        { Get-HveCoreFileSource -Path $path } | Should -Throw '*Could not extract*'
+    }
+
+    It 'Rejects a provenance header from another repository' {
+        $path = Join-Path $TestDrive 'foreign-repo.ps1'
+        '<# Adapted from example/hve-core scripts/security/Fake.ps1 as of commit aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa. #>' |
+            Set-Content -Path $path -Encoding utf8
+
+        { Get-HveCoreFileSource -Path $path } | Should -Throw '*Could not extract*'
+    }
+
+    It 'Throws when the file does not exist' {
+        { Get-HveCoreFileSource -Path (Join-Path $TestDrive 'missing.ps1') } | Should -Throw '*not found locally*'
+    }
+
+    It 'Classifies an empty file as a validation failure' {
+        $path = Join-Path $TestDrive 'empty.ps1'
+        '' | Set-Content -Path $path -NoNewline
+
+        { Get-HveCoreFileSource -Path $path } | Should -Throw -ExceptionType ([HveCoreFileValidationException])
+    }
+}
+
 Describe 'Get-DriftState' -Tag 'Unit' {
-    It 'Returns current when pinned and latest upstream SHAs match' {
-        Get-DriftState -PinnedUpstreamSha 'abc123' -LatestUpstreamSha 'abc123' | Should -Be 'current'
+    It 'Returns current when baseline and target upstream SHAs match' {
+        Get-DriftState -BaselineUpstreamSha 'abc123' -TargetUpstreamSha 'abc123' | Should -Be 'current'
     }
 
     It 'Returns current when SHAs match case-insensitively' {
-        Get-DriftState -PinnedUpstreamSha 'ABC123' -LatestUpstreamSha 'abc123' | Should -Be 'current'
+        Get-DriftState -BaselineUpstreamSha 'ABC123' -TargetUpstreamSha 'abc123' | Should -Be 'current'
     }
 
     It 'Returns drift when SHAs differ' {
-        Get-DriftState -PinnedUpstreamSha 'abc123' -LatestUpstreamSha 'def456' | Should -Be 'drift'
+        Get-DriftState -BaselineUpstreamSha 'abc123' -TargetUpstreamSha 'def456' | Should -Be 'drift'
     }
 
-    It 'Returns missing-upstream when the latest upstream SHA is empty' {
-        Get-DriftState -PinnedUpstreamSha 'abc123' -LatestUpstreamSha '' | Should -Be 'missing-upstream'
+    It 'Returns missing-target when the target upstream SHA is empty' {
+        Get-DriftState -BaselineUpstreamSha 'abc123' -TargetUpstreamSha '' | Should -Be 'missing-target'
+    }
+
+    It 'Returns missing-baseline when the baseline upstream SHA is empty' {
+        Get-DriftState -BaselineUpstreamSha '' -TargetUpstreamSha 'abc123' | Should -Be 'missing-baseline'
+    }
+
+    It 'Returns missing-both when neither upstream SHA exists' {
+        Get-DriftState -BaselineUpstreamSha '' -TargetUpstreamSha '' | Should -Be 'missing-both'
     }
 }
 
 Describe 'Get-HveCoreBlobSha' -Tag 'Unit' {
     It 'Returns the trimmed blob SHA on success' {
-        Mock gh { $global:LASTEXITCODE = 0; 'abc123def456' }
-        Get-HveCoreBlobSha -Repo 'o/r' -Path 'p' -Ref 'ref' | Should -Be 'abc123def456'
+        Mock gh { $global:LASTEXITCODE = 0; 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' }
+        Get-HveCoreBlobSha -Repo 'o/r' -Path 'p' -Ref 'ref' |
+            Should -Be 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+    }
+
+    It 'Throws when a successful response is not exactly one blob SHA' {
+        Mock gh { $global:LASTEXITCODE = 0; "warning`naaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" }
+
+        { Get-HveCoreBlobSha -Repo 'o/r' -Path 'p' -Ref 'ref' } | Should -Throw '*invalid blob SHA*'
     }
 
     It 'Returns empty string on a genuine 404 (file absent at ref)' {
@@ -111,34 +281,253 @@ Describe 'Resolve-HveCoreCommitSha' -Tag 'Unit' {
         Mock gh { $global:LASTEXITCODE = 1; 'gh: Not Found (HTTP 404)' }
         { Resolve-HveCoreCommitSha -Repo 'o/r' -Ref 'definitely-not-a-ref' } | Should -Throw
     }
+
+    It 'Throws when a successful response is not exactly one commit SHA' {
+        Mock gh { $global:LASTEXITCODE = 0; "warning`ndeadbeefdeadbeefdeadbeefdeadbeefdeadbeef" }
+
+        { Resolve-HveCoreCommitSha -Repo 'o/r' -Ref 'v1' } | Should -Throw '*invalid commit SHA*'
+    }
 }
 
 Describe 'Get-HveCoreFileDrift' -Tag 'Unit' {
     It 'Reports drift when the upstream blob changed between refs' {
         Mock gh {
             $global:LASTEXITCODE = 0
-            if ("$args" -match 'ref=PIN') { 'aaaaaaa' } else { 'bbbbbbb' }
+            if ("$args" -match 'ref=PIN') { 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' }
+            else { 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' }
         }
-        $r = Get-HveCoreFileDrift -Repo 'o/r' -Path 'p' -PinnedRef 'PIN' -LatestRef 'LATEST'
+        $r = Get-HveCoreFileDrift -Repo 'o/r' -Path 'p' -BaselineRef 'PIN' -TargetRef 'LATEST'
         $r.State | Should -Be 'drift'
         $r.Drift | Should -BeTrue
-        $r.PinnedUpstreamSha | Should -Be 'aaaaaaa'
-        $r.LatestUpstreamSha | Should -Be 'bbbbbbb'
+        $r.BaselineUpstreamSha | Should -Be 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+        $r.TargetUpstreamSha | Should -Be 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+        $r.BaselineRef | Should -Be 'PIN'
+        $r.TargetRef | Should -Be 'LATEST'
+        $r.ComparisonUrl | Should -Be 'https://github.com/o/r/compare/PIN...LATEST'
     }
 
     It 'Reports current when the upstream blob is unchanged' {
-        Mock gh { $global:LASTEXITCODE = 0; 'samesha' }
-        $r = Get-HveCoreFileDrift -Repo 'o/r' -Path 'p' -PinnedRef 'PIN' -LatestRef 'LATEST'
+        Mock gh { $global:LASTEXITCODE = 0; 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' }
+        $r = Get-HveCoreFileDrift -Repo 'o/r' -Path 'p' -BaselineRef 'PIN' -TargetRef 'LATEST'
         $r.State | Should -Be 'current'
         $r.Drift | Should -BeFalse
     }
 
-    It 'Reports missing-upstream when the file is absent at the latest ref' {
+    It 'Reports missing-target when the file is absent at the target ref' {
         Mock gh {
             if ("$args" -match 'ref=LATEST') { $global:LASTEXITCODE = 1; 'gh: Not Found (HTTP 404)' }
-            else { $global:LASTEXITCODE = 0; 'aaaaaaa' }
+            else { $global:LASTEXITCODE = 0; 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' }
         }
-        (Get-HveCoreFileDrift -Repo 'o/r' -Path 'p' -PinnedRef 'PIN' -LatestRef 'LATEST').State | Should -Be 'missing-upstream'
+        (Get-HveCoreFileDrift -Repo 'o/r' -Path 'p' -BaselineRef 'PIN' -TargetRef 'LATEST').State | Should -Be 'missing-target'
+    }
+
+    It 'Reports missing-baseline when the file is absent at the baseline ref' {
+        Mock gh {
+            if ("$args" -match 'ref=PIN') { $global:LASTEXITCODE = 1; 'gh: Not Found (HTTP 404)' }
+            else { $global:LASTEXITCODE = 0; 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' }
+        }
+
+        $r = Get-HveCoreFileDrift -Repo 'o/r' -Path 'p' -BaselineRef 'PIN' -TargetRef 'LATEST'
+        $r.State | Should -Be 'missing-baseline'
+        $r.Drift | Should -BeTrue
+    }
+
+    It 'Classifies a path missing at both refs as a validation failure' {
+        Mock gh { $global:LASTEXITCODE = 1; 'gh: Not Found (HTTP 404)' }
+
+        {
+            Get-HveCoreFileDrift -Repo 'o/r' -Path 'p' -BaselineRef 'PIN' -TargetRef 'LATEST'
+        } | Should -Throw -ExceptionType ([HveCoreFileValidationException])
+    }
+
+    It 'URL-encodes refs in comparison links' {
+        Mock gh { $global:LASTEXITCODE = 0; 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' }
+
+        $r = Get-HveCoreFileDrift -Repo 'o/r' -Path 'p' -BaselineRef 'v1](https://evil.example)' -TargetRef 'main'
+
+        $r.ComparisonUrl | Should -Not -Match '\]\('
+        $r.ComparisonUrl | Should -Match 'v1%5D%28https%3A%2F%2Fevil\.example%29'
+    }
+}
+
+Describe 'Get-HveCoreFileDriftForBaseline' -Tag 'Unit' {
+    BeforeEach {
+        Mock Test-Path { $true }
+    }
+
+    It 'Uses the source-header SHA and resolved main SHA' {
+        $path = 'scripts/security/Test-DangerousWorkflow.ps1'
+        $sourceSha = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+        $mainSha = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+        $file = [pscustomobject]@{ Path = $path; Baseline = 'source-header' }
+        Mock Get-HveCoreFileSource { [pscustomobject]@{ Path = $path; Sha = $sourceSha } }
+        Mock Get-HveCoreFileDrift { [pscustomobject]@{ State = 'current'; Drift = $false } }
+
+        $null = Get-HveCoreFileDriftForBaseline -File $file -PinnedReleaseSha 'pin' -LatestReleaseSha 'release-sha' -LatestMainSha $mainSha
+
+        Should -Invoke Get-HveCoreFileDrift -Times 1 -Exactly -ParameterFilter {
+            $Path -eq $path -and $BaselineRef -eq $sourceSha -and $TargetRef -eq $mainSha
+        }
+    }
+
+    It 'Uses the release pin and resolved latest release SHA' {
+        $path = 'scripts/security/Modules/SecurityHelpers.psm1'
+        $file = [pscustomobject]@{ Path = $path; Baseline = 'release' }
+        Mock Get-HveCoreFileSource { throw 'source parser must not run' }
+        Mock Get-HveCoreFileDrift { [pscustomobject]@{ State = 'current'; Drift = $false } }
+
+        $null = Get-HveCoreFileDriftForBaseline -File $file -PinnedReleaseSha 'pin' -LatestReleaseSha 'release-sha' -LatestMainSha 'main'
+
+        Should -Invoke Get-HveCoreFileDrift -Times 1 -Exactly -ParameterFilter {
+            $Path -eq $path -and $BaselineRef -eq 'pin' -and $TargetRef -eq 'release-sha'
+        }
+        Should -Invoke Get-HveCoreFileSource -Times 0 -Exactly
+    }
+
+    It 'Throws when the recorded upstream path differs from the local path' {
+        $file = [pscustomobject]@{
+            Path = 'scripts/security/Test-DangerousWorkflow.ps1'
+            Baseline = 'source-header'
+        }
+        Mock Get-HveCoreFileSource {
+            [pscustomobject]@{
+                Path = 'scripts/security/Other.ps1'
+                Sha = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+            }
+        }
+
+        {
+            Get-HveCoreFileDriftForBaseline -File $file -PinnedReleaseSha 'pin' -LatestReleaseSha 'release-sha' -LatestMainSha 'main'
+        } | Should -Throw '*must match its recorded*'
+    }
+
+    It 'Rejects a case-mismatched recorded upstream path' {
+        $file = [pscustomobject]@{
+            Path = 'scripts/security/Test-DangerousWorkflow.ps1'
+            Baseline = 'source-header'
+        }
+        Mock Get-HveCoreFileSource {
+            [pscustomobject]@{
+                Path = 'scripts/security/test-dangerousworkflow.ps1'
+                Sha = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+            }
+        }
+
+        {
+            Get-HveCoreFileDriftForBaseline -File $file -PinnedReleaseSha 'pin' -LatestReleaseSha 'release-sha' -LatestMainSha 'main'
+        } | Should -Throw '*must match its recorded*'
+    }
+
+    It 'Throws on an unsupported baseline' {
+        $file = [pscustomobject]@{ Path = 'scripts/security/Test-DangerousWorkflow.ps1'; Baseline = 'bogus' }
+
+        {
+            Get-HveCoreFileDriftForBaseline -File $file -PinnedReleaseSha 'pin' -LatestReleaseSha 'release-sha' -LatestMainSha 'main'
+        } | Should -Throw '*Unsupported hve-core baseline*'
+    }
+
+    It 'Throws when the derived file is missing locally' {
+        Mock Test-Path { $false }
+        $file = [pscustomobject]@{ Path = 'scripts/security/Missing.ps1'; Baseline = 'release' }
+
+        {
+            Get-HveCoreFileDriftForBaseline -File $file -PinnedReleaseSha 'pin' -LatestReleaseSha 'release-sha' -LatestMainSha 'main'
+        } | Should -Throw '*not found locally*'
+    }
+
+    It 'Rejects a source header whose recorded path is absent at its recorded commit' {
+        $path = 'scripts/security/Test-DangerousWorkflow.ps1'
+        $file = [pscustomobject]@{ Path = $path; Baseline = 'source-header' }
+        Mock Get-HveCoreFileSource {
+            [pscustomobject]@{ Path = $path; Sha = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' }
+        }
+        Mock Get-HveCoreFileDrift {
+            [pscustomobject]@{ State = 'missing-baseline'; Drift = $true }
+        }
+
+        {
+            Get-HveCoreFileDriftForBaseline -File $file -PinnedReleaseSha 'pin' -LatestReleaseSha 'release-sha' -LatestMainSha 'main'
+        } | Should -Throw '*absent at its recorded commit*'
+    }
+}
+
+Describe 'Format-HveCoreDriftCells' -Tag 'Unit' {
+    It 'Renders missing-target records with short and empty SHAs' {
+        $file = [pscustomobject]@{
+            Baseline            = 'source-header'
+            BaselineUpstreamSha = 'abc'
+            TargetUpstreamSha   = ''
+            BaselineRef         = 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
+            TargetRef           = 'main'
+            State               = 'missing-target'
+            ComparisonUrl       = ''
+        }
+
+        $cells = Format-HveCoreDriftCells -File $file
+
+        $cells.Baseline | Should -Be 'Source header'
+        $cells.BaselineSha | Should -Be 'abc'
+        $cells.TargetSha | Should -BeExactly ''
+        $cells.Comparison | Should -BeExactly ''
+        $cells.Status | Should -Match 'Not found at target ref'
+    }
+
+    It 'Escapes error details for markdown output' {
+        $file = [pscustomobject]@{
+            Baseline            = 'release'
+            BaselineUpstreamSha = ''
+            TargetUpstreamSha   = ''
+            BaselineRef         = ''
+            TargetRef           = ''
+            State               = 'error'
+            Error               = "bad | value`nnext"
+            ComparisonUrl       = ''
+        }
+
+        (Format-HveCoreDriftCells -File $file).Status | Should -Be '❌ Check failed — <code>bad &#124; value next</code>'
+    }
+
+    It 'Escapes ref text in comparison links' {
+        $file = [pscustomobject]@{
+            Baseline            = 'release'
+            BaselineUpstreamSha = 'abc123'
+            TargetUpstreamSha   = 'def456'
+            BaselineRef         = 'v1](https://evil.example)'
+            TargetRef           = 'main'
+            State               = 'drift'
+            ComparisonUrl       = 'https://github.com/o/r/compare/v1%5D%28https%3A%2F%2Fevil.example%29...main'
+        }
+
+        $comparison = (Format-HveCoreDriftCells -File $file).Comparison
+
+        $comparison | Should -Not -Match '\]\(https://evil'
+        $comparison | Should -Match 'v1&#93;&#40;https://evil\.example&#41;'
+    }
+
+    It 'Escapes an unrecognized baseline label' {
+        $file = [pscustomobject]@{
+            Baseline            = 'weird](https://evil.example)'
+            BaselineUpstreamSha = ''
+            TargetUpstreamSha   = ''
+            BaselineRef         = ''
+            TargetRef           = ''
+            State               = 'error'
+            ComparisonUrl       = ''
+        }
+
+        $baseline = (Format-HveCoreDriftCells -File $file).Baseline
+
+        $baseline | Should -Match '&#93;&#40;'
+        $baseline | Should -Not -Match '\]\(https://evil'
+    }
+}
+
+Describe 'ConvertTo-HveCoreMarkdownText' -Tag 'Unit' {
+    It 'Encodes HTML and markdown metacharacters exactly once' {
+        $encoded = ConvertTo-HveCoreMarkdownText -Value '<b>a|b`c[d](e)</b>'
+
+        $encoded | Should -Be '&lt;b&gt;a&#124;b&#96;c&#91;d&#93;&#40;e&#41;&lt;/b&gt;'
+        $encoded | Should -Not -Match '&amp;#'
     }
 }
 
@@ -146,18 +535,24 @@ Describe 'Format-HveCoreIssueBody' -Tag 'Unit' {
     It 'Formats the issue body with correct markers and links' {
         $r = [pscustomobject]@{
             LatestTag = 'hve-core-v9'
-            LatestUrl = 'http://u'
+            LatestUrl = 'https://github.com/microsoft/hve-core/releases/tag/hve-core-v9'
+            DriftCount = 1
+            ErrorCount = 0
             Pin = [pscustomobject]@{
                 PinnedTag = 'hve-core-v1'
                 File = '.github/workflows/copilot-setup-steps.yml'
             }
             Files = @(
                 [pscustomobject]@{
-                    Path = 'scripts/x.psm1'
-                    PinnedUpstreamSha = '1111111'
-                    LatestUpstreamSha = '2222222'
-                    Drift = $true
-                    State = 'drift'
+                    Path                = 'scripts/x.psm1'
+                    Baseline            = 'release'
+                    BaselineUpstreamSha = '1111111'
+                    TargetUpstreamSha   = '2222222'
+                    BaselineRef         = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+                    TargetRef           = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+                    ComparisonUrl       = 'https://github.com/microsoft/hve-core/compare/a...b'
+                    Drift               = $true
+                    State               = 'drift'
                 }
             )
         }
@@ -167,13 +562,18 @@ Describe 'Format-HveCoreIssueBody' -Tag 'Unit' {
         $body | Should -Match 'hve-core-v9'
         $body | Should -Match 'scripts/x\.psm1'
         $body | Should -Match 'compare/hve-core-v1\.\.\.hve-core-v9'
+        $body | Should -Match '\[aaaaaaa → bbbbbbb\]\(https://github\.com/microsoft/hve-core/compare/a\.\.\.b\)'
+        $body | Should -Match 'Action required: 1 drifted, 0 check errors'
+        $body | Should -Match '\| File \| Baseline \| Upstream comparison \| Baseline upstream blob \| Target upstream blob \| Status \|'
         $body | Should -Not -Match '[Pp]ersona'
     }
 
     It 'Falls back to the pinned SHA in the compare link when the tag is unknown' {
         $r = [pscustomobject]@{
             LatestTag = 'hve-core-v9'
-            LatestUrl = 'http://u'
+            LatestUrl = 'https://github.com/microsoft/hve-core/releases/tag/hve-core-v9'
+            DriftCount = 1
+            ErrorCount = 0
             Pin = [pscustomobject]@{
                 PinnedTag = 'unknown'
                 PinnedSha = 'abcdef1234567890'
@@ -181,11 +581,15 @@ Describe 'Format-HveCoreIssueBody' -Tag 'Unit' {
             }
             Files = @(
                 [pscustomobject]@{
-                    Path = 'scripts/x.psm1'
-                    PinnedUpstreamSha = '1111111'
-                    LatestUpstreamSha = '2222222'
-                    Drift = $true
-                    State = 'drift'
+                    Path                = 'scripts/x.psm1'
+                    Baseline            = 'source-header'
+                    BaselineUpstreamSha = '1111111'
+                    TargetUpstreamSha   = '2222222'
+                    BaselineRef         = 'hve-core-v1'
+                    TargetRef           = 'main'
+                    ComparisonUrl       = 'https://github.com/microsoft/hve-core/compare/hve-core-v1...main'
+                    Drift               = $true
+                    State               = 'drift'
                 }
             )
         }
@@ -194,24 +598,73 @@ Describe 'Format-HveCoreIssueBody' -Tag 'Unit' {
         $body | Should -Match 'compare/abcdef1234567890\.\.\.hve-core-v9'
         $body | Should -Not -Match 'compare/unknown'
     }
+
+    It 'Rejects a release URL outside GitHub' {
+        $r = [pscustomobject]@{
+            LatestTag = 'hve-core-v9'
+            LatestUrl = 'https://evil.example/release'
+            DriftCount = 0
+            ErrorCount = 0
+            Pin = [pscustomobject]@{
+                PinnedTag = 'hve-core-v1'
+                File = '.github/workflows/copilot-setup-steps.yml'
+            }
+            Files = @()
+        }
+
+        {
+            Format-HveCoreIssueBody -Result $r -RunUrl 'http://run' -CheckDate '2026-01-01'
+        } | Should -Throw '*Unexpected hve-core release URL*'
+    }
+
+    It 'Rejects non-HTTPS and lookalike release URLs' -ForEach @(
+        'http://github.com/microsoft/hve-core/releases/tag/v1'
+        'https://github.com.evil.example/microsoft/hve-core/releases/tag/v1'
+        'not-a-url'
+        '//github.com/microsoft/hve-core/releases/tag/v1'
+    ) {
+        $r = [pscustomobject]@{
+            LatestTag = 'hve-core-v9'
+            LatestUrl = $_
+            LatestMainSha = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+            DriftCount = 0
+            ErrorCount = 0
+            Pin = [pscustomobject]@{
+                PinnedTag = 'hve-core-v1'
+                File = '.github/workflows/copilot-setup-steps.yml'
+            }
+            Files = @()
+        }
+
+        {
+            Format-HveCoreIssueBody -Result $r -RunUrl 'http://run' -CheckDate '2026-01-01'
+        } | Should -Throw '*Unexpected hve-core release URL*'
+    }
 }
 
 Describe 'Format-HveCoreJobSummary' -Tag 'Unit' {
     It 'Formats the job summary correctly' {
         $r = [pscustomobject]@{
             LatestTag = 'hve-core-v9'
-            LatestUrl = 'http://u'
+            LatestUrl = 'https://github.com/microsoft/hve-core/releases/tag/hve-core-v9'
+            LatestMainSha = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+            DriftCount = 1
+            ErrorCount = 0
             Pin = [pscustomobject]@{
                 PinnedTag = 'hve-core-v1'
                 File = '.github/workflows/copilot-setup-steps.yml'
             }
             Files = @(
                 [pscustomobject]@{
-                    Path = 'scripts/x.psm1'
-                    PinnedUpstreamSha = '1111111'
-                    LatestUpstreamSha = '2222222'
-                    Drift = $true
-                    State = 'drift'
+                    Path                = 'scripts/x.psm1'
+                    Baseline            = 'source-header'
+                    BaselineUpstreamSha = '1111111'
+                    TargetUpstreamSha   = '2222222'
+                    BaselineRef         = 'hve-core-v1'
+                    TargetRef           = 'main'
+                    ComparisonUrl       = 'https://github.com/microsoft/hve-core/compare/hve-core-v1...main'
+                    Drift               = $true
+                    State               = 'drift'
                 }
             )
         }
@@ -220,7 +673,316 @@ Describe 'Format-HveCoreJobSummary' -Tag 'Unit' {
         $summary | Should -Match 'hve-core-v9'
         $summary | Should -Match 'scripts/x\.psm1'
         $summary | Should -Match '⚠️ Upstream advanced'
-        $summary | Should -Match '\| Pinned blob \| Latest blob \|'
+        $summary | Should -Match '\| File \| Baseline \| Upstream comparison \| Baseline upstream blob \| Target upstream blob \| Status \|'
+        $summary | Should -Match '\| Source header \|'
         $summary | Should -Match '\| 1111111 \| 2222222 \|'
+        $summary | Should -Match '\[hve-core-v1 → main\]\(https://github\.com/microsoft/hve-core/compare/hve-core-v1\.\.\.main\)'
+        $summary | Should -Match 'Source-header target: b{40}'
+        $summary | Should -Match 'Action required: 1 drifted, 0 check errors'
+    }
+
+    It 'Escapes untrusted refs in the job summary' {
+        $r = [pscustomobject]@{
+            LatestTag = 'v1|spoof'
+            LatestMainSha = 'main](https://evil.example)'
+            DriftCount = 0
+            ErrorCount = 0
+            Pin = [pscustomobject]@{ PinnedTag = 'pin`value' }
+            Files = @()
+        }
+
+        $summary = Format-HveCoreJobSummary -Result $r
+
+        $summary | Should -Match 'v1&#124;spoof'
+        $summary | Should -Match 'main&#93;&#40;https://evil\.example&#41;'
+        $summary | Should -Match 'pin&#96;value'
+    }
+}
+
+Describe 'Get-HveCoreReleases' -Tag 'Unit' {
+    It 'Parses release objects from the GitHub API' {
+        Mock gh {
+            $global:LASTEXITCODE = 0
+            '[{"tag_name":"v1","draft":false},{"tag_name":"v2","draft":true}]'
+        }
+
+        $releases = @(Get-HveCoreReleases -Repo 'o/r')
+
+        $releases.Count | Should -Be 2
+        $releases[0].tag_name | Should -Be 'v1'
+        Should -Invoke gh -Times 1 -Exactly -ParameterFilter {
+            "$args" -match 'repos/o/r/releases\?per_page=30'
+        }
+    }
+
+    It 'Throws when the GitHub API fails' {
+        Mock gh { $global:LASTEXITCODE = 1; 'HTTP 403 rate limit' }
+
+        { Get-HveCoreReleases -Repo 'o/r' } | Should -Throw '*cannot produce reliable results*'
+    }
+
+    It 'Throws when the GitHub API returns no payload' {
+        Mock gh { $global:LASTEXITCODE = 0; '' }
+
+        { Get-HveCoreReleases -Repo 'o/r' } | Should -Throw '*cannot produce reliable results*'
+    }
+}
+
+Describe 'Invoke-HveCoreFreshnessCheck' -Tag 'Unit' {
+    BeforeEach {
+        Mock Get-HveCoreReleases {
+            @([pscustomobject]@{
+                    tag_name = 'hve-core-v9'
+                    draft = $false
+                    created_at = '2026-08-01T00:00:00Z'
+                    html_url = 'https://github.com/microsoft/hve-core/releases/tag/hve-core-v9'
+                })
+        }
+        Mock Resolve-HveCoreCommitSha {
+            if ($Ref -eq 'main') { 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' }
+            else { 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' }
+        }
+        Mock Get-PinnedHveCoreRef {
+            [ordered]@{
+                Tag = 'hve-core-v1'
+                Sha = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+            }
+        }
+
+        Mock Get-HveCoreFileDriftForBaseline {
+            [ordered]@{
+                Path                = $File.Path
+                BaselineUpstreamSha = '1111111'
+                TargetUpstreamSha   = '1111111'
+                BaselineRef         = 'pin'
+                TargetRef           = 'target'
+                ComparisonUrl       = 'https://example.test/compare'
+                Drift               = $false
+                State               = 'current'
+            }
+        }
+    }
+
+    It 'Writes the resolved main SHA and all configured files to results JSON' {
+        $resultsFile = Join-Path $TestDrive 'results.json'
+
+        $outcome = Invoke-HveCoreFreshnessCheck -RepoRoot $script:RepoRoot -ResultsFile $resultsFile
+        $result = Get-Content -Path $resultsFile -Raw | ConvertFrom-Json
+
+        $outcome.AttentionCount | Should -Be 0
+        $outcome.DriftCount | Should -Be 0
+        $outcome.ErrorCount | Should -Be 0
+        $result.LatestMainSha | Should -Be 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
+        $result.LatestReleaseSha | Should -Be 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+        $result.DriftCount | Should -Be 0
+        $result.ErrorCount | Should -Be 0
+        @($result.Files).Count | Should -Be $script:DerivedFiles.Count
+        @($result.Files | Where-Object { $_.Baseline -eq 'source-header' }).Count | Should -Be 2
+    }
+
+    It 'Records a file-level error and continues checking remaining files' {
+        $resultsFile = Join-Path $TestDrive 'results-with-error.json'
+        Mock Get-HveCoreFileDriftForBaseline {
+            if ($File.Path -eq 'scripts/security/Test-DangerousWorkflow.ps1') {
+                throw [HveCoreFileValidationException]::new('invalid provenance header')
+            }
+            [ordered]@{
+                Path                = $File.Path
+                BaselineUpstreamSha = '1111111'
+                TargetUpstreamSha   = '1111111'
+                BaselineRef         = 'pin'
+                TargetRef           = 'target'
+                ComparisonUrl       = 'https://example.test/compare'
+                Drift               = $false
+                State               = 'current'
+            }
+        }
+
+        $outcome = Invoke-HveCoreFreshnessCheck -RepoRoot $script:RepoRoot -ResultsFile $resultsFile
+        $result = Get-Content -Path $resultsFile -Raw | ConvertFrom-Json
+        $failed = $result.Files | Where-Object { $_.Path -eq 'scripts/security/Test-DangerousWorkflow.ps1' }
+
+        $outcome.AttentionCount | Should -Be 1
+        $outcome.DriftCount | Should -Be 0
+        $outcome.ErrorCount | Should -Be 1
+        $result.DriftCount | Should -Be 0
+        $result.ErrorCount | Should -Be 1
+        @($result.Files).Count | Should -Be $script:DerivedFiles.Count
+        $failed.State | Should -Be 'error'
+        $failed.Error | Should -Be 'invalid provenance header'
+        $failed.Drift | Should -BeFalse
+    }
+
+    It 'Counts drift and validation errors independently' {
+        $resultsFile = Join-Path $TestDrive 'results-with-drift-and-error.json'
+        Mock Get-HveCoreFileDriftForBaseline {
+            if ($File.Path -eq 'scripts/security/Test-DangerousWorkflow.ps1') {
+                throw [HveCoreFileValidationException]::new('invalid provenance header')
+            }
+            $isDrift = $File.Path -eq 'scripts/security/Test-WorkflowPermissions.ps1'
+            [ordered]@{
+                Path                = $File.Path
+                BaselineUpstreamSha = '1111111111111111111111111111111111111111'
+                TargetUpstreamSha   = if ($isDrift) { '2222222222222222222222222222222222222222' } else { '1111111111111111111111111111111111111111' }
+                BaselineRef         = 'pin'
+                TargetRef           = 'target'
+                ComparisonUrl       = 'https://example.test/compare'
+                Drift               = $isDrift
+                State               = if ($isDrift) { 'drift' } else { 'current' }
+            }
+        }
+
+        $outcome = Invoke-HveCoreFreshnessCheck -RepoRoot $script:RepoRoot -ResultsFile $resultsFile
+        $result = Get-Content -Path $resultsFile -Raw | ConvertFrom-Json
+
+        $outcome.AttentionCount | Should -Be 2
+        $outcome.DriftCount | Should -Be 1
+        $outcome.ErrorCount | Should -Be 1
+        $result.DriftCount | Should -Be 1
+        $result.ErrorCount | Should -Be 1
+    }
+
+    It 'Throws before checking files when UPSTREAM_REF is unavailable' {
+        $resultsFile = Join-Path $TestDrive 'results-without-pin.json'
+        Mock Get-PinnedHveCoreRef { $null }
+
+        {
+            Invoke-HveCoreFreshnessCheck -RepoRoot $script:RepoRoot -ResultsFile $resultsFile
+        } | Should -Throw '*Could not extract UPSTREAM_REF*'
+        Should -Invoke Get-HveCoreFileDriftForBaseline -Times 0 -Exactly
+        Test-Path $resultsFile | Should -BeFalse
+    }
+
+    It 'Throws before checking files when the pinned ref does not resolve' {
+        $resultsFile = Join-Path $TestDrive 'results-with-invalid-pin.json'
+        Mock Resolve-HveCoreCommitSha {
+            if ($Ref -eq 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa') {
+                throw 'invalid pinned ref'
+            }
+            if ($Ref -eq 'main') { 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' }
+            else { 'cccccccccccccccccccccccccccccccccccccccc' }
+        }
+
+        {
+            Invoke-HveCoreFreshnessCheck -RepoRoot $script:RepoRoot -ResultsFile $resultsFile
+        } | Should -Throw '*invalid pinned ref*'
+        Should -Invoke Get-HveCoreFileDriftForBaseline -Times 0 -Exactly
+        Test-Path $resultsFile | Should -BeFalse
+    }
+
+    It 'Propagates upstream failures instead of reporting false drift' {
+        $resultsFile = Join-Path $TestDrive 'results-with-api-error.json'
+        Mock Get-HveCoreFileDriftForBaseline {
+            throw 'gh api failed for scripts/security/Test-DangerousWorkflow.ps1@main'
+        }
+
+        {
+            Invoke-HveCoreFreshnessCheck -RepoRoot $script:RepoRoot -ResultsFile $resultsFile
+        } | Should -Throw '*gh api failed*'
+        Test-Path $resultsFile | Should -BeFalse
+    }
+}
+
+Describe 'Get-HveCoreTrackingIssue' -Tag 'Unit' {
+    It 'Returns the trimmed issue number' {
+        Mock gh { $global:LASTEXITCODE = 0; " 42 `n" }
+
+        Get-HveCoreTrackingIssue | Should -Be '42'
+    }
+
+    It 'Returns null when no issue exists' {
+        Mock gh { $global:LASTEXITCODE = 0; '' }
+
+        Get-HveCoreTrackingIssue | Should -BeNullOrEmpty
+    }
+
+    It 'Throws when the issue lookup fails' {
+        Mock gh { $global:LASTEXITCODE = 1; 'gh: API rate limit exceeded' }
+
+        { Get-HveCoreTrackingIssue } | Should -Throw '*Could not query existing*'
+    }
+}
+
+Describe 'Write-HveCoreGitHubOutputs' -Tag 'Unit' {
+    It 'Emits all freshness counters exactly once' {
+        $outputPath = Join-Path $TestDrive 'github-output.txt'
+        $outcome = [pscustomobject]@{
+            AttentionCount = 2
+            DriftCount = 1
+            ErrorCount = 1
+        }
+
+        Write-HveCoreGitHubOutputs -Outcome $outcome -Path $outputPath
+        $lines = @(Get-Content -Path $outputPath)
+
+        $lines | Should -Be @(
+            'attention-count=2'
+            'drift-count=1'
+            'error-count=1'
+        )
+    }
+
+    It 'Matches every workflow output consumer' {
+        $outputPath = Join-Path $TestDrive 'github-output-contract.txt'
+        $outcome = [pscustomobject]@{
+            AttentionCount = 0
+            DriftCount = 0
+            ErrorCount = 0
+        }
+        Write-HveCoreGitHubOutputs -Outcome $outcome -Path $outputPath
+        $emitted = @(Get-Content -Path $outputPath | ForEach-Object { ($_ -split '=', 2)[0] })
+        $workflowPath = Join-Path $script:RepoRoot '.github/workflows/check-hve-core-freshness.yml'
+        $workflow = Get-Content -Path $workflowPath -Raw
+        $referenced = @([regex]::Matches($workflow, 'steps\.check\.outputs\.([a-z-]+)') |
+                ForEach-Object { $_.Groups[1].Value } |
+                Select-Object -Unique)
+
+        $referenced | Should -Be @('attention-count', 'drift-count', 'error-count')
+        foreach ($name in $referenced) {
+            $emitted | Should -Contain $name
+        }
+    }
+
+    It 'Updates the tracking issue when the check step reports validation errors' {
+        $workflowPath = Join-Path $script:RepoRoot '.github/workflows/check-hve-core-freshness.yml'
+        $workflow = Get-Content -Path $workflowPath -Raw
+
+        $workflow | Should -Match "if:\s*[""']?!cancelled\(\)\s*&&\s*steps\.check\.outputs\.attention-count\s*!=\s*''\s*&&\s*steps\.check\.outputs\.attention-count\s*!=\s*'0'"
+    }
+}
+
+Describe 'Get-HveCoreFreshnessExitCode' -Tag 'Unit' {
+    It 'Returns success for current and drift-only outcomes' -ForEach @(
+        @{ DriftCount = 0; ErrorCount = 0 }
+        @{ DriftCount = 2; ErrorCount = 0 }
+    ) {
+        $outcome = [pscustomobject]@{
+            DriftCount = $_.DriftCount
+            ErrorCount = $_.ErrorCount
+        }
+
+        Get-HveCoreFreshnessExitCode -Outcome $outcome | Should -Be 0
+    }
+
+    It 'Returns failure when validation errors are present' {
+        $outcome = [pscustomobject]@{
+            DriftCount = 1
+            ErrorCount = 1
+        }
+
+        Get-HveCoreFreshnessExitCode -Outcome $outcome | Should -Be 2
+    }
+}
+
+Describe 'Test-HveCoreFreshness entry point' -Tag 'Unit' {
+    It 'Lists derived files and baselines in config preview' {
+        $scriptPath = Join-Path $script:RepoRoot 'scripts/security/Test-HveCoreFreshness.ps1'
+
+        $output = & pwsh -NoProfile -File $scriptPath -ConfigPreview 2>&1
+
+        $LASTEXITCODE | Should -Be 0
+        "$output" | Should -Match 'Test-DangerousWorkflow\.ps1 \[source-header\]'
+        "$output" | Should -Match 'SecurityHelpers\.psm1 \[release\]'
+        "$output" | Should -Not -Match 'OrderedDictionary'
     }
 }


### PR DESCRIPTION
This PR extends the repository's weekly hve-core freshness check to cover two vendored PowerShell security linters.

## Problem and Context

Issue #1133 documents a blind spot in the existing freshness check. The check covered hve-core-derived PowerShell modules by comparing the upstream blob at the repository's pinned hve-core release commit with the blob in the newest release, but it did not cover `Test-WorkflowPermissions.ps1` or `Test-DangerousWorkflow.ps1`.

Those linters cannot use one global release baseline. Their local headers identify different reviewed upstream commits, and at least one upstream source is available on `main` but not in a release. The local files also contain intentional adaptations, so comparing local file contents directly with upstream would report expected differences as drift.

## Proposed Solution

The documented design uses two baseline types in one manifest:

| Baseline | Files | Comparison |
|----------|-------|------------|
| `release` | Existing derived modules | Upstream blob at the RPI bootstrap's pinned `UPSTREAM_REF` versus the same path at the resolved newest non-draft release commit |
| `source-header` | Vendored security linters | Upstream blob at the exact commit recorded in the local file's provenance header versus the same path at one resolved upstream `main` commit |

Both modes compare upstream blobs with upstream blobs. This is the principal mechanism for excluding intentional local adaptations from the drift signal.

The script distinguishes upstream drift from invalid local provenance. Drift remains an issue-triaged signal with a successful process exit; local validation errors produce exit code 2. The workflow receives separate attention, drift, and error counters.

## Logical Changed Blocks

### Freshness manifest and provenance parsing

`scripts/security/Test-HveCoreFreshness.ps1` changes the derived-file manifest from a path list to entries containing `Path` and `Baseline`. It adds both security linters as `source-header` entries.

`Get-HveCoreFileSource` reads only the comment-based help header and requires one exact provenance statement containing the hve-core path and a full 40-character commit SHA. The recorded upstream path must match the local manifest path exactly. These constraints prevent malformed or misleading provenance from selecting the wrong upstream object. The two linter headers remove their parenthesized dates because repository comment policy prohibits temporal markers in code; the immutable commit SHA remains the provenance identifier.

Issue #1133 requires a per-file source revision. The implementation validates that revision and path before trusting them as comparison inputs.

### Immutable upstream resolution and drift classification

The check resolves the latest non-draft release tag and upstream `main` to immutable full commit SHAs once per run. It validates the pinned release ref before checking individual files. Each manifest entry is dispatched to its baseline-specific comparison.

The drift model now distinguishes current, changed, missing-at-baseline, missing-at-target, missing-at-both, and local validation-error states. A missing path at both refs is treated as invalid configuration. A missing source-header path at its recorded commit is also treated as invalid provenance.

Documented rationale: the PR description says each run should use one immutable release commit and one immutable `main` commit, and should separate upstream drift from local validation errors.

### GitHub API and rendering boundaries

GitHub API helpers validate returned commit and blob SHAs. API failures other than a reported HTTP 404 throw instead of appearing as missing files. This prevents transient or malformed API responses from creating false drift issues. Release URLs are restricted to HTTPS URLs on `github.com`, and external text is encoded before insertion into Markdown tables and labels so API-controlled values cannot alter generated issue or job-summary structure. The helper contracts, failure messages, and focused tests make these trust-boundary requirements explicit.

### Results, process status, and workflow outputs

The JSON result gains the resolved release and `main` SHAs plus independent `DriftCount` and `ErrorCount` values. The script emits `attention-count`, `drift-count`, and `error-count` to GitHub Actions. Drift alone exits successfully; validation errors exit with code 2.

The workflow opens or updates a tracking issue whenever attention is required, uses separate drift and error counts in its title and comment, and closes the issue only when neither exists. It checks the exit status after editing an existing issue before adding the weekly comment.

Documented rationale: the PR description defines drift as issue-triaged and invalid local provenance as workflow-failing. The issue itself asks only that drift be surfaced; the exact failure policy is a design choice recorded in this branch and its PR description.

### Reports and documentation

Issue and job-summary tables identify each file's baseline type, exact upstream comparison, blob SHAs, state, and validation error. Refresh guidance tells maintainers to review upstream changes, preserve local adaptations, and update a source-header commit after review.

`scripts/README.md` documents both baseline modes and the required source-header syntax. `.github/copilot-instructions.md` records the same maintenance convention for future coding agents.

### Test expansion

`scripts/tests/security/Test-HveCoreFreshness.Tests.ps1` expands coverage across the complete manifest, provenance parsing, release selection, API response validation, state classification, baseline dispatch, Markdown rendering, orchestration, workflow-output consumers, exit policy, and the configuration-preview entry point.

## Summary

- Compare release-baseline modules between the pinned `UPSTREAM_REF` and one immutable resolved latest-release commit; compare source-header security linters between their recorded source commit and one immutable resolved upstream `main` commit.
- Report upstream drift and local validation errors separately in JSON, workflow outputs, and job summaries.
- Keep upstream drift as an issue-triaged signal while failing the workflow for invalid local provenance.
- Validate provenance paths, full commit SHAs, API responses, release tags, release URLs, and Markdown rendering at trust boundaries.
- Enforce the script-to-workflow output contract and fail when tracking-issue updates do not succeed.
- Expand Pester coverage for the complete manifest, API request shapes, report formatting, orchestration, and workflow consumers.

## Validation

- Affected security Pester suites: 163 passed
- PSScriptAnalyzer: 4 changed PowerShell files, 0 errors, 0 warnings
- Runtime smoke tests: freshness preview, live comparison, malformed provenance, clean scans, violations, and invalid paths
- `git diff --check`

Closes #1133