### PR TITLE
build: enforce consistent TOML formatting

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -54,6 +54,7 @@
 		"serialised",
 		"serialises",
 		"sparkline",
+		"taplo",
 		"tegra",
 		"trackio",
 		"unbuilt",

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -54,7 +54,7 @@ Conventions, domain knowledge, and non-obvious patterns for agents working in th
 * Do not modify files in `external/`
 * Version: managed by release-please across `pyproject.toml` and `package.json`
 * Python: >=3.12, managed by `uv` (not pip); `hatchling` builds `training/rl` into wheel
-* Linting: `npm run lint:md` (markdownlint-cli2), `npm run spell-check` (cspell), `npm run lint:yaml` (yaml-lint)
+* Linting: `npm run lint:md` (markdownlint-cli2), `npm run lint:toml` (Taplo), `npm run spell-check` (cspell), `npm run lint:yaml` (yaml-lint)
 
 ## Terraform Conventions
 
@@ -469,6 +469,7 @@ Run `npm install` (or `npm ci`) before any `npm run` lint commands. `shellcheck`
 | `*.sh` | `shellcheck <file>` |
 | `*.ps1` | `npm run lint:ps` |
 | `*.yml` (GitHub Actions) | `npm run lint:yaml` |
+| `*.toml` | `npm run lint:toml`; run `npm run format:toml` to fix formatting |
 | `data-management/viewer/frontend/**` | `cd data-management/viewer/frontend && npm run validate` (type-check + lint + test) |
 | `data-management/viewer/backend/**` | `cd data-management/viewer/backend && pytest` and `ruff check src/` |
 | `training/**/*.py` | `cd training && ruff check . && pytest` |
@@ -480,9 +481,9 @@ Run `npm install` (or `npm ci`) before any `npm run` lint commands. `shellcheck`
 
 ### Linting
 
-* `npm run lint:all` runs `lint:md` + `lint:ps` + `lint:links` + `lint:yaml` + `lint:tf` + `lint:go` + `lint:sh` + `lint:py` + `lint:hfpins` + `lint:uvlock` in sequence
+* `npm run lint:all` runs `lint:md` + `lint:ps` + `lint:links` + `lint:yaml` + `lint:tf` + `lint:toml` + `lint:go` + `lint:sh` + `lint:py` + `lint:hfpins` + `lint:uvlock` in sequence
 * `npm run spell-check` and `npm run format:tables` are NOT included in `lint:all` — run them separately
-* `npm run lint:md:fix` and `npm run format:tables` auto-fix markdown issues
+* `npm run lint:md:fix`, `npm run format:toml`, and `npm run format:tables` apply formatting fixes
 * `.copilot-tracking/` is excluded from markdown linting via `.markdownlint-cli2.jsonc`
 
 ### Terraform
@@ -510,7 +511,9 @@ Terraform validation is per-directory — each deployment directory has its own 
 ## CI/CD Pipeline
 
 * Two orchestrators: `main.yml` (push to main), `pr-validation.yml` (PRs) using reusable `workflow_call` workflows
-* PR validation sequence: spell check → markdown lint → table format → frontmatter → PSScriptAnalyzer → YAML lint → link check → Python lint → Python tests → uv lock consistency → frontend tests → Pester → dependency review → dependency pinning → CodeQL
+* PR validation formatting and documentation checks: spelling, Markdown, TOML, tables, frontmatter, YAML, and links
+* PR validation code checks: PowerShell, Python, Terraform, Go, shell, and uv lock consistency
+* PR validation test and security checks: Python and frontend tests, Pester, dependency review and pinning, and CodeQL
 * Security: all actions SHA-pinned (not tag-referenced), `persist-credentials: false` on all checkouts
 * Security workflows: CodeQL (weekly + PR), Gitleaks (push + PR), OpenSSF Scorecard (weekly), dependency review (PR), SHA pinning scan (PR + main), container image digest freshness (weekly)
 * Pre-commit: Husky v9 + lint-staged on frontend files only (ESLint + Prettier auto-fix)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,6 +27,13 @@ jobs:
     permissions:
       contents: read
 
+  # TOML formatting using Taplo
+  toml-format:
+    name: TOML Format
+    uses: ./.github/workflows/toml-format.yml
+    permissions:
+      contents: read
+
   # Markdown table formatting check
   table-format:
     name: Table Format
@@ -286,6 +293,7 @@ jobs:
     needs:
       - spell-check
       - markdown-lint
+      - toml-format
       - table-format
       - frontmatter-validation
       - psscriptanalyzer

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -110,6 +110,13 @@ jobs:
     permissions:
       contents: read
 
+  # TOML formatting using Taplo
+  toml-format:
+    name: TOML Format
+    uses: ./.github/workflows/toml-format.yml
+    permissions:
+      contents: read
+
   # Markdown table formatting check
   table-format:
     name: Table Format
@@ -485,6 +492,7 @@ jobs:
       - workflow-refs-check
       - spell-check
       - markdown-lint
+      - toml-format
       - table-format
       - frontmatter-validation
       - msdate-freshness

--- a/.github/workflows/toml-format.yml
+++ b/.github/workflows/toml-format.yml
@@ -1,0 +1,36 @@
+name: TOML Format
+
+on:
+  workflow_call:
+    inputs:
+      soft-fail:
+        description: 'Whether to continue on TOML formatting violations'
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: pwsh
+
+jobs:
+  toml-format:
+    name: TOML Format
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js and install dependencies
+        uses: ./.github/actions/setup-node-deps
+
+      - name: Check TOML formatting
+        run: npm run lint:toml
+        continue-on-error: ${{ inputs.soft-fail }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,6 +145,7 @@ Run these commands to validate changes before submitting a PR:
 ```bash
 npm run lint:md        # Markdownlint
 npm run lint:links     # Markdown link validation
+npm run lint:toml      # Taplo format check
 npm run lint:vuln      # OSV-Scanner v2.3.8 dependency vulnerability scan
 npm run spell-check    # cspell
 npm run test:tf        # Terraform module tests (no Azure credentials required)
@@ -165,6 +166,7 @@ All CI linters enforce warnings-as-errors. PRs that introduce new warnings will 
 | Go (lint:go)          | Errors block      | .golangci.yml                                     |
 | ShellCheck (lint:sh)  | Warnings + errors | .shellcheckrc                                     |
 | Python (lint:py)      | Errors block      | pyproject.toml [tool.ruff]                        |
+| TOML (lint:toml)      | Formatting blocks | taplo.toml                                        |
 | uv lock (lint:uvlock) | Drift blocks      | scripts/linting/Invoke-UvLockConsistencyCheck.ps1 |
 | Vulns (lint:vuln)     | Errors block      | osv-scanner.toml                                  |
 | Link check            | Errors block      | .markdownlint-cli2.jsonc                          |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 title: Contributing
 description: How to contribute to the Physical AI Toolchain
 author: Microsoft Robotics-AI Team
-ms.date: 2026-06-01
+ms.date: 2026-09-08
 ms.topic: how-to
 keywords:
   - contributing

--- a/data-management/viewer/backend/pyproject.toml
+++ b/data-management/viewer/backend/pyproject.toml
@@ -70,9 +70,9 @@ extend = "../../../pyproject.toml"
 
 [tool.ruff.lint]
 ignore = [
-    "B008",   # Depends() in function defaults is a FastAPI pattern
-    "B905",   # zip() without strict= is acceptable
-    "B904",   # Exception cause via constructor, not raise-from
+    "B008", # Depends() in function defaults is a FastAPI pattern
+    "B905", # zip() without strict= is acceptable
+    "B904", # Exception cause via constructor, not raise-from
 ]
 
 [tool.ruff.lint.isort]

--- a/docs/contributing/contribution-workflow.md
+++ b/docs/contributing/contribution-workflow.md
@@ -3,7 +3,7 @@ sidebar_position: 4
 title: Contribution Workflow
 description: How to contribute including legal requirements, bug reports, enhancement suggestions, and documentation improvements
 author: Microsoft Robotics-AI Team
-ms.date: 2026-06-01
+ms.date: 2026-09-07
 ms.topic: how-to
 keywords:
   - contributing
@@ -171,7 +171,7 @@ This reference architecture validates through deployment rather than automated t
 | Training scripts            | AzureML job submission in test workspace with logs                                                                 |
 | Workflow templates          | Workflow execution validation with job outputs                                                                     |
 | Go modules                  | `npm run lint:go` (golangci-lint), `npm run test:go` (`go test`, requires `terraform-docs`)                        |
-| Configuration manifests     | Syntax validation, test deployment in non-production cluster                                                       |
+| Configuration manifests     | `npm run lint:toml`, syntax validation, test deployment in non-production cluster                                  |
 
 ### Testing Documentation
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.8.0",
       "license": "MIT",
       "devDependencies": {
+        "@taplo/cli": "0.7.0",
         "cspell": "10.1.0",
         "husky": "9.1.7",
         "lint-staged": "17.3.0",
@@ -750,6 +751,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@taplo/cli": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@taplo/cli/-/cli-0.7.0.tgz",
+      "integrity": "sha512-Ck3zFhQhIhi02Hl6T4ZmJsXdnJE+wXcJz5f8klxd4keRYgenMnip3JDPMGDRLbnC/2iGd8P0sBIQqI3KxfVjBg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "taplo": "dist/cli.js"
       }
     },
     "node_modules/@types/debug": {

--- a/package.json
+++ b/package.json
@@ -20,9 +20,11 @@
     "lint:yaml": "pwsh -File scripts/linting/Invoke-YamlLint.ps1",
     "lint:tf": "pwsh -File scripts/linting/Invoke-TFLint.ps1",
     "lint:tf:validate": "pwsh -File scripts/linting/Invoke-TerraformValidation.ps1",
+    "lint:toml": "taplo fmt --check",
     "lint:uvlock": "pwsh -File scripts/linting/Invoke-UvLockConsistencyCheck.ps1",
     "lint:vuln": "osv-scanner --config osv-scanner.toml .",
-    "lint:all": "npm run lint:md && npm run lint:ps && npm run lint:links && npm run lint:yaml && npm run lint:tf && npm run lint:go && npm run lint:sh && npm run lint:py && npm run lint:hfpins && npm run lint:uvlock",
+    "lint:all": "npm run lint:md && npm run lint:ps && npm run lint:links && npm run lint:yaml && npm run lint:tf && npm run lint:toml && npm run lint:go && npm run lint:sh && npm run lint:py && npm run lint:hfpins && npm run lint:uvlock",
+    "format:toml": "taplo fmt",
     "format:tables": "markdown-table-formatter \"**/*.md\"",
     "test:ps": "pwsh -File ./scripts/tests/Invoke-PesterTests.ps1",
     "test:tf": "pwsh -File scripts/linting/Invoke-TerraformTest.ps1",
@@ -35,6 +37,7 @@
     "docs:generate:tf": "pwsh -File scripts/Update-TerraformDocs.ps1"
   },
   "devDependencies": {
+    "@taplo/cli": "0.7.0",
     "cspell": "10.1.0",
     "husky": "9.1.7",
     "lint-staged": "17.3.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,13 @@ override-dependencies = [
 ]
 
 [tool.pytest.ini_options]
-testpaths = ["tests", "training/tests", "data-management/tools/tests", "fleet-deployment/inference/tests", "shared/ci/tests"]
+testpaths = [
+    "tests",
+    "training/tests",
+    "data-management/tools/tests",
+    "fleet-deployment/inference/tests",
+    "shared/ci/tests",
+]
 pythonpath = [".", "data-management/tools"]
 python_files = ["test_*.py", "fuzz_harness.py"]
 addopts = [
@@ -85,14 +91,14 @@ line-length = 120
 
 [tool.ruff.lint]
 select = [
-    "E",    # pycodestyle errors
-    "W",    # pycodestyle warnings
-    "F",    # pyflakes
-    "I",    # isort
-    "UP",   # pyupgrade
-    "B",    # flake8-bugbear
-    "SIM",  # flake8-simplify
-    "RUF",  # ruff-specific rules
+    "E",   # pycodestyle errors
+    "W",   # pycodestyle warnings
+    "F",   # pyflakes
+    "I",   # isort
+    "UP",  # pyupgrade
+    "B",   # flake8-bugbear
+    "SIM", # flake8-simplify
+    "RUF", # ruff-specific rules
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/taplo.toml
+++ b/taplo.toml
@@ -1,0 +1,8 @@
+include = ["**/*.toml"]
+exclude = ["**/.venv/**", "external/**", "scripts/tests/Fixtures/**", "shared/ci/tests/Fixtures/**"]
+
+[formatting]
+array_auto_collapse = false
+column_width = 120
+indent_string = "    "
+reorder_keys = false


### PR DESCRIPTION
## Summary

- add pinned Taplo tooling with repository-wide `lint:toml` and `format:toml` commands
- add a reusable TOML formatting workflow to pull-request and main validation
- format the existing noncompliant TOML files without semantic changes
- document the formatter in contributor and agent guidance

## Scope

This PR contains no Python dependency-version or uv lock changes. The only dependency addition is the pinned `@taplo/cli` development tool.

## Validation

- clean `npm ci` completed from the committed package lock
- `npm run lint:toml`, YAML/actionlint, Markdown lint, and spelling passed
- parsed TOML values before and after formatting are identical
- package-lock metadata uses the canonical public npm registry

Closes #1484
