### PR TITLE
refactor(infrastructure): use AzureRM for AML workspace

### DIFF
--- a/docs/infrastructure/infrastructure-reference.md
+++ b/docs/infrastructure/infrastructure-reference.md
@@ -3,7 +3,7 @@ sidebar_position: 4
 title: Infrastructure Reference
 description: Architecture, module structure, outputs, and troubleshooting for the Terraform deployment
 author: Microsoft Robotics-AI Team
-ms.date: 2026-08-31
+ms.date: 2026-09-07
 ms.topic: reference
 keywords:
   - architecture
@@ -108,6 +108,27 @@ Use `aml_managed_network_isolation_mode` to control the AzureML workspace manage
 | `AllowOnlyApprovedOutbound` | AzureML managed network is on and outbound access is restricted      |
 
 Treat changes to `aml_managed_network_isolation_mode` as AzureML redeploy operations. AzureML does not support disabling managed network isolation after it is enabled, or switching between `AllowInternetOutbound` and `AllowOnlyApprovedOutbound` in place. Delete and recreate managed compute resources when enabling managed networking on an existing workspace; recreate the workspace for unsupported mode transitions.
+
+### AzureML workspace provider migration
+
+> [!CAUTION]
+> Existing deployments require a one-time Terraform state migration from the AzAPI resource address to the AzureRM resource address. Without this migration, Terraform attempts to create a workspace with the existing name and then destroy the workspace tracked by the old address.
+
+Back up the current state, remove the old state entry without deleting the Azure resource, then import the existing workspace at the new address:
+
+```bash
+terraform state pull > terraform.tfstate.pre-aml-workspace-migration.backup
+
+terraform state rm 'module.platform.azapi_resource.ml_workspace'
+
+terraform import -var-file=terraform.tfvars \
+  'module.platform.azurerm_machine_learning_workspace.main' \
+  '/subscriptions/<sub-id>/resourceGroups/<rg-name>/providers/Microsoft.MachineLearningServices/workspaces/<workspace-name>'
+
+terraform plan -var-file=terraform.tfvars
+```
+
+Confirm that the plan does not replace the workspace before applying.
 
 ### AzureML compute cluster migration
 

--- a/infrastructure/terraform/modules/platform/TERRAFORM.md
+++ b/infrastructure/terraform/modules/platform/TERRAFORM.md
@@ -2,7 +2,7 @@
 title: Platform Module
 description: "Deploys shared Azure infrastructure services for robotics ML workloads. Resources include: networking, DNS zones, security, observability, ACR, storage, ML workspace. Optional: PostgreSQL and Redis for OSMO workloads."
 author: Microsoft Robotics-AI Team
-ms.date: 2026-08-31
+ms.date: 2026-09-07
 ms.topic: reference
 ---
 
@@ -33,7 +33,6 @@ Optional: PostgreSQL and Redis for OSMO workloads.
 
 | Name                                                                                                                                                                                              | Type        |
 |---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-| [azapi_resource.ml_workspace](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource)                                                                                 | resource    |
 | [azapi_resource.osmo_admin_password](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource)                                                                          | resource    |
 | [azapi_resource.postgresql_password](https://registry.terraform.io/providers/Azure/azapi/latest/docs/resources/resource)                                                                          | resource    |
 | [azurerm_application_insights.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/application_insights)                                                         | resource    |
@@ -43,6 +42,7 @@ Optional: PostgreSQL and Redis for OSMO workloads.
 | [azurerm_key_vault_secret.redis_primary_key](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/key_vault_secret)                                                    | resource    |
 | [azurerm_log_analytics_workspace.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/log_analytics_workspace)                                                   | resource    |
 | [azurerm_machine_learning_compute_cluster.gpu](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/machine_learning_compute_cluster)                                  | resource    |
+| [azurerm_machine_learning_workspace.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/machine_learning_workspace)                                             | resource    |
 | [azurerm_managed_redis.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/managed_redis)                                                                       | resource    |
 | [azurerm_monitor_data_collection_endpoint.main](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_data_collection_endpoint)                                 | resource    |
 | [azurerm_monitor_diagnostic_setting.ml_workspace_logs](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/monitor_diagnostic_setting)                                | resource    |

--- a/infrastructure/terraform/modules/platform/azureml.tf
+++ b/infrastructure/terraform/modules/platform/azureml.tf
@@ -9,55 +9,33 @@
  */
 
 // ============================================================
-// Azure Machine Learning Workspace (via azapi)
+// Azure Machine Learning Workspace
 // ============================================================
-// Using azapi_resource because azurerm does not expose systemDatastoresAuthMode.
-// This property is required when storage account has shared_access_key_enabled = false.
 
-resource "azapi_resource" "ml_workspace" {
-  type      = "Microsoft.MachineLearningServices/workspaces@2024-04-01"
-  name      = "mlw-${local.resource_name_suffix}${var.workspace_name_suffix}"
-  location  = var.resource_group.location
-  parent_id = var.resource_group.id
-
-  // Disable schema validation because azapi provider schema doesn't include
-  // systemDatastoresAuthMode property, but it's valid per Microsoft ARM docs.
-  schema_validation_enabled = false
+resource "azurerm_machine_learning_workspace" "main" {
+  # checkov:skip=CKV_AZURE_144:Public access is configurable for dev/test and disabled by default.
+  # checkov:skip=CKV2_AZURE_49:Public access is configurable for dev/test and disabled by default.
+  # checkov:skip=CKV2_AZURE_50:Linked storage public access is configurable and disabled by default.
+  name                          = "mlw-${local.resource_name_suffix}${var.workspace_name_suffix}"
+  location                      = var.resource_group.location
+  resource_group_name           = var.resource_group.name
+  application_insights_id       = azurerm_application_insights.main.id
+  key_vault_id                  = azurerm_key_vault.main.id
+  storage_account_id            = azurerm_storage_account.main.id
+  container_registry_id         = azurerm_container_registry.main.id
+  public_network_access_enabled = var.should_enable_public_network_access
+  v1_legacy_mode_enabled        = false
+  storage_account_access_type   = var.should_enable_storage_shared_access_key ? "AccessKey" : "Identity"
+  sku_name                      = "Basic"
+  kind                          = "Default"
+  friendly_name                 = "mlw-${local.resource_name_suffix}"
 
   identity {
     type = "SystemAssigned"
   }
 
-  body = {
-    sku = {
-      name = "Basic"
-      tier = "Basic"
-    }
-    kind = "Default"
-    properties = {
-      friendlyName             = "mlw-${local.resource_name_suffix}"
-      keyVault                 = azurerm_key_vault.main.id
-      storageAccount           = azurerm_storage_account.main.id
-      containerRegistry        = azurerm_container_registry.main.id
-      applicationInsights      = azurerm_application_insights.main.id
-      publicNetworkAccess      = var.should_enable_public_network_access ? "Enabled" : "Disabled"
-      v1LegacyMode             = false
-      systemDatastoresAuthMode = var.should_enable_storage_shared_access_key ? "accessKey" : "identity"
-      managedNetwork = {
-        isolationMode = var.aml_managed_network_isolation_mode
-      }
-    }
-  }
-
-  response_export_values = ["properties.workspaceId", "identity.principalId"]
-
-  lifecycle {
-    ignore_changes = [
-      // ARM API returns resource provider segments with varying casing
-      // (e.g. Microsoft.insights vs Microsoft.Insights) causing perpetual drift
-      body.properties.applicationInsights,
-      body.properties.keyVault,
-    ]
+  managed_network {
+    isolation_mode = var.aml_managed_network_isolation_mode
   }
 }
 
@@ -75,7 +53,7 @@ resource "azurerm_private_endpoint" "azureml_api" {
 
   private_service_connection {
     name                           = "psc-ml-api-${local.resource_name_suffix}"
-    private_connection_resource_id = azapi_resource.ml_workspace.id
+    private_connection_resource_id = azurerm_machine_learning_workspace.main.id
     subresource_names              = ["amlworkspace"]
     is_manual_connection           = false
   }
@@ -93,7 +71,7 @@ resource "azurerm_monitor_diagnostic_setting" "ml_workspace_logs" {
   count = var.should_enable_aml_diagnostic_logs ? 1 : 0
 
   name                       = "diag-mlw-${local.resource_name_suffix}"
-  target_resource_id         = azapi_resource.ml_workspace.id
+  target_resource_id         = azurerm_machine_learning_workspace.main.id
   log_analytics_workspace_id = azurerm_log_analytics_workspace.main.id
 
   enabled_log {
@@ -133,7 +111,7 @@ resource "azurerm_machine_learning_compute_cluster" "gpu" {
   for_each = local.aml_compute_clusters_normalized
 
   name                          = each.key
-  machine_learning_workspace_id = azapi_resource.ml_workspace.id
+  machine_learning_workspace_id = azurerm_machine_learning_workspace.main.id
   location                      = each.value.location
   vm_size                       = each.value.vm_size
   vm_priority                   = each.value.vm_priority

--- a/infrastructure/terraform/modules/platform/outputs.tf
+++ b/infrastructure/terraform/modules/platform/outputs.tf
@@ -190,9 +190,9 @@ output "data_lake_storage_account_access" {
 output "azureml_workspace" {
   description = "ML workspace for AKS extension."
   value = {
-    id           = azapi_resource.ml_workspace.id
-    name         = azapi_resource.ml_workspace.name
-    workspace_id = azapi_resource.ml_workspace.output.properties.workspaceId
+    id           = azurerm_machine_learning_workspace.main.id
+    name         = azurerm_machine_learning_workspace.main.name
+    workspace_id = azurerm_machine_learning_workspace.main.workspace_id
   }
 }
 

--- a/infrastructure/terraform/modules/platform/role-assignments.tf
+++ b/infrastructure/terraform/modules/platform/role-assignments.tf
@@ -132,7 +132,7 @@ resource "azurerm_role_assignment" "osmo_acr_pull" {
 // Provides workspace read access and ability to submit/manage experiments and runs
 resource "azurerm_role_assignment" "osmo_ml_data_scientist" {
   count                = var.should_enable_osmo_identity ? 1 : 0
-  scope                = azapi_resource.ml_workspace.id
+  scope                = azurerm_machine_learning_workspace.main.id
   role_definition_name = "AzureML Data Scientist"
   principal_id         = azurerm_user_assigned_identity.osmo[0].principal_id
 }

--- a/infrastructure/terraform/modules/platform/tests/conditionals.tftest.hcl
+++ b/infrastructure/terraform/modules/platform/tests/conditionals.tftest.hcl
@@ -13,6 +13,14 @@ override_data {
   }
 }
 
+override_resource {
+  target          = azurerm_machine_learning_workspace.main
+  override_during = plan
+  values = {
+    id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test-dev-001/providers/Microsoft.MachineLearningServices/workspaces/mlw-test-dev-001"
+  }
+}
+
 variables {
   current_user_oid                   = "00000000-0000-0000-0000-000000000001"
   aml_managed_network_isolation_mode = "Disabled"
@@ -126,6 +134,11 @@ run "private_endpoints_enabled" {
   assert {
     condition     = length(azurerm_private_endpoint.azureml_api) == 1
     error_message = "ML API PE should be created when PE is enabled"
+  }
+
+  assert {
+    condition     = one(azurerm_private_endpoint.azureml_api[0].private_service_connection).private_connection_resource_id == azurerm_machine_learning_workspace.main.id
+    error_message = "ML API PE should target the AzureML workspace"
   }
 }
 
@@ -607,6 +620,11 @@ run "osmo_identity_enabled" {
     condition     = length(azurerm_role_assignment.osmo_kv_secrets_user) == 1
     error_message = "OSMO KV secrets user role assignment should be created when OSMO identity is enabled"
   }
+
+  assert {
+    condition     = azurerm_role_assignment.osmo_ml_data_scientist[0].scope == azurerm_machine_learning_workspace.main.id
+    error_message = "OSMO AzureML role assignment should target the AzureML workspace"
+  }
 }
 
 run "osmo_identity_disabled" {
@@ -658,6 +676,11 @@ run "aml_diagnostic_logs_enabled" {
   assert {
     condition     = one(azurerm_monitor_diagnostic_setting.ml_workspace_logs[0].enabled_log).category_group == "allLogs"
     error_message = "AML diagnostic setting should enable all AML log categories"
+  }
+
+  assert {
+    condition     = azurerm_monitor_diagnostic_setting.ml_workspace_logs[0].target_resource_id == azurerm_machine_learning_workspace.main.id
+    error_message = "AML diagnostic setting should target the AzureML workspace"
   }
 }
 
@@ -748,6 +771,11 @@ run "aml_compute_one_cluster" {
   assert {
     condition     = azurerm_machine_learning_compute_cluster.gpu["gpu-cluster"].location == run.setup.location
     error_message = "AML compute cluster should inherit the workspace location when cluster location is omitted"
+  }
+
+  assert {
+    condition     = azurerm_machine_learning_compute_cluster.gpu["gpu-cluster"].machine_learning_workspace_id == azurerm_machine_learning_workspace.main.id
+    error_message = "AML compute cluster should target the AzureML workspace"
   }
 }
 
@@ -923,7 +951,7 @@ run "aml_compute_disabled_managed_network_uses_custom_subnet" {
   }
 
   assert {
-    condition     = azapi_resource.ml_workspace.body.properties.managedNetwork.isolationMode == "Disabled"
+    condition     = one(azurerm_machine_learning_workspace.main.managed_network).isolation_mode == "Disabled"
     error_message = "AML workspace managed network isolation mode should be disabled"
   }
 
@@ -962,7 +990,7 @@ run "aml_compute_managed_network_without_custom_subnet" {
   }
 
   assert {
-    condition     = azapi_resource.ml_workspace.body.properties.managedNetwork.isolationMode == "AllowOnlyApprovedOutbound"
+    condition     = one(azurerm_machine_learning_workspace.main.managed_network).isolation_mode == "AllowOnlyApprovedOutbound"
     error_message = "AML workspace should use the configured managed network isolation mode"
   }
 
@@ -974,6 +1002,25 @@ run "aml_compute_managed_network_without_custom_subnet" {
   assert {
     condition     = local.should_attach_aml_compute_to_customer_subnet == false
     error_message = "AML compute should not attach to a customer subnet when managed network isolation is enabled"
+  }
+}
+
+run "aml_workspace_allow_internet_outbound" {
+  command = plan
+
+  variables {
+    resource_prefix                    = run.setup.resource_prefix
+    environment                        = run.setup.environment
+    instance                           = run.setup.instance
+    location                           = run.setup.location
+    resource_group                     = run.setup.resource_group
+    current_user_oid                   = run.setup.current_user_oid
+    aml_managed_network_isolation_mode = "AllowInternetOutbound"
+  }
+
+  assert {
+    condition     = one(azurerm_machine_learning_workspace.main.managed_network).isolation_mode == "AllowInternetOutbound"
+    error_message = "AML workspace should use internet outbound managed network isolation when configured"
   }
 }
 

--- a/infrastructure/terraform/modules/platform/tests/naming.tftest.hcl
+++ b/infrastructure/terraform/modules/platform/tests/naming.tftest.hcl
@@ -110,7 +110,7 @@ run "verify_standard_naming" {
 
   // AzureML Workspace
   assert {
-    condition     = azapi_resource.ml_workspace.name == "mlw-${run.setup.resource_prefix}-${run.setup.environment}-${run.setup.instance}"
+    condition     = azurerm_machine_learning_workspace.main.name == "mlw-${run.setup.resource_prefix}-${run.setup.environment}-${run.setup.instance}"
     error_message = "ML workspace name must follow mlw-{prefix}-{env}-{instance}"
   }
 
@@ -149,6 +149,30 @@ run "verify_no_hyphen_naming" {
   assert {
     condition     = azurerm_storage_account.main.name == "st${run.setup.resource_prefix}${run.setup.environment}${run.setup.instance}"
     error_message = "Storage account name must follow st{prefix}{env}{instance} (no hyphens)"
+  }
+}
+
+run "verify_aml_workspace_name_suffix" {
+  command = plan
+
+  variables {
+    resource_prefix       = run.setup.resource_prefix
+    environment           = run.setup.environment
+    instance              = run.setup.instance
+    location              = run.setup.location
+    resource_group        = run.setup.resource_group
+    current_user_oid      = run.setup.current_user_oid
+    workspace_name_suffix = "-secondary"
+  }
+
+  assert {
+    condition     = azurerm_machine_learning_workspace.main.name == "mlw-${run.setup.resource_prefix}-${run.setup.environment}-${run.setup.instance}-secondary"
+    error_message = "ML workspace name should include workspace_name_suffix"
+  }
+
+  assert {
+    condition     = azurerm_machine_learning_workspace.main.friendly_name == "mlw-${run.setup.resource_prefix}-${run.setup.environment}-${run.setup.instance}"
+    error_message = "ML workspace friendly name should remain the base workspace name"
   }
 }
 

--- a/infrastructure/terraform/modules/platform/tests/outputs.tftest.hcl
+++ b/infrastructure/terraform/modules/platform/tests/outputs.tftest.hcl
@@ -106,6 +106,48 @@ run "aml_compute_clusters_output_populated" {
   }
 }
 
+run "azureml_workspace_output_shape" {
+  command = plan
+
+  override_resource {
+    target          = azurerm_machine_learning_workspace.main
+    override_during = plan
+    values = {
+      id           = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test-dev-001/providers/Microsoft.MachineLearningServices/workspaces/mlw-test-dev-001"
+      workspace_id = "00000000-0000-0000-0000-000000000002"
+    }
+  }
+
+  variables {
+    resource_prefix  = run.setup.resource_prefix
+    environment      = run.setup.environment
+    instance         = run.setup.instance
+    location         = run.setup.location
+    resource_group   = run.setup.resource_group
+    current_user_oid = run.setup.current_user_oid
+  }
+
+  assert {
+    condition     = output.azureml_workspace.id == "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test-dev-001/providers/Microsoft.MachineLearningServices/workspaces/mlw-test-dev-001"
+    error_message = "azureml_workspace output should expose the workspace resource ID"
+  }
+
+  assert {
+    condition     = output.azureml_workspace.name == "mlw-${run.setup.resource_prefix}-${run.setup.environment}-${run.setup.instance}"
+    error_message = "azureml_workspace output should expose the workspace name"
+  }
+
+  assert {
+    condition     = output.azureml_workspace.workspace_id == "00000000-0000-0000-0000-000000000002"
+    error_message = "azureml_workspace output should expose the workspace GUID"
+  }
+
+  assert {
+    condition     = length(keys(output.azureml_workspace)) == 3 && alltrue([for key in ["id", "name", "workspace_id"] : contains(keys(output.azureml_workspace), key)])
+    error_message = "azureml_workspace output should preserve the id, name, and workspace_id contract"
+  }
+}
+
 run "private_dns_zones_empty_when_pe_disabled" {
   command = plan
 

--- a/infrastructure/terraform/modules/platform/tests/security.tftest.hcl
+++ b/infrastructure/terraform/modules/platform/tests/security.tftest.hcl
@@ -104,6 +104,16 @@ run "kv_public_access_disabled" {
     condition     = azurerm_log_analytics_workspace.main.internet_query_access_type == "Disabled"
     error_message = "Log Analytics query access should be disabled when public access is disabled"
   }
+
+  assert {
+    condition     = azurerm_machine_learning_workspace.main.public_network_access_enabled == false
+    error_message = "ML workspace public access should be disabled"
+  }
+
+  assert {
+    condition     = azurerm_machine_learning_workspace.main.v1_legacy_mode_enabled == false
+    error_message = "ML workspace v1 legacy mode should be disabled"
+  }
 }
 
 run "kv_public_access_enabled" {
@@ -138,6 +148,111 @@ run "kv_public_access_enabled" {
     condition     = azurerm_log_analytics_workspace.main.internet_query_access_type == "Enabled"
     error_message = "Log Analytics query access should be enabled when public access is enabled"
   }
+
+  assert {
+    condition     = azurerm_machine_learning_workspace.main.public_network_access_enabled == true
+    error_message = "ML workspace public access should be enabled"
+  }
+}
+
+run "aml_workspace_configuration" {
+  command = plan
+
+  override_resource {
+    target          = azurerm_application_insights.main
+    override_during = plan
+    values = {
+      id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test-dev-001/providers/Microsoft.Insights/components/ai-test-dev-001"
+    }
+  }
+
+  override_resource {
+    target          = azurerm_key_vault.main
+    override_during = plan
+    values = {
+      id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test-dev-001/providers/Microsoft.KeyVault/vaults/kvtestdev001"
+    }
+  }
+
+  override_resource {
+    target          = azurerm_storage_account.main
+    override_during = plan
+    values = {
+      id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test-dev-001/providers/Microsoft.Storage/storageAccounts/sttestdev001"
+    }
+  }
+
+  override_resource {
+    target          = azurerm_container_registry.main
+    override_during = plan
+    values = {
+      id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg-test-dev-001/providers/Microsoft.ContainerRegistry/registries/acrtestdev001"
+    }
+  }
+
+  variables {
+    resource_prefix  = run.setup.resource_prefix
+    environment      = run.setup.environment
+    instance         = run.setup.instance
+    location         = run.setup.location
+    resource_group   = run.setup.resource_group
+    current_user_oid = run.setup.current_user_oid
+  }
+
+  assert {
+    condition     = azurerm_machine_learning_workspace.main.application_insights_id == azurerm_application_insights.main.id
+    error_message = "ML workspace should use the platform Application Insights resource"
+  }
+
+  assert {
+    condition     = azurerm_machine_learning_workspace.main.location == run.setup.location
+    error_message = "ML workspace should use the platform resource group location"
+  }
+
+  assert {
+    condition     = azurerm_machine_learning_workspace.main.resource_group_name == run.setup.resource_group.name
+    error_message = "ML workspace should use the platform resource group"
+  }
+
+  assert {
+    condition     = azurerm_machine_learning_workspace.main.key_vault_id == azurerm_key_vault.main.id
+    error_message = "ML workspace should use the platform Key Vault"
+  }
+
+  assert {
+    condition     = azurerm_machine_learning_workspace.main.storage_account_id == azurerm_storage_account.main.id
+    error_message = "ML workspace should use the platform storage account"
+  }
+
+  assert {
+    condition     = azurerm_machine_learning_workspace.main.container_registry_id == azurerm_container_registry.main.id
+    error_message = "ML workspace should use the platform container registry"
+  }
+
+  assert {
+    condition     = one(azurerm_machine_learning_workspace.main.identity).type == "SystemAssigned"
+    error_message = "ML workspace should use a system-assigned identity"
+  }
+
+  assert {
+    condition     = azurerm_machine_learning_workspace.main.sku_name == "Basic"
+    error_message = "ML workspace should preserve the Basic SKU"
+  }
+
+  assert {
+    condition     = azurerm_machine_learning_workspace.main.kind == "Default"
+    error_message = "ML workspace should preserve the Default kind"
+  }
+
+  assert {
+    condition     = azurerm_machine_learning_workspace.main.public_network_access_enabled == false
+    error_message = "ML workspace should disable public network access by default"
+  }
+
+  assert {
+    condition     = azurerm_machine_learning_workspace.main.friendly_name == "mlw-${run.setup.resource_prefix}-${run.setup.environment}-${run.setup.instance}"
+    error_message = "ML workspace should preserve its friendly name"
+  }
 }
 
 run "storage_security" {
@@ -168,7 +283,7 @@ run "storage_security" {
   }
 
   assert {
-    condition     = azapi_resource.ml_workspace.body.properties.systemDatastoresAuthMode == "identity"
+    condition     = azurerm_machine_learning_workspace.main.storage_account_access_type == "Identity"
     error_message = "ML workspace must use identity-based system datastore auth by default"
   }
 }
@@ -198,7 +313,7 @@ run "storage_shared_access_key_enabled" {
   }
 
   assert {
-    condition     = azapi_resource.ml_workspace.body.properties.systemDatastoresAuthMode == "accessKey"
+    condition     = azurerm_machine_learning_workspace.main.storage_account_access_type == "AccessKey"
     error_message = "ML workspace must use accessKey system datastore auth when shared access keys are enabled"
   }
 }


### PR DESCRIPTION
# Pull Request

## Description

Replace the Azure Machine Learning workspace `azapi_resource` with `azurerm_machine_learning_workspace`. Preserve all configured identity, linked-resource, network-isolation, public-access, legacy-mode, and datastore-authentication properties through native AzureRM arguments.

Existing deployments require a one-time state backup, removal, and import because Terraform cannot move state between the AzAPI and AzureRM resource types. The infrastructure reference documents the migration procedure. No configured workspace property requires `azapi_update_resource`.

Addresses #384

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change fixing an issue)
- [ ] ✨ New feature (non-breaking change adding functionality)
- [x] 💥 Breaking change (fix or feature causing existing functionality to change)
- [x] 📚 Documentation update
- [x] 🏗️ Infrastructure change (Terraform/IaC)
- [x] ♻️ Refactoring (no functional changes)

## Component(s) Affected

- [ ] `infrastructure/terraform/prerequisites/` - Azure subscription setup
- [x] `infrastructure/terraform/` - Terraform infrastructure
- [ ] `infrastructure/setup/` - OSMO control plane / Helm
- [ ] `workflows/` - Training and evaluation workflows
- [ ] `training/` - Training pipelines and scripts
- [x] `docs/` - Documentation

## Testing Performed

- [x] Terraform `plan` reviewed (no unexpected changes)
- [x] Terraform `apply` tested in dev environment
- [ ] Training scripts tested locally with Isaac Sim
- [ ] OSMO workflow submitted successfully
- [ ] Smoke tests passed (`smoke_test_azure.py`)

All 90 Terraform module tests and TFLint passed. The tests cover every configured workspace property, all three managed-network modes, the public output contract, and downstream workspace references from private endpoints, diagnostic settings, compute clusters, and role assignments.

The CI-pinned Checkov 3.3.13 image passed the targeted Azure ML policy scan with three documented skips. Checkov cannot resolve the module's configurable public-network inputs; secure defaults remain covered by Terraform regression tests.

### Live migration validation

Six temporary workspaces were first deployed with the pre-migration `azapi_resource` configuration. Each managed-network isolation mode was tested with both supported access profiles:

| Managed-network isolation mode | Public network access | Datastore authentication |
|--------------------------------|-----------------------|--------------------------|
| `Disabled` | Disabled | `Identity` |
| `Disabled` | Enabled | `AccessKey` |
| `AllowInternetOutbound` | Disabled | `Identity` |
| `AllowInternetOutbound` | Enabled | `AccessKey` |
| `AllowOnlyApprovedOutbound` | Disabled | `Identity` |
| `AllowOnlyApprovedOutbound` | Enabled | `AccessKey` |

Each fixture included the workspace identity, Key Vault, storage account, container registry, Application Insights, SKU, kind, friendly name, legacy-mode setting, managed-network setting, public-access setting, and datastore-authentication setting used by the platform module.

The migration was validated through the same sequence required for an existing deployment:

1. Apply the original AzAPI-based module and capture each workspace's Terraform state, Azure resource ID, and immutable Azure Machine Learning workspace ID.
2. Replace the module source with this branch while retaining the deployed resources and Terraform state.
3. Back up the state, remove each old `azapi_resource` workspace address, and import the existing Azure resource into the corresponding `azurerm_machine_learning_workspace` address.
4. Generate and inspect the migrated Terraform plan in JSON form.
5. Compare the imported AzureRM state with the captured AzAPI state and deployed workspace identities.

| Assertion | Result |
|-----------|--------|
| AzureRM workspace operation | `no-op` for all 6 workspaces |
| Workspace creates, updates, destroys, or replacements | 0 |
| Replacement paths | None |
| Azure resource ID preserved | 6 of 6 |
| Immutable Azure Machine Learning workspace ID preserved | 6 of 6 |
| Linked Key Vault, storage, registry, and Application Insights resources preserved | 6 of 6 |
| Managed-network, public-access, legacy-mode, and datastore-authentication values preserved | 6 of 6 |

The three public `AccessKey` fixtures also exposed pre-existing environment drift on their dependencies: Key Vault public access and storage public/shared-key access refreshed back to disabled after apply. Reapplying those dependency settings did not stabilize them. The Azure Machine Learning workspace resources remained `no-op`, so this dependency drift is independent of the provider migration.

The temporary resources were destroyed after validation.

## Documentation Impact

- [ ] No documentation changes needed
- [x] Documentation updated in this PR
- [ ] Documentation issue filed

## Bug Fix Checklist

Not applicable; this PR is an infrastructure provider migration.

## Checklist

- [x] My code follows the [project conventions](copilot-instructions.md)
- [x] Commit messages follow [conventional commit format](instructions/commit-message.instructions.md)
- [x] I have performed a self-review
- [x] Documentation impact assessed above
- [x] No new linting warnings introduced
