### PR TITLE
fix(training): make OSMO replay outputs durable

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -277,6 +277,7 @@ jobs:
       rl: true
       il: true
       evaluation: true
+      osmo_replay: true
       dataviewer: true
     permissions:
       contents: read

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -24,6 +24,7 @@ jobs:
       rl: ${{ steps.filter.outputs.rl }}
       il: ${{ steps.filter.outputs.il }}
       evaluation: ${{ steps.filter.outputs.evaluation }}
+      osmo_replay: ${{ steps.filter.outputs.osmo_replay }}
       dm_tools: ${{ steps.filter.outputs.dm_tools }}
       data_pipeline: ${{ steps.filter.outputs.data_pipeline }}
       inference: ${{ steps.filter.outputs.inference }}
@@ -62,6 +63,7 @@ jobs:
             echo "rl=$(match '^(training/rl/|shared/ci/|scripts/lib/common\.sh|\.github/workflows/smoke-cpu\.yml)')"
             echo "il=$(match '^(training/il/|shared/ci/|\.github/workflows/smoke-cpu\.yml)')"
             echo "evaluation=$(match '^(evaluation/|training/il/lerobot/|shared/ci/|scripts/lib/common\.sh|\.github/workflows/smoke-cpu\.yml)')"
+            echo "osmo_replay=$(match '^(workflows/osmo/|training/utils/aml_mirror\.py|training/utils/replay-azureml\.sh|shared/ci/|scripts/lib/common\.sh|\.github/workflows/smoke-cpu\.yml)')"
             echo "dm_tools=$(match '^data-management/tools/')"
             echo "data_pipeline=$(match '^data-pipeline/capture/')"
             echo "inference=$(match '^fleet-deployment/inference/')"
@@ -85,6 +87,7 @@ jobs:
       rl: ${{ needs.changes.outputs.rl == 'true' }}
       il: ${{ needs.changes.outputs.il == 'true' }}
       evaluation: ${{ needs.changes.outputs.evaluation == 'true' }}
+      osmo_replay: ${{ needs.changes.outputs.osmo_replay == 'true' }}
       dataviewer: ${{ needs.changes.outputs.dv_backend == 'true' || needs.changes.outputs.dv_frontend == 'true' }}
     permissions:
       contents: read

--- a/.github/workflows/smoke-cpu.yml
+++ b/.github/workflows/smoke-cpu.yml
@@ -23,6 +23,11 @@ name: Smoke (GPU-free)
         required: false
         default: false
         type: boolean
+      osmo_replay:
+        description: 'Run the OSMO replay runtime-image smoke (workflows/osmo changed)'
+        required: false
+        default: false
+        type: boolean
       dataviewer:
         description: 'Build the dataviewer compose stack (viewer images/compose changed)'
         required: false
@@ -47,7 +52,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        domain: [rl, il, vla, evaluation]
+        domain: [rl, il, vla, evaluation, osmo-replay]
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
@@ -124,6 +129,22 @@ jobs:
 
       - name: Runtime-image smoke
         run: shared/ci/smoke-image.sh evaluation
+
+  image-smoke-osmo-replay:
+    name: Runtime-Image Smoke (osmo-replay)
+    if: inputs.osmo_replay
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Runtime-image smoke
+        run: shared/ci/smoke-image.sh osmo-replay
 
   # Docker compose smoke: build the dataviewer images on their pinned bases,
   # start the stack, and wait for both services to report healthy. Path-gated by

--- a/infrastructure/setup/README.md
+++ b/infrastructure/setup/README.md
@@ -113,19 +113,21 @@ AzureML integration is configured in the OSMO workflow YAML directly. The workfl
 
 ### Using
 
-Submit a replay for any completed run:
+Submit a replay for a completed OSMO workflow with a declared persisted output:
 
 ```bash
-./training/utils/replay-azureml.sh <run-id> [model-name]
+./training/utils/replay-azureml.sh <workflow-id> <output-uri> [model-name]
 ```
+
+Use the `azure://` URI declared by the source workflow's task output. Set `OSMO_OUTPUT_SUBPATH` when checkpoints are below that output root.
 
 ### What it does
 
-| Component       | Action                                                                     |
-|-----------------|----------------------------------------------------------------------------|
-| Workflow YAML   | Passes AzureML workspace coordinates as env vars to the training container |
-| Replay workflow | Spawns an OSMO pod that reads the run's output directory                   |
-| `aml_mirror.py` | Uploads tensorboard logs + filtered final checkpoint                       |
+| Component       | Action                                                                      |
+|-----------------|-----------------------------------------------------------------------------|
+| Workflow YAML   | Passes AzureML workspace coordinates as env vars to the training container  |
+| Replay workflow | Mounts the completed workflow's persisted output and uploads its checkpoint |
+| `aml_mirror.py` | Uploads tensorboard logs + filtered final checkpoint                        |
 
 ### Troubleshooting
 

--- a/shared/ci/README.md
+++ b/shared/ci/README.md
@@ -27,9 +27,11 @@ shared/ci/smoke-image.sh rl --mode cpu           # CPU import smoke, lightweight
 shared/ci/smoke-image.sh il --mode cpu
 shared/ci/smoke-image.sh vla --mode cpu
 shared/ci/smoke-image.sh evaluation --mode cpu
+shared/ci/smoke-image.sh osmo-replay --mode cpu
 shared/ci/smoke-image.sh rl                       # runtime-image smoke (Isaac Lab)
 shared/ci/smoke-image.sh il                       # runtime-image smoke (PyTorch)
 shared/ci/smoke-image.sh evaluation               # runtime-image smoke (PyTorch)
+shared/ci/smoke-image.sh osmo-replay               # runtime-image smoke (Python slim)
 
 # linux/x86_64 host or CI — run the inner probe directly, no Docker
 shared/ci/smoke-import.sh rl --mode cpu
@@ -49,14 +51,15 @@ shared/ci/smoke-import.sh rl --mode cpu
 
 ## 🧪 Domains
 
-| Domain       | Python | Runtime image                          | CPU smoke | Runtime-image smoke |
-|--------------|--------|----------------------------------------|-----------|---------------------|
-| `rl`         | 3.11   | Isaac Lab (`DEFAULT_ISAAC_LAB_IMAGE`)  | yes       | yes                 |
-| `il`         | 3.12   | PyTorch (`lerobot-train.yaml` default) | yes       | yes                 |
-| `vla`        | 3.12   | none                                   | yes       | no                  |
-| `evaluation` | 3.12   | PyTorch (`evaluate.yaml`)              | yes       | yes                 |
+| Domain        | Python | Runtime image                          | CPU smoke | Runtime-image smoke |
+|---------------|--------|----------------------------------------|-----------|---------------------|
+| `rl`          | 3.11   | Isaac Lab (`DEFAULT_ISAAC_LAB_IMAGE`)  | yes       | yes                 |
+| `il`          | 3.12   | PyTorch (`lerobot-train.yaml` default) | yes       | yes                 |
+| `vla`         | 3.12   | none                                   | yes       | no                  |
+| `evaluation`  | 3.12   | PyTorch (`evaluate.yaml`)              | yes       | yes                 |
+| `osmo-replay` | 3.11   | Python (`replay-azureml.yaml`)         | yes       | yes                 |
 
-Image references come from their source of truth: `scripts/lib/common.sh` for `rl`, `training/il/workflows/osmo/lerobot-train.yaml` for `il`, and `evaluation/sil/workflows/azureml/components/evaluate.yaml` for `evaluation`.
+Image references come from their source of truth: `scripts/lib/common.sh` for `rl`, `training/il/workflows/osmo/lerobot-train.yaml` for `il`, `evaluation/sil/workflows/azureml/components/evaluate.yaml` for `evaluation`, and `workflows/osmo/replay-azureml.yaml` for `osmo-replay`.
 
 ## 🔍 What each depth catches
 
@@ -87,13 +90,13 @@ The CPU depth is also the cheap baseline that runs on every PR, while the runtim
 
 ### Install preserves the committed resolution
 
-The domain locks encode pyproject `override-dependencies` and package sources. The IL and evaluation runtime-image smokes use frozen `uv sync`, matching their production entrypoints and preserving the explicit PyTorch CUDA index. The RL runtime-image smoke exports the lock and installs it with `--no-deps`, matching `training/rl/scripts/train.sh`. Both paths install the committed resolution rather than resolving dependencies again.
+The domain locks encode pyproject `override-dependencies` and package sources. The IL and evaluation runtime-image smokes use frozen `uv sync`, matching their production entrypoints and preserving the explicit PyTorch CUDA index. The RL and OSMO replay runtime-image smokes export their locks and install with `--no-deps`, matching their production entrypoints. Both paths install the committed resolution rather than resolving dependencies again.
 
 The import step is load-bearing: dependency or ABI skew can install cleanly and fail only when imported. For the CPU depth, the export removes the CUDA local-version suffix before `--torch-backend cpu` selects CPU wheels, and strips standalone `nvidia-*` and `cuda-*` packages.
 
 ### Per-domain runtime images and interpreters
 
-Each domain runs in its own production runtime; there is no single image. Image references are read from their source of truth: `DEFAULT_ISAAC_LAB_IMAGE` in `scripts/lib/common.sh` for `rl`, the `lerobot-train.yaml` default for `il`, and the Azure ML `evaluate.yaml` component for `evaluation`.
+Each domain runs in its own production runtime; there is no single image. Image references are read from their source of truth: `DEFAULT_ISAAC_LAB_IMAGE` in `scripts/lib/common.sh` for `rl`, the `lerobot-train.yaml` default for `il`, the Azure ML `evaluate.yaml` component for `evaluation`, and the `replay-azureml.yaml` default for `osmo-replay`.
 
 The LeRobot lock requires Python 3.12 while its PyTorch image ships 3.11, so the `il` and `evaluation` runtime-image smokes provision 3.12 in a venv, mirroring their production entry scripts; `rl` uses the Isaac Lab kit interpreter.
 

--- a/shared/ci/smoke-image.sh
+++ b/shared/ci/smoke-image.sh
@@ -15,6 +15,8 @@ source "$REPO_ROOT/scripts/lib/common.sh"
 LEROBOT_WORKFLOW="training/il/workflows/osmo/lerobot-train.yaml"
 # Source of truth for the Azure ML evaluation runtime image.
 EVALUATION_COMPONENT="evaluation/sil/workflows/azureml/components/evaluate.yaml"
+# Source of truth for the OSMO replay runtime image.
+OSMO_REPLAY_WORKFLOW="workflows/osmo/replay-azureml.yaml"
 # Lightweight linux/amd64 image with uv preinstalled, used for the CPU smoke.
 CPU_IMAGE="ghcr.io/astral-sh/uv:python3.12-bookworm-slim"
 
@@ -30,6 +32,7 @@ DOMAIN:
     il            Imitation learning / LeRobot (training/il/lerobot)
     vla           Vision-language-action / LeRobot (training/vla/lerobot) -- --mode cpu only
     evaluation    Software-in-the-loop evaluation (evaluation)
+    osmo-replay   OSMO-to-AzureML replay mirror (workflows/osmo)
 
 OPTIONS:
     -m, --mode MODE    image (default) runs the domain's production container;
@@ -63,8 +66,8 @@ done
 
 if [[ "$mode" == "cpu" ]]; then
     case "$domain" in
-        rl | il | vla | evaluation) image="$CPU_IMAGE" ;;
-        *) fatal "Unknown domain: $domain (expected rl, il, vla, or evaluation)" ;;
+        rl | il | vla | evaluation | osmo-replay) image="$CPU_IMAGE" ;;
+        *) fatal "Unknown domain: $domain (expected rl, il, vla, evaluation, or osmo-replay)" ;;
     esac
 else
     case "$domain" in
@@ -79,8 +82,13 @@ else
                 "$REPO_ROOT/$EVALUATION_COMPONENT" | awk '{print $2}')"
             [[ -n "$image" ]] || fatal "Could not resolve evaluation image from $EVALUATION_COMPONENT"
             ;;
+        osmo-replay)
+            image="$(grep -m1 -E '^[[:space:]]*image:[[:space:]]*python:' \
+                "$REPO_ROOT/$OSMO_REPLAY_WORKFLOW" | awk '{print $2}')"
+            [[ -n "$image" ]] || fatal "Could not resolve OSMO replay image from $OSMO_REPLAY_WORKFLOW"
+            ;;
         vla) fatal "vla has no runtime-image smoke; use --mode cpu" ;;
-        *) fatal "Unknown domain: $domain (expected rl, il, vla, or evaluation)" ;;
+        *) fatal "Unknown domain: $domain (expected rl, il, vla, evaluation, or osmo-replay)" ;;
     esac
 fi
 
@@ -97,8 +105,20 @@ if [[ "$mode" == "cpu" ]]; then
     container_cmd="apt-get update -qq \
         && apt-get install -y -qq --no-install-recommends build-essential linux-libc-dev >/dev/null \
         && ${container_cmd}"
+elif [[ "$domain" == "osmo-replay" ]]; then
+    container_cmd="apt-get update -qq \
+        && apt-get install -y -qq --no-install-recommends ca-certificates curl >/dev/null \
+        && ${container_cmd}"
 fi
 
-docker run --rm --platform linux/amd64 --entrypoint bash \
+docker_args=(run --rm --platform linux/amd64 --entrypoint bash)
+package_index_url="${UV_INDEX_URL:-${UV_DEFAULT_INDEX:-}}"
+if [[ -n "$package_index_url" ]]; then
+    export UV_INDEX_URL="$package_index_url"
+    export PIP_INDEX_URL="$package_index_url"
+    docker_args+=(-e UV_INDEX_URL -e PIP_INDEX_URL)
+fi
+
+docker "${docker_args[@]}" \
     -v "${REPO_ROOT}:/workspace" -w /workspace \
     "$image" -c "$container_cmd"

--- a/shared/ci/smoke-import.sh
+++ b/shared/ci/smoke-import.sh
@@ -31,6 +31,7 @@ DOMAIN:
     il            Imitation learning / LeRobot (training/il/lerobot), Python 3.12
     vla           Vision-language-action / LeRobot (training/vla/lerobot), Python 3.12
     evaluation    Software-in-the-loop evaluation (evaluation), Python 3.12
+    osmo-replay   OSMO-to-AzureML replay mirror (workflows/osmo), Python 3.11
 
 OPTIONS:
     -m, --mode MODE    cpu (default) or image
@@ -99,7 +100,12 @@ case "$domain" in
         py_version="3.12"
         probe=(-c "import numpy, torch; import evaluation.sil.policy_evaluation")
         ;;
-    *) fatal "Unknown domain: $domain (expected rl, il, vla, or evaluation)" ;;
+    osmo-replay)
+        project="workflows/osmo"
+        py_version="3.11"
+        probe=(-c "import azure.ai.ml, azure.identity, azureml.mlflow, mlflow, tbparse; import training.utils.aml_mirror")
+        ;;
+    *) fatal "Unknown domain: $domain (expected rl, il, vla, evaluation, or osmo-replay)" ;;
 esac
 
 ensure_uv() {
@@ -159,6 +165,11 @@ smoke_image() {
         python_exec="${venv}/bin/python"
         # LeRobot runtime entrypoints install directly from the source-aware lock.
         uv sync --active --frozen --no-config --no-install-project --project "$runtime_project"
+    elif [[ "$domain" == "osmo-replay" ]]; then
+        python_exec="python3"
+        local requirements="/tmp/smoke-requirements-${domain}.txt"
+        uv export --frozen --no-hashes --no-emit-project --project "$project" > "$requirements"
+        "$python_exec" -m pip install --no-cache-dir --no-deps --requirement "$requirements"
     else
         # RL: the Isaac Lab kit interpreter is the production runtime.
         python_exec="/isaac-sim/kit/python/bin/python3"

--- a/tests/e2e/_aml.py
+++ b/tests/e2e/_aml.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import re
 import subprocess
+import tempfile
 from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
@@ -133,6 +134,43 @@ def resolve_registered_model(
     version = str(max(versions))
     log_e2e(f"Resolved AzureML model {model_name} to concrete version {version}")
     return AmlModelRef(name=model_name, version=version)
+
+
+def assert_registered_model_has_artifacts(
+    repo_root: Path,
+    aml_workspace: AzureMLWorkspace,
+    model: AmlModelRef,
+) -> None:
+    """Download a registered model version and assert that it contains files."""
+    with tempfile.TemporaryDirectory(prefix="e2e-model-artifacts-") as download_root:
+        result = run_command(
+            [
+                "az",
+                "ml",
+                "model",
+                "download",
+                "--name",
+                model.name,
+                "--version",
+                model.version,
+                "--download-path",
+                download_root,
+                *aml_workspace_args(aml_workspace),
+                "--output",
+                "none",
+            ],
+            cwd=repo_root,
+        )
+        if result.returncode != 0:
+            raise AssertionError(
+                f"Failed to download AzureML model {model.name!r}:{model.version}\n\n"
+                f"{format_command_failure(result)}"
+            )
+        artifact_files = [path for path in Path(download_root).rglob("*") if path.is_file()]
+        if not artifact_files:
+            raise AssertionError(f"AzureML model {model.name!r}:{model.version} contained no artifact files")
+
+    log_e2e(f"AzureML model artifacts passed: model={model.name}:{model.version}, artifacts={len(artifact_files)}")
 
 
 def archive_all_model_versions(repo_root: Path, aml_workspace: AzureMLWorkspace, model_name: str) -> None:

--- a/tests/e2e/_aml.py
+++ b/tests/e2e/_aml.py
@@ -163,8 +163,7 @@ def assert_registered_model_has_artifacts(
         )
         if result.returncode != 0:
             raise AssertionError(
-                f"Failed to download AzureML model {model.name!r}:{model.version}\n\n"
-                f"{format_command_failure(result)}"
+                f"Failed to download AzureML model {model.name!r}:{model.version}\n\n{format_command_failure(result)}"
             )
         artifact_files = [path for path in Path(download_root).rglob("*") if path.is_file()]
         if not artifact_files:

--- a/tests/e2e/_mlflow.py
+++ b/tests/e2e/_mlflow.py
@@ -60,15 +60,17 @@ def _tracking_uri(subscription_id: str, resource_group: str, workspace_name: str
 
 
 def _mlflow_client(aml_workspace: AzureMLWorkspace) -> MlflowClient:
+    import mlflow
     from mlflow.tracking import MlflowClient
 
-    return MlflowClient(
-        tracking_uri=_tracking_uri(
-            aml_workspace.subscription_id,
-            aml_workspace.resource_group,
-            aml_workspace.workspace_name,
-        )
+    tracking_uri = _tracking_uri(
+        aml_workspace.subscription_id,
+        aml_workspace.resource_group,
+        aml_workspace.workspace_name,
     )
+    mlflow.set_tracking_uri(tracking_uri)
+    mlflow.set_registry_uri(tracking_uri)
+    return MlflowClient(tracking_uri=tracking_uri, registry_uri=tracking_uri)
 
 
 _MLFLOW_SEARCH_TIMEOUT_SECONDS = 300
@@ -233,6 +235,34 @@ def assert_osmo_workflow_has_mlflow_tracking(workflow: OSMOWorkflow, aml_workspa
         f"OSMO MLflow tracking passed: run_id={run_id} metrics=[{rendered_metrics}] "
         f"params=[{rendered_params}] tags=[{rendered_tags}]"
     )
+
+
+def assert_osmo_replay_has_mlflow_run(
+    *,
+    source_run_id: str,
+    model_name: str,
+    aml_workspace: AzureMLWorkspace,
+) -> None:
+    """Assert that replay created the expected tagged MLflow run."""
+    client = _mlflow_client(aml_workspace)
+    escaped_source_run_id = source_run_id.replace("'", "\\'")
+    runs = _search_experiment_runs_with_retry(
+        client,
+        model_name,
+        filter_string=f"tags.osmo.replay_source = '{escaped_source_run_id}'",
+        max_results=2,
+        criteria=f"replay source {source_run_id!r}",
+    )
+    if len(runs) > 1:
+        raise AssertionError(
+            f"Multiple MLflow runs were found in experiment {model_name!r} for replay source {source_run_id!r}"
+        )
+
+    run = runs[0]
+    if run.data.tags.get("osmo.replay") != "true":
+        raise AssertionError(f"MLflow replay run {run.info.run_id!r} did not include osmo.replay=true")
+
+    log_e2e(f"OSMO replay MLflow run passed: run_id={run.info.run_id}, source_run_id={source_run_id}")
 
 
 _LEROBOT_EVAL_REQUIRED_METRICS = (

--- a/tests/e2e/_osmo.py
+++ b/tests/e2e/_osmo.py
@@ -1096,3 +1096,81 @@ def submit_osmo_vla_finetune(
         raise AssertionError(f"OSMO VLA fine-tuning e2e submission failed\n\n{format_command_failure(result)}")
 
     return _osmo_workflow_from_submission(result, job_name, "OSMO VLA fine-tuning")
+
+
+def submit_osmo_azureml_replay(
+    repo_root: Path,
+    *,
+    source_run_id: str,
+    source_output_uri: str,
+    model_name: str,
+) -> OSMOWorkflow:
+    """Replay an OSMO output directory into AzureML through the production wrapper."""
+    log_e2e(f"Submitting OSMO AzureML replay for source_run_id={source_run_id}, model={model_name}")
+    result = run_command(
+        [
+            str(repo_root / "training/utils/replay-azureml.sh"),
+            source_run_id,
+            source_output_uri,
+            model_name,
+            "--",
+            "--set",
+            "cpu=1",
+            "memory=2Gi",
+            "--format-type",
+            "json",
+        ],
+        cwd=repo_root,
+    )
+    if result.returncode != 0:
+        raise AssertionError(f"OSMO AzureML replay submission failed\n\n{format_command_failure(result)}")
+
+    return _osmo_workflow_from_submission(
+        result,
+        model_name,
+        "OSMO AzureML replay",
+        correlation_id=source_run_id,
+    )
+
+
+def submit_osmo_replay_output_fixture(
+    repo_root: Path,
+) -> tuple[OSMOWorkflow, str]:
+    """Create a small checkpoint in OSMO persisted workflow output storage."""
+    workflow_name = e2e_name("replay-output")
+    config_result = run_command(["osmo", "config", "show", "WORKFLOW"], cwd=repo_root)
+    if config_result.returncode != 0:
+        raise AssertionError(f"OSMO workflow configuration lookup failed\n\n{format_command_failure(config_result)}")
+    try:
+        workflow_data_uri = json.loads(config_result.stdout)["workflow_data"]["credential"]["endpoint"]
+    except (KeyError, TypeError, json.JSONDecodeError) as error:
+        raise AssertionError("OSMO workflow configuration did not contain a workflow-data endpoint") from error
+    if not isinstance(workflow_data_uri, str) or not workflow_data_uri.startswith("azure://"):
+        raise AssertionError(f"OSMO workflow-data endpoint is not an azure:// URI: {workflow_data_uri!r}")
+
+    output_uri = f"{workflow_data_uri.rstrip('/')}/e2e/replay/{workflow_name}"
+    result = run_command(
+        [
+            "osmo",
+            "workflow",
+            "submit",
+            str(repo_root / "tests/e2e/fixtures/osmo-replay-output.yaml"),
+            "--set-string",
+            f"workflow_name={workflow_name}",
+            f"output_uri={output_uri}",
+            "--format-type",
+            "json",
+        ],
+        cwd=repo_root,
+    )
+    if result.returncode != 0:
+        raise AssertionError(f"OSMO replay output submission failed\n\n{format_command_failure(result)}")
+    workflow = _osmo_workflow_from_submission(result, workflow_name, "OSMO replay output")
+    return workflow, output_uri
+
+
+def cleanup_osmo_replay_output(repo_root: Path, output_uri: str) -> None:
+    """Remove an E2E replay fixture from OSMO persisted workflow storage."""
+    result = run_command(["osmo", "data", "delete", output_uri], cwd=repo_root)
+    if result.returncode != 0:
+        raise AssertionError(f"OSMO replay output cleanup failed\n\n{format_command_failure(result)}")

--- a/tests/e2e/fixtures/osmo-replay-output.yaml
+++ b/tests/e2e/fixtures/osmo-replay-output.yaml
@@ -1,0 +1,20 @@
+workflow:
+  name: "{{workflow_name}}"
+  resources:
+    default: { cpu: 1, memory: 1Gi, storage: 1Gi, gpu: 0 }
+  timeout: { exec_timeout: 10m, queue_timeout: 10m }
+  tasks:
+    - name: manage-output
+      image: python:3.11-slim@sha256:b27df5841f3355e9473f9a516d38a6783b6c8dfeacaf2d14a240f443b368ddb6
+      outputs:
+        - url: "{{output_uri}}"
+      command: ["bash", "-euc"]
+      args:
+        - |
+          mkdir -p "{{output}}/run-e2e/checkpoint-1"
+          printf '%s\n' '{"model_type":"e2e-replay-fixture"}' > "{{output}}/run-e2e/checkpoint-1/config.json"
+          printf '%s\n' 'e2e replay weights' > "{{output}}/run-e2e/checkpoint-1/model.safetensors"
+
+default-values:
+  workflow_name: replay-output-fixture
+  output_uri: azure://placeholder/osmo/workflows/data/e2e/replay-output-fixture

--- a/tests/e2e/test_e2e_osmo_azureml_replay.py
+++ b/tests/e2e/test_e2e_osmo_azureml_replay.py
@@ -1,0 +1,71 @@
+"""End-to-end test for replaying persisted OSMO output into AzureML.
+
+Seeds a minimal checkpoint in OSMO shared output storage, submits the production
+replay wrapper, and validates MLflow artifacts and AzureML model registration.
+
+```shell
+uv run pytest -vv -s -m e2e tests/e2e/test_e2e_osmo_azureml_replay.py
+```
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tests.e2e._aml import (
+    AzureMLWorkspace,
+    archive_all_model_versions,
+    assert_registered_model_has_artifacts,
+    resolve_registered_model,
+)
+from tests.e2e._common import e2e_name, log_e2e
+from tests.e2e._mlflow import assert_osmo_replay_has_mlflow_run
+from tests.e2e._osmo import (
+    assert_workflow_task_succeeded,
+    cleanup_osmo_replay_output,
+    monitor_osmo_workflow,
+    submit_osmo_azureml_replay,
+    submit_osmo_replay_output_fixture,
+)
+
+_OUTPUT_TASK_NAME = "manage-output"
+_REPLAY_TASK_NAME = "mirror"
+
+
+@pytest.mark.e2e
+@pytest.mark.usefixtures("ensure_osmo_cli_available")
+def test_osmo_azureml_replay_e2e(
+    request: pytest.FixtureRequest,
+    aml_workspace: AzureMLWorkspace,
+    monkeypatch: pytest.MonkeyPatch,
+    repo_root: Path,
+) -> None:
+    model_name = e2e_name("replay-e2e-osmo-model")
+    request.addfinalizer(lambda: archive_all_model_versions(repo_root, aml_workspace, model_name))
+
+    log_e2e("Seeding an OSMO persisted replay output fixture")
+    seed_workflow, source_output_uri = submit_osmo_replay_output_fixture(repo_root)
+    request.addfinalizer(lambda: cleanup_osmo_replay_output(repo_root, source_output_uri))
+    monitor_osmo_workflow(request, seed_workflow, repo_root, _OUTPUT_TASK_NAME, phase="replay fixture seed")
+    assert_workflow_task_succeeded(seed_workflow, repo_root, _OUTPUT_TASK_NAME)
+
+    source_run_id = seed_workflow.workflow_id
+    monkeypatch.setenv("OSMO_OUTPUT_SUBPATH", "run-e2e")
+    replay_workflow = submit_osmo_azureml_replay(
+        repo_root,
+        source_run_id=source_run_id,
+        source_output_uri=source_output_uri,
+        model_name=model_name,
+    )
+    monitor_osmo_workflow(request, replay_workflow, repo_root, _REPLAY_TASK_NAME, phase="AzureML replay")
+    assert_workflow_task_succeeded(replay_workflow, repo_root, _REPLAY_TASK_NAME)
+    assert_osmo_replay_has_mlflow_run(
+        source_run_id=source_run_id,
+        model_name=model_name,
+        aml_workspace=aml_workspace,
+    )
+    model = resolve_registered_model(repo_root, aml_workspace, model_name=model_name)
+    assert_registered_model_has_artifacts(repo_root, aml_workspace, model)
+    log_e2e("OSMO AzureML replay e2e test finished successfully")

--- a/tests/e2e/test_osmo_helpers.py
+++ b/tests/e2e/test_osmo_helpers.py
@@ -85,6 +85,7 @@ def test_submit_osmo_replay_output_fixture_forwards_safe_values(
     tmp_path: Path,
 ) -> None:
     captured_args: list[str] = []
+
     def fake_run_command(
         args: list[str], *, cwd: Path, input_text: str | None = None
     ) -> subprocess.CompletedProcess[str]:

--- a/tests/e2e/test_osmo_helpers.py
+++ b/tests/e2e/test_osmo_helpers.py
@@ -21,6 +21,7 @@ from tests.e2e._osmo import (
     _osmo_status,
     _task_statuses,
     cancel_osmo_workflow,
+    submit_osmo_replay_output_fixture,
     wait_until_osmo_completed,
     wait_until_osmo_started,
 )
@@ -77,6 +78,39 @@ def test_cancel_osmo_workflow_raises_on_failed_cancel(monkeypatch: pytest.Monkey
 
     with pytest.raises(AssertionError, match="Failed to cancel OSMO workflow"):
         cancel_osmo_workflow(workflow, tmp_path)
+
+
+def test_submit_osmo_replay_output_fixture_forwards_safe_values(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    captured_args: list[str] = []
+    def fake_run_command(
+        args: list[str], *, cwd: Path, input_text: str | None = None
+    ) -> subprocess.CompletedProcess[str]:
+        captured_args.extend(args)
+        if args == ["osmo", "config", "show", "WORKFLOW"]:
+            return subprocess.CompletedProcess(
+                args=args,
+                returncode=0,
+                stdout='{"workflow_data":{"credential":{"endpoint":"azure://storage1/custom/workflows/data"}}}',
+                stderr="",
+            )
+        return subprocess.CompletedProcess(
+            args=args,
+            returncode=0,
+            stdout='{"workflow_id":"fixture-1","name":"fixture-1"}',
+            stderr="",
+        )
+
+    monkeypatch.setattr("tests.e2e._osmo.run_command", fake_run_command)
+
+    workflow, output_uri = submit_osmo_replay_output_fixture(tmp_path)
+
+    assert workflow.workflow_id == "fixture-1"
+    assert output_uri.startswith("azure://storage1/custom/workflows/data/e2e/replay/")
+    assert f"output_uri={output_uri}" in captured_args
+    assert captured_args[-2:] == ["--format-type", "json"]
 
 
 def test_wait_until_started_restarts_after_startup_disruption(

--- a/training/tests/test_aml_mirror.py
+++ b/training/tests/test_aml_mirror.py
@@ -37,6 +37,13 @@ sys.modules.setdefault("azure.ai.ml", _fake_ai_ml)
 sys.modules.setdefault("azure.identity", _fake_identity)
 
 _fake_mlflow = MagicMock(name="mlflow")
+_fake_registry_client = MagicMock(name="registry_client")
+
+
+class _FakeMlflowException(Exception):
+    def __init__(self, error_code: str) -> None:
+        super().__init__(error_code)
+        self.error_code = error_code
 
 
 class _FakeRun:
@@ -51,7 +58,10 @@ class _FakeRun:
 
 
 _fake_mlflow.start_run.return_value = _FakeRun()
-_fake_mlflow.register_model.return_value = SimpleNamespace(name="model-x", version="3")
+_fake_mlflow.MlflowClient.return_value = _fake_registry_client
+_fake_mlflow.exceptions.MlflowException = _FakeMlflowException
+_fake_mlflow.get_artifact_uri.return_value = "azureml://artifacts/origin/container/model"
+_fake_registry_client.create_model_version.return_value = SimpleNamespace(name="model-x", version="3")
 sys.modules.setdefault("mlflow", _fake_mlflow)
 
 _MOD = load_training_module("training_utils_aml_mirror", "training/utils/aml_mirror.py")
@@ -60,8 +70,12 @@ _MOD = load_training_module("training_utils_aml_mirror", "training/utils/aml_mir
 @pytest.fixture(autouse=True)
 def _reset_mlflow() -> None:
     _fake_mlflow.reset_mock()
+    _fake_registry_client.reset_mock()
     _fake_mlflow.start_run.return_value = _FakeRun()
-    _fake_mlflow.register_model.return_value = SimpleNamespace(name="model-x", version="3")
+    _fake_mlflow.MlflowClient.return_value = _fake_registry_client
+    _fake_mlflow.get_artifact_uri.return_value = "azureml://artifacts/origin/container/model"
+    _fake_registry_client.create_registered_model.side_effect = None
+    _fake_registry_client.create_model_version.return_value = SimpleNamespace(name="model-x", version="3")
 
 
 @pytest.fixture()
@@ -170,7 +184,12 @@ class TestMain:
         assert result == 0
         _fake_mlflow.set_tracking_uri.assert_called_once()
         _fake_mlflow.set_experiment.assert_called_once_with("my-model")
-        _fake_mlflow.register_model.assert_called_once()
+        _fake_registry_client.create_registered_model.assert_called_once_with("my-model")
+        _fake_registry_client.create_model_version.assert_called_once_with(
+            name="my-model",
+            source="azureml://artifacts/origin/container/model",
+            run_id="run-abc",
+        )
 
     def test_skip_files_excluded(self, _env_vars: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         ckpt = _env_vars / "checkpoint-50"
@@ -202,6 +221,20 @@ class TestMain:
         tag_calls = {c.args[0]: c.args[1] for c in _fake_mlflow.set_tag.call_args_list}
         assert tag_calls["osmo.replay"] == "true"
         assert tag_calls["osmo.replay_source"] == "original-run-99"
+
+    def test_existing_registered_model_creates_new_version(
+        self, _env_vars: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        ckpt = _env_vars / "checkpoint-1"
+        ckpt.mkdir()
+        (ckpt / "model.bin").write_bytes(b"x")
+        _fake_registry_client.create_registered_model.side_effect = _FakeMlflowException(
+            "RESOURCE_ALREADY_EXISTS"
+        )
+        monkeypatch.setattr(_MOD, "mlflow", _fake_mlflow)
+
+        assert _MOD.main() == 0
+        _fake_registry_client.create_model_version.assert_called_once()
 
     def test_tensorboard_dir_logged(self, _env_vars: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         tb_dir = _env_vars / "runs"
@@ -241,5 +274,5 @@ class TestMain:
 
         _MOD.main()
 
-        register_call = _fake_mlflow.register_model.call_args
+        register_call = _fake_registry_client.create_model_version.call_args
         assert register_call is not None

--- a/training/tests/test_aml_mirror.py
+++ b/training/tests/test_aml_mirror.py
@@ -228,9 +228,7 @@ class TestMain:
         ckpt = _env_vars / "checkpoint-1"
         ckpt.mkdir()
         (ckpt / "model.bin").write_bytes(b"x")
-        _fake_registry_client.create_registered_model.side_effect = _FakeMlflowException(
-            "RESOURCE_ALREADY_EXISTS"
-        )
+        _fake_registry_client.create_registered_model.side_effect = _FakeMlflowException("RESOURCE_ALREADY_EXISTS")
         monkeypatch.setattr(_MOD, "mlflow", _fake_mlflow)
 
         assert _MOD.main() == 0

--- a/training/utils/aml_mirror.py
+++ b/training/utils/aml_mirror.py
@@ -159,9 +159,17 @@ def main() -> int:
         finally:
             shutil.rmtree(staged, ignore_errors=True)
 
-        registered = mlflow.register_model(
-            model_uri=f"runs:/{run.info.run_id}/model",
-            name=os.environ["AZUREML_MODEL_NAME"],
+        registry_client = mlflow.MlflowClient()
+        model_name = os.environ["AZUREML_MODEL_NAME"]
+        try:
+            registry_client.create_registered_model(model_name)
+        except mlflow.exceptions.MlflowException as error:
+            if error.error_code != "RESOURCE_ALREADY_EXISTS":
+                raise
+        registered = registry_client.create_model_version(
+            name=model_name,
+            source=mlflow.get_artifact_uri("model"),
+            run_id=run.info.run_id,
         )
         print(
             json.dumps(

--- a/training/utils/replay-azureml.sh
+++ b/training/utils/replay-azureml.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Replay a completed OSMO training run to Azure ML.
 #
-# Usage: ./replay-azureml.sh <run-id> [model-name]
+# Usage: ./replay-azureml.sh <run-id> <output-uri> [model-name]
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -13,14 +13,31 @@ source "$REPO_ROOT/scripts/lib/common.sh"
 source "$REPO_ROOT/scripts/lib/terraform-outputs.sh"
 read_terraform_outputs "$REPO_ROOT/infrastructure/terraform" 2>/dev/null || true
 
-run_id="${1:?Usage: $0 <run-id> [model-name]}"
-model_name="${2:-${AZUREML_MODEL_NAME:-lerobot-policy}}"
+run_id="${1:?Usage: $0 <run-id> <output-uri> [model-name] [-- OSMO_ARGS...]}"
+shift
+output_uri="${1:?Usage: $0 <run-id> <output-uri> [model-name] [-- OSMO_ARGS...]}"
+shift
+[[ "$output_uri" == azure://* ]] || fatal "Output URI must use the azure:// scheme"
+
+model_name="${AZUREML_MODEL_NAME:-lerobot-policy}"
+if [[ $# -gt 0 && "$1" != "--" ]]; then
+  model_name="$1"
+  shift
+fi
+
+forward_args=()
+if [[ $# -gt 0 ]]; then
+  [[ "$1" == "--" ]] || fatal "Unexpected argument: $1"
+  shift
+  forward_args=("$@")
+fi
 
 subscription_id="${AZURE_SUBSCRIPTION_ID:-$(get_subscription_id)}"
 resource_group="${AZURE_RESOURCE_GROUP:-$(get_resource_group)}"
 workspace_name="${AZUREML_WORKSPACE_NAME:-$(get_azureml_workspace)}"
+output_subpath="${OSMO_OUTPUT_SUBPATH:-.}"
 
-require_tools osmo uv
+require_tools jq osmo uv
 
 aml_mirror_script="$SCRIPT_DIR/aml_mirror.py"
 if [[ ! -f "$aml_mirror_script" ]]; then
@@ -34,6 +51,7 @@ fi
 
 section "Submit Azure ML Replay"
 print_kv "Run ID"     "$run_id"
+print_kv "Output URI" "$output_uri"
 print_kv "Model name" "$model_name"
 
 aml_mirror_b64=$(base64 < "$aml_mirror_script" | tr -d '\n')
@@ -47,6 +65,8 @@ submit_args=(
   workflow submit "$REPO_ROOT/workflows/osmo/replay-azureml.yaml"
   --set-string "run_id=$run_id"
   "model_name=$model_name"
+  "output_uri=$output_uri"
+  "output_subpath=$output_subpath"
   "aml_mirror_b64=$aml_mirror_b64"
   "aml_mirror_requirements_b64=$aml_mirror_requirements_b64"
 )
@@ -54,6 +74,7 @@ submit_args=(
 [[ -n "$subscription_id" ]] && submit_args+=("azure_subscription_id=$subscription_id")
 [[ -n "$resource_group" ]]  && submit_args+=("azure_resource_group=$resource_group")
 [[ -n "$workspace_name" ]]  && submit_args+=("azureml_workspace_name=$workspace_name")
+[[ ${#forward_args[@]} -gt 0 ]] && submit_args+=("${forward_args[@]}")
 
 osmo "${submit_args[@]}"
 

--- a/workflows/osmo/replay-azureml.yaml
+++ b/workflows/osmo/replay-azureml.yaml
@@ -1,15 +1,17 @@
 workflow:
   name: "{{workflow_name}}"
   resources:
-    default: { cpu: 4, memory: 8Gi, storage: 4Gi, gpu: 0 }
+    default: { cpu: {{cpu}}, memory: {{memory}}, storage: 4Gi, gpu: 0 }
   timeout: { exec_timeout: 6h, queue_timeout: 1h }
   tasks:
     - name: mirror
       image: "{{image}}"
+      inputs:
+        - url: "{{output_uri}}"
       command: ["bash"]
-      args: ["-lc", "set -euo pipefail; echo \"$AML_MIRROR_B64\" | base64 -d > /tmp/aml_mirror.py; echo \"$AML_MIRROR_REQUIREMENTS_B64\" | base64 -d > /tmp/requirements-aml-mirror.txt; pip install --quiet -r /tmp/requirements-aml-mirror.txt && python /tmp/aml_mirror.py"]
+      args: ["-lc", "set -euo pipefail; echo \"$AML_MIRROR_B64\" | base64 -d > /tmp/aml_mirror.py; echo \"$AML_MIRROR_REQUIREMENTS_B64\" | base64 -d > /tmp/requirements-aml-mirror.txt; pip install --quiet --no-deps -r /tmp/requirements-aml-mirror.txt && python /tmp/aml_mirror.py"]
       environment:
-        OUTPUT_DIR: "{{output_base}}/{{run_id}}"
+        OUTPUT_DIR: "{{input:0}}/{{output_subpath}}"
         RUN_ID: "{{run_id}}-replay"
         REPLAY_RUN_ID: "{{run_id}}"
         AZUREML_MODEL_NAME: "{{model_name}}"
@@ -25,7 +27,10 @@ default-values:
   workflow_name: replay-azureml
   run_id: ""
   model_name: ""
-  output_base: /outputs
+  output_uri: ""
+  output_subpath: "."
+  cpu: 4
+  memory: 8Gi
   # Pinned by @sha256 digest for reproducibility; refresh via scripts/update-image-digests.sh.
   image: python:3.11-slim@sha256:b27df5841f3355e9473f9a516d38a6783b6c8dfeacaf2d14a240f443b368ddb6
   aml_mirror_b64: ""


### PR DESCRIPTION
## Summary

- require the production replay wrapper to receive the source workflow's declared durable `azure://` output URI
- mount the persisted output explicitly and support nested checkpoint paths
- replace the unsupported fluent MLflow registration path with explicit registered-model and model-version operations
- add replay CPU and production-image smoke coverage
- add a focused OSMO-to-Azure ML cloud E2E with authoritative workflow-storage discovery and cleanup

## Scope

This PR keeps all Python dependency manifests and uv locks unchanged. The dependency upgrade remains in #1470 and follows this correctness baseline.

## Validation

- replay production-image smoke passed with the existing Python 3.11 image and frozen MLflow 3.13 lock
- focused cloud E2E passed, including persisted output retrieval, workload identity, Azure ML tracking, model registration, registered-model artifact download, and cleanup
- 28 targeted Python tests passed
- Ruff, ShellCheck, actionlint/YAML lint, Markdown lint, spelling, OSMO template validation, and diff checks passed

Closes #1483
