### PR TITLE
fix: stabilize cloud E2E infrastructure and backend configuration

### DIFF
--- a/evaluation/sil/scripts/submit-azureml-lerobot-eval.sh
+++ b/evaluation/sil/scripts/submit-azureml-lerobot-eval.sh
@@ -293,16 +293,8 @@ if [[ "$assets_only" == "true" ]]; then
   exit 0
 fi
 
-managed_identity_client_id="${AZURE_CLIENT_ID:-}"
-if [[ -z "$managed_identity_client_id" && -n "$compute" ]]; then
-  managed_identity_client_id=$(az ml compute show \
-    --name "${compute#azureml:}" \
-    --resource-group "$resource_group" \
-    --workspace-name "$workspace_name" \
-    --query "identity.user_assigned_identities[0].client_id" \
-    --output tsv)
-  [[ "$managed_identity_client_id" == "None" ]] && managed_identity_client_id=""
-fi
+managed_identity_client_id=$(resolve_azureml_compute_identity_client_id \
+  "$compute" "$resource_group" "$workspace_name")
 
 #------------------------------------------------------------------------------
 # Build Submission Command

--- a/evaluation/sil/scripts/submit-azureml-lerobot-eval.sh
+++ b/evaluation/sil/scripts/submit-azureml-lerobot-eval.sh
@@ -293,6 +293,16 @@ if [[ "$assets_only" == "true" ]]; then
   exit 0
 fi
 
+managed_identity_client_id="${AZURE_CLIENT_ID:-}"
+if [[ -z "$managed_identity_client_id" && -n "$compute" ]]; then
+  managed_identity_client_id=$(az ml compute show \
+    --name "${compute#azureml:}" \
+    --resource-group "$resource_group" \
+    --workspace-name "$workspace_name" \
+    --query "identity.user_assigned_identities[0].client_id" \
+    --output tsv)
+  [[ "$managed_identity_client_id" == "None" ]] && managed_identity_client_id=""
+fi
 
 #------------------------------------------------------------------------------
 # Build Submission Command
@@ -371,6 +381,7 @@ az_args+=(
 [[ -n "$lerobot_version" ]] && az_args+=(--set "environment_variables.LEROBOT_VERSION=$lerobot_version")
 [[ -n "$experiment_name" ]] && az_args+=(--set "environment_variables.EXPERIMENT_NAME=$experiment_name")
 [[ -n "$register_model" ]] && az_args+=(--set "environment_variables.REGISTER_MODEL=$register_model")
+[[ -n "$managed_identity_client_id" ]] && az_args+=(--set "environment_variables.AZURE_CLIENT_ID=$managed_identity_client_id")
 
 [[ ${#forward_args[@]} -gt 0 ]] && az_args+=("${forward_args[@]}")
 az_args+=(--query "name" -o "tsv")

--- a/evaluation/sil/scripts/submit-osmo-lerobot-eval.sh
+++ b/evaluation/sil/scripts/submit-osmo-lerobot-eval.sh
@@ -106,6 +106,7 @@ model_name="${AML_MODEL_NAME:-}"
 model_version="${AML_MODEL_VERSION:-}"
 builtin_policy="${BUILTIN_POLICY:-false}"
 from_blob_dataset=false
+use_huggingface_credential="true"
 storage_account="${BLOB_STORAGE_ACCOUNT:-${AZURE_STORAGE_ACCOUNT_NAME:-}}"
 storage_container="${BLOB_STORAGE_CONTAINER:-datasets}"
 blob_prefix="${BLOB_PREFIX:-}"
@@ -202,6 +203,10 @@ else
   [[ -z "$dataset_revision" ]] && fatal "--dataset-revision is required with --dataset-repo-id"
 fi
 
+if [[ "$from_blob_dataset" == "true" && ( "$from_aml_model" == "true" || "$builtin_policy" == "true" ) ]]; then
+  use_huggingface_credential="false"
+fi
+
 [[ -f "$workflow" ]] || fatal "Workflow template not found: $workflow"
 [[ -d "$REPO_ROOT/training/il" ]] || fatal "Directory training/il not found"
 
@@ -278,6 +283,7 @@ submit_args=(
   "eval_episodes=$eval_episodes"
   "eval_batch_size=$eval_batch_size"
   "record_video=$record_video"
+  "use_huggingface_credential=$use_huggingface_credential"
 )
 
 [[ -n "$policy_revision" ]] && submit_args+=("policy_revision=$policy_revision")

--- a/evaluation/sil/workflows/osmo/lerobot-eval.yaml
+++ b/evaluation/sil/workflows/osmo/lerobot-eval.yaml
@@ -21,9 +21,11 @@ workflow:
       inputs:
         - url: "{{ code_url }}"
           regex: ".*"
+{% if use_huggingface_credential == "true" %}
       credentials:
         huggingface:
           HF_TOKEN: hf_token
+{% endif %}
       environment:
         NVIDIA_DRIVER_CAPABILITIES: "all"
         POLICY_REPO_ID: "{{ policy_repo_id }}"
@@ -88,6 +90,7 @@ default-values:
   blob_storage_container: datasets
   blob_prefix: ""
   builtin_policy: "false"
+  use_huggingface_credential: "true"
   code_url: ""
   entry_script_b64: ""
   payload_root: /workspace/lerobot_payload

--- a/infrastructure/setup/03-deploy-osmo.sh
+++ b/infrastructure/setup/03-deploy-osmo.sh
@@ -454,35 +454,35 @@ if [[ "$skip_mek" == "false" ]]; then
         # Clear service_auth from DB — it was encrypted with the old MEK and is now
         # undecryptable. The service regenerates a fresh keypair on next start.
         info "Clearing stale service_auth from database..."
-                kubectl delete pod osmo-clear-auth -n "$NS_OSMO_CONTROL_PLANE" --ignore-not-found >/dev/null
-                cat <<EOF | kubectl apply -f - >/dev/null
+        kubectl delete pod osmo-clear-auth -n "$NS_OSMO_CONTROL_PLANE" --ignore-not-found >/dev/null
+        cat <<EOF | kubectl apply -f - >/dev/null
 apiVersion: v1
 kind: Pod
 metadata:
-    name: osmo-clear-auth
-    namespace: $NS_OSMO_CONTROL_PLANE
+  name: osmo-clear-auth
+  namespace: $NS_OSMO_CONTROL_PLANE
 spec:
-    restartPolicy: Never
-    containers:
-        - name: psql
-            image: postgres:16@sha256:eb4759788a2182f08257135e61a34f2cfc3c2914079f3465d64ee62350f4d081
-            env:
-                - name: PGPASSWORD
-                    valueFrom:
-                        secretKeyRef:
-                            name: db-secret
-                            key: db-password
-            command: [psql]
-            args:
-                - "host=$pg_fqdn port=5432 dbname=osmo user=$pg_user sslmode=require"
-                - -c
-                - "DELETE FROM configs WHERE key='service_auth' AND type='SERVICE'"
+  restartPolicy: Never
+  containers:
+    - name: psql
+      image: postgres:16@sha256:eb4759788a2182f08257135e61a34f2cfc3c2914079f3465d64ee62350f4d081
+      env:
+        - name: PGPASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: db-secret
+              key: db-password
+      command: [psql]
+      args:
+        - "host=$pg_fqdn port=5432 dbname=osmo user=$pg_user sslmode=require"
+        - -c
+        - "DELETE FROM configs WHERE key='service_auth' AND type='SERVICE'"
 EOF
-                if ! kubectl wait pod/osmo-clear-auth -n "$NS_OSMO_CONTROL_PLANE" \
-                        --for=jsonpath='{.status.phase}'=Succeeded --timeout=60s >/dev/null 2>&1; then
-                        warn "Could not clear service_auth (DB may not be initialized yet — safe on first deploy)"
-                fi
-                kubectl delete pod osmo-clear-auth -n "$NS_OSMO_CONTROL_PLANE" --ignore-not-found >/dev/null
+        if ! kubectl wait pod/osmo-clear-auth -n "$NS_OSMO_CONTROL_PLANE" \
+            --for=jsonpath='{.status.phase}'=Succeeded --timeout=60s >/dev/null 2>&1; then
+            warn "Could not clear service_auth (DB may not be initialized yet — safe on first deploy)"
+        fi
+        kubectl delete pod osmo-clear-auth -n "$NS_OSMO_CONTROL_PLANE" --ignore-not-found >/dev/null
 
         # Ensure the service pod restarts to pick up the new MEK and regenerate service_auth.
         # Helm upgrade may not trigger a rollout if values are unchanged.

--- a/infrastructure/setup/values/nvidia-gpu-operator.yaml
+++ b/infrastructure/setup/values/nvidia-gpu-operator.yaml
@@ -37,6 +37,7 @@ driver:
 # Container toolkit
 toolkit:
   enabled: true
+  version: v1.17.8-ubuntu20.04
   tolerations:
     - key: nvidia.com/gpu
       operator: Exists

--- a/infrastructure/setup/values/nvidia-gpu-operator.yaml
+++ b/infrastructure/setup/values/nvidia-gpu-operator.yaml
@@ -37,6 +37,8 @@ driver:
 # Container toolkit
 toolkit:
   enabled: true
+  # v1.19.1 writes a containerd v4 drop-in, which prevents startup with AKS's v2 root configuration.
+  # Before changing, deploy on AKS and verify `containerd config dump`, node readiness, and allocatable nvidia.com/gpu.
   version: v1.17.8-ubuntu20.04
   tolerations:
     - key: nvidia.com/gpu

--- a/infrastructure/setup/values/nvidia-gpu-operator.yaml
+++ b/infrastructure/setup/values/nvidia-gpu-operator.yaml
@@ -38,7 +38,7 @@ driver:
 toolkit:
   enabled: true
   # v1.19.1 writes a containerd v4 drop-in, which prevents startup with AKS's v2 root configuration.
-  # Before changing, deploy on AKS and verify `containerd config dump`, node readiness, and allocatable nvidia.com/gpu.
+  # If changing, deploy on AKS and verify OSMO e2e tests.
   version: v1.17.8-ubuntu20.04
   tolerations:
     - key: nvidia.com/gpu

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -95,6 +95,24 @@ EOF
   info "Environment ${name}:${version} already exists with matching image; continuing"
 }
 
+resolve_azureml_compute_identity_client_id() {
+  local compute_target="${1:-}" resource_group="${2:?resource group required}"
+  local workspace_name="${3:?workspace name required}" client_id="${AZURE_CLIENT_ID:-}"
+
+  if [[ -z "$client_id" && -n "$compute_target" ]]; then
+    # Toolchain compute targets have exactly one user-assigned managed identity.
+    client_id=$(az ml compute show \
+      --name "${compute_target#azureml:}" \
+      --resource-group "$resource_group" \
+      --workspace-name "$workspace_name" \
+      --query "identity.user_assigned_identities[0].client_id" \
+      --output tsv)
+    [[ "$client_id" == "None" ]] && client_id=""
+  fi
+
+  printf '%s' "$client_id"
+}
+
 # Check for required tools
 require_tools() {
   local missing=()

--- a/tests/e2e/_aml.py
+++ b/tests/e2e/_aml.py
@@ -106,6 +106,8 @@ def _list_model_versions(repo_root: Path, aml_workspace: AzureMLWorkspace, model
         cwd=repo_root,
     )
     if result.returncode != 0:
+        if "ModelNotFound" in result.stderr:
+            return []
         raise AssertionError(
             f"Failed to list AzureML model versions for {model_name!r}\n\n{format_command_failure(result)}"
         )

--- a/tests/e2e/_lerobot_dataset.py
+++ b/tests/e2e/_lerobot_dataset.py
@@ -387,10 +387,8 @@ def validate_synthetic_dataset(root: Path) -> None:
 
 
 # --- Blob staging -----------------------------------------------------------
-# The OSMO data container ("osmo") always exists and the OSMO workflow identity
-# holds account-scoped Storage Blob Data Contributor, so a training/eval pod can
-# read a dataset staged here via its workload identity (no SAS needed). Mirrors
-# the VLA dataset staging in tests/e2e/_osmo.py.
+# OSMO callers default to the OSMO data container. Other backends supply their
+# own provisioned container explicitly.
 
 _IL_DATASET_CONTAINER_ENV = "E2E_IL_DATASET_CONTAINER"
 _DEFAULT_IL_DATASET_CONTAINER = "osmo"
@@ -419,14 +417,22 @@ def _materialize_synthetic_dataset(request: pytest.FixtureRequest, *, prefix: st
 
 
 def stage_synthetic_lerobot_dataset(
-    request: pytest.FixtureRequest, repo_root: Path, storage_account: str
+    request: pytest.FixtureRequest,
+    repo_root: Path,
+    storage_account: str,
+    *,
+    container: str | None = None,
 ) -> StagedDataset:
     """Generate the synthetic dataset, upload it to blob, and register teardown cleanup.
 
-    Returns the staged location so a test can drive the OSMO training (``--blob-url``)
-    or eval (``--from-blob-dataset``) submission without a HuggingFace token.
+    Returns the staged location so a test can drive training or evaluation from
+    Azure Blob Storage without a HuggingFace token.
     """
-    container = env_value(_IL_DATASET_CONTAINER_ENV, _DEFAULT_IL_DATASET_CONTAINER) or _DEFAULT_IL_DATASET_CONTAINER
+    container = (
+        container
+        or env_value(_IL_DATASET_CONTAINER_ENV, _DEFAULT_IL_DATASET_CONTAINER)
+        or _DEFAULT_IL_DATASET_CONTAINER
+    )
 
     dataset_dir = _materialize_synthetic_dataset(
         request, prefix="il-e2e-dataset-", log_message="Generating synthetic LeRobot v3.0 dataset"

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -366,7 +366,7 @@ def _cluster_has_scalable_gpu_node_pool(repo_root: Path) -> bool:
 
     tf_outputs = _terraform_outputs(repo_root)
     resource_group = os.environ.get("AZURE_RESOURCE_GROUP") or tf_outputs.try_key_value("resource_group")
-    cluster_name = tf_outputs.try_key_value("aks_cluster")
+    cluster_name = os.environ.get("AKS_CLUSTER_NAME") or tf_outputs.try_key_value("aks_cluster")
     if not resource_group or not cluster_name:
         return False
 

--- a/tests/e2e/test_e2e_aml_il_lifecycle.py
+++ b/tests/e2e/test_e2e_aml_il_lifecycle.py
@@ -85,7 +85,12 @@ def test_aml_il_lifecycle_e2e(
 ) -> None:
     log_e2e("Starting AzureML IL (LeRobot) lifecycle e2e test")
     policy_source = resolve_aml_lerobot_eval_policy_override()
-    dataset = stage_synthetic_lerobot_dataset(request, repo_root, storage_account)
+    dataset = stage_synthetic_lerobot_dataset(
+        request,
+        repo_root,
+        storage_account,
+        container="ml-workspace",
+    )
     if policy_source is None:
         register_model_name = e2e_name("il-e2e-aml-model")
         job = submit_aml_lerobot_training(

--- a/training/il/scripts/submit-azureml-lerobot-pipeline.sh
+++ b/training/il/scripts/submit-azureml-lerobot-pipeline.sh
@@ -502,7 +502,7 @@ info "  Policy Type: $policy_type"
 info "  Job Name: $job_name"
 [[ "$with_register" == "true" ]] && info "  Register Model: $register_model_name"
 
-# shellcheck disable=SC2329  # invoked indirectly via `trap`
+# shellcheck disable=SC2317,SC2329  # invoked indirectly via `trap`
 _interrupt_message() {
   error "Interrupted while waiting for az ml job create. The pipeline may have been submitted."
   error "Check: https://ml.azure.com/runs?wsid=/subscriptions/${subscription_id}/resourceGroups/${resource_group}/providers/Microsoft.MachineLearningServices/workspaces/${workspace_name}"

--- a/training/il/scripts/submit-azureml-lerobot-pipeline.sh
+++ b/training/il/scripts/submit-azureml-lerobot-pipeline.sh
@@ -153,6 +153,23 @@ ensure_ml_extension() {
     fatal "Azure ML CLI extension not installed. Run: az extension add --name ml"
 }
 
+resolve_managed_identity_client_id() {
+  local compute_target="$1"
+  local client_id="${AZURE_CLIENT_ID:-}"
+
+  if [[ -z "$client_id" ]]; then
+    client_id=$(az ml compute show \
+      --name "${compute_target#azureml:}" \
+      --resource-group "$resource_group" \
+      --workspace-name "$workspace_name" \
+      --query "identity.user_assigned_identities[0].client_id" \
+      --output tsv)
+    [[ "$client_id" == "None" ]] && client_id=""
+  fi
+
+  printf '%s' "$client_id"
+}
+
 #------------------------------------------------------------------------------
 # Defaults
 #------------------------------------------------------------------------------
@@ -352,6 +369,13 @@ if [[ "$config_preview" == "true" ]]; then
   exit 0
 fi
 
+train_managed_identity_client_id=$(resolve_managed_identity_client_id "$compute_train")
+evaluate_managed_identity_client_id=$(resolve_managed_identity_client_id "$compute_evaluate")
+register_managed_identity_client_id=""
+if [[ "$with_register" == "true" ]]; then
+  register_managed_identity_client_id=$(resolve_managed_identity_client_id "$compute_register")
+fi
+
 #------------------------------------------------------------------------------
 # Build Submission Command
 #
@@ -431,6 +455,7 @@ az_args+=(
 [[ -n "$training_steps" ]]      && az_args+=(--set "jobs.train_step.environment_variables.TRAINING_STEPS=$training_steps")
 [[ -n "$batch_size" ]]          && az_args+=(--set "jobs.train_step.environment_variables.BATCH_SIZE=$batch_size")
 [[ -n "$eval_freq" ]]           && az_args+=(--set "jobs.train_step.environment_variables.EVAL_FREQ=$eval_freq")
+[[ -n "$train_managed_identity_client_id" ]] && az_args+=(--set "jobs.train_step.environment_variables.AZURE_CLIENT_ID=$train_managed_identity_client_id")
 
 # evaluate_step
 az_args+=(
@@ -446,6 +471,7 @@ az_args+=(
   --set "jobs.evaluate_step.environment_variables.MLFLOW_HTTP_REQUEST_TIMEOUT=$mlflow_timeout"
 )
 [[ -n "$lerobot_version" ]] && az_args+=(--set "jobs.evaluate_step.environment_variables.LEROBOT_VERSION=$lerobot_version")
+[[ -n "$evaluate_managed_identity_client_id" ]] && az_args+=(--set "jobs.evaluate_step.environment_variables.AZURE_CLIENT_ID=$evaluate_managed_identity_client_id")
 
 # register_step (opt-in)
 if [[ "$with_register" == "true" ]]; then
@@ -457,6 +483,7 @@ if [[ "$with_register" == "true" ]]; then
     --set "jobs.register_step.environment_variables.AZURE_RESOURCE_GROUP=$resource_group"
     --set "jobs.register_step.environment_variables.AZUREML_WORKSPACE_NAME=$workspace_name"
   )
+  [[ -n "$register_managed_identity_client_id" ]] && az_args+=(--set "jobs.register_step.environment_variables.AZURE_CLIENT_ID=$register_managed_identity_client_id")
 fi
 
 [[ ${#forward_args[@]} -gt 0 ]] && az_args+=("${forward_args[@]}")

--- a/training/il/scripts/submit-azureml-lerobot-pipeline.sh
+++ b/training/il/scripts/submit-azureml-lerobot-pipeline.sh
@@ -153,23 +153,6 @@ ensure_ml_extension() {
     fatal "Azure ML CLI extension not installed. Run: az extension add --name ml"
 }
 
-resolve_managed_identity_client_id() {
-  local compute_target="$1"
-  local client_id="${AZURE_CLIENT_ID:-}"
-
-  if [[ -z "$client_id" ]]; then
-    client_id=$(az ml compute show \
-      --name "${compute_target#azureml:}" \
-      --resource-group "$resource_group" \
-      --workspace-name "$workspace_name" \
-      --query "identity.user_assigned_identities[0].client_id" \
-      --output tsv)
-    [[ "$client_id" == "None" ]] && client_id=""
-  fi
-
-  printf '%s' "$client_id"
-}
-
 #------------------------------------------------------------------------------
 # Defaults
 #------------------------------------------------------------------------------
@@ -369,11 +352,14 @@ if [[ "$config_preview" == "true" ]]; then
   exit 0
 fi
 
-train_managed_identity_client_id=$(resolve_managed_identity_client_id "$compute_train")
-evaluate_managed_identity_client_id=$(resolve_managed_identity_client_id "$compute_evaluate")
+train_managed_identity_client_id=$(resolve_azureml_compute_identity_client_id \
+  "$compute_train" "$resource_group" "$workspace_name")
+evaluate_managed_identity_client_id=$(resolve_azureml_compute_identity_client_id \
+  "$compute_evaluate" "$resource_group" "$workspace_name")
 register_managed_identity_client_id=""
 if [[ "$with_register" == "true" ]]; then
-  register_managed_identity_client_id=$(resolve_managed_identity_client_id "$compute_register")
+  register_managed_identity_client_id=$(resolve_azureml_compute_identity_client_id \
+    "$compute_register" "$resource_group" "$workspace_name")
 fi
 
 #------------------------------------------------------------------------------

--- a/training/il/scripts/submit-azureml-lerobot-pipeline.sh
+++ b/training/il/scripts/submit-azureml-lerobot-pipeline.sh
@@ -502,7 +502,7 @@ info "  Policy Type: $policy_type"
 info "  Job Name: $job_name"
 [[ "$with_register" == "true" ]] && info "  Register Model: $register_model_name"
 
-# shellcheck disable=SC2317,SC2329  # invoked indirectly via `trap`
+# shellcheck disable=SC2329  # invoked indirectly via `trap`
 _interrupt_message() {
   error "Interrupted while waiting for az ml job create. The pipeline may have been submitted."
   error "Check: https://ml.azure.com/runs?wsid=/subscriptions/${subscription_id}/resourceGroups/${resource_group}/providers/Microsoft.MachineLearningServices/workspaces/${workspace_name}"

--- a/training/il/scripts/submit-azureml-lerobot-training.sh
+++ b/training/il/scripts/submit-azureml-lerobot-training.sh
@@ -476,6 +476,17 @@ if [[ "$assets_only" == "true" ]]; then
   exit 0
 fi
 
+managed_identity_client_id="${AZURE_CLIENT_ID:-}"
+if [[ -z "$managed_identity_client_id" ]]; then
+  managed_identity_client_id=$(az ml compute show \
+    --name "${compute#azureml:}" \
+    --resource-group "$resource_group" \
+    --workspace-name "$workspace_name" \
+    --query "identity.user_assigned_identities[0].client_id" \
+    --output tsv)
+  [[ "$managed_identity_client_id" == "None" ]] && managed_identity_client_id=""
+fi
+
 #------------------------------------------------------------------------------
 # Pre-submission Checks
 #------------------------------------------------------------------------------
@@ -523,6 +534,7 @@ az_args=(
 [[ -n "$instance_type" ]] && az_args+=(--set "resources.instance_type=$instance_type")
 [[ -n "$experiment_name" ]] && az_args+=(--set "experiment_name=$experiment_name")
 [[ -n "$display_name" ]] && az_args+=(--set "display_name=$display_name")
+[[ -n "$managed_identity_client_id" ]] && az_args+=(--set "environment_variables.AZURE_CLIENT_ID=$managed_identity_client_id")
 
 az_args+=(--set "command=$train_cmd")
 

--- a/training/il/scripts/submit-azureml-lerobot-training.sh
+++ b/training/il/scripts/submit-azureml-lerobot-training.sh
@@ -627,7 +627,7 @@ info "  Image: $image"
 # Ctrl+C between az invocation and a successful return leaves the operator
 # unsure whether the job was accepted. Print a clear pointer to the portal so
 # they can resolve the ambiguity instead of blindly resubmitting.
-# shellcheck disable=SC2329  # invoked indirectly via `trap`
+# shellcheck disable=SC2317,SC2329  # invoked indirectly via `trap`
 _interrupt_message() {
   error "Interrupted while waiting for az ml job create. The job may have been submitted."
   error "Check: https://ml.azure.com/runs?wsid=/subscriptions/${subscription_id}/resourceGroups/${resource_group}/providers/Microsoft.MachineLearningServices/workspaces/${workspace_name}"

--- a/training/il/scripts/submit-azureml-lerobot-training.sh
+++ b/training/il/scripts/submit-azureml-lerobot-training.sh
@@ -627,7 +627,7 @@ info "  Image: $image"
 # Ctrl+C between az invocation and a successful return leaves the operator
 # unsure whether the job was accepted. Print a clear pointer to the portal so
 # they can resolve the ambiguity instead of blindly resubmitting.
-# shellcheck disable=SC2317,SC2329  # invoked indirectly via `trap`
+# shellcheck disable=SC2329  # invoked indirectly via `trap`
 _interrupt_message() {
   error "Interrupted while waiting for az ml job create. The job may have been submitted."
   error "Check: https://ml.azure.com/runs?wsid=/subscriptions/${subscription_id}/resourceGroups/${resource_group}/providers/Microsoft.MachineLearningServices/workspaces/${workspace_name}"

--- a/training/il/scripts/submit-azureml-lerobot-training.sh
+++ b/training/il/scripts/submit-azureml-lerobot-training.sh
@@ -476,16 +476,8 @@ if [[ "$assets_only" == "true" ]]; then
   exit 0
 fi
 
-managed_identity_client_id="${AZURE_CLIENT_ID:-}"
-if [[ -z "$managed_identity_client_id" ]]; then
-  managed_identity_client_id=$(az ml compute show \
-    --name "${compute#azureml:}" \
-    --resource-group "$resource_group" \
-    --workspace-name "$workspace_name" \
-    --query "identity.user_assigned_identities[0].client_id" \
-    --output tsv)
-  [[ "$managed_identity_client_id" == "None" ]] && managed_identity_client_id=""
-fi
+managed_identity_client_id=$(resolve_azureml_compute_identity_client_id \
+  "$compute" "$resource_group" "$workspace_name")
 
 #------------------------------------------------------------------------------
 # Pre-submission Checks

--- a/training/il/scripts/submit-osmo-lerobot-training.sh
+++ b/training/il/scripts/submit-osmo-lerobot-training.sh
@@ -153,6 +153,7 @@ dataset_root="${DATASET_ROOT:-/workspace/data}"
 blob_urls=()
 blob_urls_json="[]"
 blob_source_count=0
+use_huggingface_credential="true"
 
 training_steps="${TRAINING_STEPS:-100000}"
 batch_size="${BATCH_SIZE:-32}"
@@ -254,6 +255,7 @@ if [[ ${#blob_urls[@]} -gt 0 ]]; then
   validate_blob_urls "${blob_urls[@]}"
   blob_urls_json=$(json_array "${blob_urls[@]}")
   blob_source_count="${#blob_urls[@]}"
+  use_huggingface_credential="false"
 elif [[ -z "$dataset_repo_id" ]]; then
   fatal "No dataset source specified. Use --dataset-repo-id for HuggingFace Hub, or provide one or more --blob-url sources."
 fi
@@ -332,6 +334,7 @@ submit_args=(
   "dataset_repo_id=$dataset_repo_id"
   "dataset_root=$dataset_root"
   "blob_urls=$blob_urls_json"
+  "use_huggingface_credential=$use_huggingface_credential"
   "policy_type=$policy_type"
   "job_name=$job_name"
   "output_dir=$output_dir"

--- a/training/il/workflows/osmo/lerobot-train.yaml
+++ b/training/il/workflows/osmo/lerobot-train.yaml
@@ -21,9 +21,11 @@ workflow:
       inputs:
         - url: "{{ code_url }}"
           regex: ".*"
+{% if use_huggingface_credential == "true" %}
       credentials:
         huggingface:
           HF_TOKEN: hf_token
+{% endif %}
       environment:
         GIT_PYTHON_REFRESH: "quiet"
         NVIDIA_DRIVER_CAPABILITIES: "all"
@@ -71,6 +73,7 @@ default-values:
   dataset_repo_id: ""
   dataset_root: /workspace/data
   blob_urls: "[]"
+  use_huggingface_credential: "true"
   policy_type: act
   output_dir: /workspace/outputs/train
   job_name: lerobot-training


### PR DESCRIPTION
## Summary

- pin NVIDIA Container Toolkit to the AKS-compatible `v1.17.8-ubuntu20.04` release while retaining GPU Operator `v26.3.2`
- correct the OSMO service-auth cleanup Pod manifest
- isolate Azure Blob and Hugging Face dataset metadata and request Hugging Face credentials only for workflows that use them
- propagate each Azure ML compute target's user-assigned managed identity to training, pipeline, and evaluation jobs
- tolerate absent model containers during cleanup and select the Terraform-resolved AKS cluster for E2E runs

## Validation

| Suite | Passing attempt | Cloud jobs or workflows | Duration |
| --- | ---: | --- | ---: |
| Azure ML IL pipeline | 3 | `willing_sponge_qs318xznd1` | 14m 01s |
| Azure ML RL lifecycle | 1 | `good_garlic_yljr0zlj50`, `bright_jewel_5fvkwbbl40` | 15m 47s |
| Azure ML IL lifecycle | 3 | `green_room_7k82ps8nhy`, `epic_beet_2t9lfthcn1` | 10m 13s |
| OSMO RL lifecycle | 3 | `isaaclab-inline-training-3`, `isaaclab-inference-1` | 8m 09s |
| OSMO RL dataset training | 4 | `isaaclab-dataset-training-3` | 3m 28s |
| OSMO IL lifecycle | 5 | `lerobot-training-4`, `lerobot-inference-2` | 11m 48s |
| OSMO VLA fine-tuning | 3 | `vla-finetune-e2e-osmo-1787144860-5196bc77-1` | 18m 32s |

- all seven cloud E2E suites passed
- ShellCheck passed for the changed deployment and submission scripts
- Ruff passed for the changed E2E Python modules
- Azure-only OSMO training and evaluation workflows render without a Hugging Face credential
- GPU nodes reached `Ready`, advertised allocatable `nvidia.com/gpu`, and reconciled `ClusterPolicy` successfully

Closes #1392
